### PR TITLE
Use label selector for informers.

### DIFF
--- a/cmd/csi-operator/main.go
+++ b/cmd/csi-operator/main.go
@@ -42,14 +42,16 @@ func main() {
 
 	resyncPeriod := time.Duration(30) * time.Second
 	namespace := v1.NamespaceAll
+	// Watch only things with OwnerLabelName label
+	ownedSelectorString := controller.OwnerLabelName
 
 	sdk.Watch("csidriver.storage.openshift.io/v1alpha1", "CSIDriverDeployment", namespace, resyncPeriod)
-	sdk.Watch("apps/v1", "Deployment", namespace, resyncPeriod)
-	sdk.Watch("apps/v1", "DaemonSet", namespace, resyncPeriod)
-	sdk.Watch("v1", "ServiceAccount", namespace, resyncPeriod)
-	sdk.Watch("rbac.authorization.k8s.io/v1", "RoleBinding", namespace, resyncPeriod)
-	sdk.Watch("rbac.authorization.k8s.io/v1", "ClusterRoleBinding", namespace, resyncPeriod)
-	sdk.Watch("storage.k8s.io/v1", "StorageClass", namespace, resyncPeriod)
+	sdk.Watch("apps/v1", "Deployment", namespace, resyncPeriod, sdk.WithLabelSelector(ownedSelectorString))
+	sdk.Watch("apps/v1", "DaemonSet", namespace, resyncPeriod, sdk.WithLabelSelector(ownedSelectorString))
+	sdk.Watch("v1", "ServiceAccount", namespace, resyncPeriod, sdk.WithLabelSelector(ownedSelectorString))
+	sdk.Watch("rbac.authorization.k8s.io/v1", "RoleBinding", namespace, resyncPeriod, sdk.WithLabelSelector(ownedSelectorString))
+	sdk.Watch("rbac.authorization.k8s.io/v1", "ClusterRoleBinding", namespace, resyncPeriod, sdk.WithLabelSelector(ownedSelectorString))
+	sdk.Watch("storage.k8s.io/v1", "StorageClass", namespace, resyncPeriod, sdk.WithLabelSelector(ownedSelectorString))
 
 	handler, err := controller.NewHandler(cfg)
 	if err != nil {

--- a/pkg/controller/objects.go
+++ b/pkg/controller/objects.go
@@ -408,12 +408,12 @@ func (h *Handler) addOwnerLabels(meta *metav1.ObjectMeta, cr *csidriverv1alpha1.
 		meta.Labels = map[string]string{}
 		changed = true
 	}
-	if v, exists := meta.Labels[ownerLabelNamespace]; !exists || v != cr.Namespace {
-		meta.Labels[ownerLabelNamespace] = cr.Namespace
+	if v, exists := meta.Labels[OwnerLabelNamespace]; !exists || v != cr.Namespace {
+		meta.Labels[OwnerLabelNamespace] = cr.Namespace
 		changed = true
 	}
-	if v, exists := meta.Labels[ownerLabelName]; !exists || v != cr.Name {
-		meta.Labels[ownerLabelName] = cr.Name
+	if v, exists := meta.Labels[OwnerLabelName]; !exists || v != cr.Name {
+		meta.Labels[OwnerLabelName] = cr.Name
 		changed = true
 	}
 


### PR DESCRIPTION
The operator is interested only in things it manages, not in all ServiceAccounts, DaemonSets, Deployments and so on. To find the managed things we can use a label selector.