### PR TITLE
Fix operator images

### DIFF
--- a/deploy/openshift/image-references
+++ b/deploy/openshift/image-references
@@ -5,7 +5,7 @@ spec:
   - name: csi-operator
     from:
       kind: DockerImage
-      name: csi-operator
+      name: registry.svc.ci.openshift.org/openshift/origin-v4.0:csi-operator
   - name: csi-external-attacher
     from:
       kind: DockerImage

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -16,7 +16,7 @@ spec:
       serviceAccount: csi-operator
       containers:
         - name: csi-operator
-          image: csi-operator:latest
+          image: registry.svc.ci.openshift.org/openshift/origin-v4.0:csi-operator
           ports:
           - containerPort: 60000
             name: metrics

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: csi-operator
-  namespace: csi-operator
+  namespace: openshift-csi-operator
 spec:
   replicas: 1
   selector:

--- a/deploy/prerequisites/04_namespace.yaml
+++ b/deploy/prerequisites/04_namespace.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: csi-operator
+  name: openshift-csi-operator
 spec:
 status:

--- a/deploy/prerequisites/05_sa.yaml
+++ b/deploy/prerequisites/05_sa.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: csi-operator
-  namespace: csi-operator
+  namespace: openshift-csi-operator

--- a/deploy/prerequisites/06_role_binding.yaml
+++ b/deploy/prerequisites/06_role_binding.yaml
@@ -9,4 +9,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: csi-operator
-  namespace: csi-operator
+  namespace: openshift-csi-operator

--- a/deploy/prerequisites/07_config.yaml
+++ b/deploy/prerequisites/07_config.yaml
@@ -2,7 +2,7 @@ kind: ConfigMap
 apiVersion: v1
 metadata:
   name: csi-operator-config
-  namespace: csi-operator
+  namespace: openshift-csi-operator
 data:
   config.yaml: |
     defaultImages:


### PR DESCRIPTION
"csi-operator" is too generic and matches e.g. namespace names. Use "registry.svc.ci.openshift.org/openshift/origin-v4.0:csi-operator".

And use "openshift-csi-operator" namespace when at it.