### PR TITLE
Add /var/lib/kubelet HostPath directory to node drivers

### DIFF
--- a/deploy/samples/gce.yaml
+++ b/deploy/samples/gce.yaml
@@ -6,9 +6,6 @@ spec:
   driverName: com.google.csi.gcepd
 
   driverControllerTemplate:
-    metadata:
-      labels:
-        foo: bar
     spec:
       containers:
       - args:
@@ -48,16 +45,9 @@ spec:
         securityContext:
           privileged: true
         volumeMounts:
-        - mountPath: /var/lib/origin/openshift.local.volumes/pods/
-          mountPropagation: Bidirectional
-          name: mountpoint-dir
         - name: device-dir
           mountPath: /host/dev
       volumes:
-      - hostPath:
-          path: /var/lib/origin/openshift.local.volumes/pods/
-        type: DirectoryOrCreate
-        name: mountpoint-dir
       - name: device-dir
         hostPath:
           path: /dev
@@ -73,7 +63,7 @@ spec:
       reclaimPolicy: Delete
       allowVolumeExpansion: true
       volumeBindingMode: Immediate
-      
+
     - metadata:
         name: sc2
       parameters:

--- a/deploy/samples/hostpath.yaml
+++ b/deploy/samples/hostpath.yaml
@@ -55,25 +55,12 @@ spec:
         securityContext:
           privileged: true
         volumeMounts:
-        - mountPath: /var/lib/origin/openshift.local.volumes/pods/
-          mountPropagation: Bidirectional
-          name: mountpoint-dir
-        - name: device-dir
-          mountPath: /host/dev
         - name: hostpath-root
           mountPath: /tmp
       volumes:
-      - hostPath:
-          path: /var/lib/origin/openshift.local.volumes/pods/
-        type: DirectoryOrCreate
-        name: mountpoint-dir
       - name: hostpath-root
         hostPath:
           path: /tmp
-          type: Directory
-      - name: device-dir
-        hostPath:
-          path: /dev
           type: Directory
 
   driverSocket: /csi/csi.sock
@@ -86,7 +73,7 @@ spec:
       reclaimPolicy: Delete
       allowVolumeExpansion: true
       volumeBindingMode: Immediate
-      
+
     - metadata:
         name: sc2
       parameters:

--- a/pkg/controller/objects_test.go
+++ b/pkg/controller/objects_test.go
@@ -277,6 +277,7 @@ var (
 
 	typeDir         = corev1.HostPathDirectory
 	typeDirOrCreate = corev1.HostPathDirectoryOrCreate
+	bidirectional   = corev1.MountPropagationBidirectional
 
 	defaultDaemonSet = &appsv1.DaemonSet{
 		ObjectMeta: metav1.ObjectMeta{
@@ -311,6 +312,11 @@ var (
 								{
 									Name:      "csi-driver",
 									MountPath: "/my/csi/path",
+								},
+								{
+									Name:             "kubelet-root",
+									MountPath:        "/var/lib/kubelet",
+									MountPropagation: &bidirectional,
 								},
 							},
 							Ports: []corev1.ContainerPort{
@@ -411,6 +417,15 @@ var (
 								HostPath: &corev1.HostPathVolumeSource{
 									Path: "/var/lib/kubelet/plugins/default",
 									Type: &typeDirOrCreate,
+								},
+							},
+						},
+						{
+							Name: "kubelet-root",
+							VolumeSource: corev1.VolumeSource{
+								HostPath: &corev1.HostPathVolumeSource{
+									Path: "/var/lib/kubelet",
+									Type: &typeDir,
 								},
 							},
 						},


### PR DESCRIPTION
Various Kubernetes distributions can have different location of /var/lib/kubelet. We want the CSIDriverDeployment to be the same for them.