### PR TITLE
Pass SecurityContext to sidecar containers

### DIFF
--- a/pkg/controller/csidriverdeployment/objects_test.go
+++ b/pkg/controller/csidriverdeployment/objects_test.go
@@ -346,9 +346,6 @@ var (
 								"--v=5",
 								"--csi-address=$(ADDRESS)",
 							},
-							SecurityContext: &corev1.SecurityContext{
-								Privileged: &bTrue,
-							},
 							Env: []corev1.EnvVar{
 								{
 									Name:  "ADDRESS",

--- a/pkg/controller/csidriverdeployment/testdata/01-simple-deployment/in-csidriverdeployment.yaml
+++ b/pkg/controller/csidriverdeployment/testdata/01-simple-deployment/in-csidriverdeployment.yaml
@@ -17,8 +17,6 @@ spec:
         volumeMounts:
         - name: hostpath-root
           mountPath: /tmp
-        securityContext:
-          privileged: true
       volumes:
       - name: hostpath-root
         hostPath:

--- a/pkg/controller/csidriverdeployment/testdata/01-simple-deployment/out-csidriverdeployment.yaml
+++ b/pkg/controller/csidriverdeployment/testdata/01-simple-deployment/out-csidriverdeployment.yaml
@@ -21,8 +21,6 @@ spec:
         volumeMounts:
         - name: hostpath-root
           mountPath: /tmp
-        securityContext:
-          privileged: true
       volumes:
       - name: hostpath-root
         hostPath:

--- a/pkg/controller/csidriverdeployment/testdata/01-simple-deployment/out-daemonset.yaml
+++ b/pkg/controller/csidriverdeployment/testdata/01-simple-deployment/out-daemonset.yaml
@@ -58,8 +58,6 @@ spec:
               fieldPath: spec.nodeName
         image: quay.io/k8scsi/driver-registrar:v0.3.0
         name: csi-driver-registrar
-        securityContext:
-          privileged: true
         volumeMounts:
         - mountPath: /csi
           name: csi-driver

--- a/pkg/controller/csidriverdeployment/testdata/01-simple-deployment/out-deployment.yaml
+++ b/pkg/controller/csidriverdeployment/testdata/01-simple-deployment/out-deployment.yaml
@@ -41,8 +41,6 @@ spec:
         - containerPort: 9808
           name: csi-probe
           protocol: TCP
-        securityContext:
-          privileged: true
         volumeMounts:
         - mountPath: /tmp
           name: hostpath-root

--- a/pkg/controller/csidriverdeployment/testdata/02-custom-service-account/in-csidriverdeployment.yaml
+++ b/pkg/controller/csidriverdeployment/testdata/02-custom-service-account/in-csidriverdeployment.yaml
@@ -18,8 +18,6 @@ spec:
         volumeMounts:
         - name: hostpath-root
           mountPath: /tmp
-        securityContext:
-          privileged: true
       volumes:
       - name: hostpath-root
         hostPath:

--- a/pkg/controller/csidriverdeployment/testdata/02-custom-service-account/out-csidriverdeployment.yaml
+++ b/pkg/controller/csidriverdeployment/testdata/02-custom-service-account/out-csidriverdeployment.yaml
@@ -21,8 +21,6 @@ spec:
         volumeMounts:
         - name: hostpath-root
           mountPath: /tmp
-        securityContext:
-          privileged: true
       volumes:
       - name: hostpath-root
         hostPath:

--- a/pkg/controller/csidriverdeployment/testdata/02-custom-service-account/out-daemonset.yaml
+++ b/pkg/controller/csidriverdeployment/testdata/02-custom-service-account/out-daemonset.yaml
@@ -59,8 +59,6 @@ spec:
               fieldPath: spec.nodeName
         image: quay.io/k8scsi/driver-registrar:v0.3.0
         name: csi-driver-registrar
-        securityContext:
-          privileged: true
         volumeMounts:
         - mountPath: /csi
           name: csi-driver

--- a/pkg/controller/csidriverdeployment/testdata/02-custom-service-account/out-deployment.yaml
+++ b/pkg/controller/csidriverdeployment/testdata/02-custom-service-account/out-deployment.yaml
@@ -43,8 +43,6 @@ spec:
           name: csi-probe
           protocol: TCP
         resources: {}
-        securityContext:
-          privileged: true
         volumeMounts:
         - mountPath: /tmp
           name: hostpath-root

--- a/pkg/controller/csidriverdeployment/testdata/03-no-liveness-probe/in-csidriverdeployment.yaml
+++ b/pkg/controller/csidriverdeployment/testdata/03-no-liveness-probe/in-csidriverdeployment.yaml
@@ -17,8 +17,6 @@ spec:
         volumeMounts:
         - name: hostpath-root
           mountPath: /tmp
-        securityContext:
-          privileged: true
       volumes:
       - name: hostpath-root
         hostPath:

--- a/pkg/controller/csidriverdeployment/testdata/03-no-liveness-probe/out-csidriverdeployment.yaml
+++ b/pkg/controller/csidriverdeployment/testdata/03-no-liveness-probe/out-csidriverdeployment.yaml
@@ -20,8 +20,6 @@ spec:
         volumeMounts:
         - name: hostpath-root
           mountPath: /tmp
-        securityContext:
-          privileged: true
       volumes:
       - name: hostpath-root
         hostPath:

--- a/pkg/controller/csidriverdeployment/testdata/03-no-liveness-probe/out-daemonset.yaml
+++ b/pkg/controller/csidriverdeployment/testdata/03-no-liveness-probe/out-daemonset.yaml
@@ -46,8 +46,6 @@ spec:
               fieldPath: spec.nodeName
         image: quay.io/k8scsi/driver-registrar:v0.3.0
         name: csi-driver-registrar
-        securityContext:
-          privileged: true
         volumeMounts:
         - mountPath: /csi
           name: csi-driver

--- a/pkg/controller/csidriverdeployment/testdata/03-no-liveness-probe/out-deployment.yaml
+++ b/pkg/controller/csidriverdeployment/testdata/03-no-liveness-probe/out-deployment.yaml
@@ -29,8 +29,6 @@ spec:
         - --test-argument=foo
         image: quay.io/k8scsi/hostpathplugin:v0.2.0
         name: csi-driver
-        securityContext:
-          privileged: true
         volumeMounts:
         - mountPath: /tmp
           name: hostpath-root

--- a/pkg/controller/csidriverdeployment/testdata/04-noop/in-csidriverdeployment.yaml
+++ b/pkg/controller/csidriverdeployment/testdata/04-noop/in-csidriverdeployment.yaml
@@ -21,8 +21,6 @@ spec:
         volumeMounts:
         - name: hostpath-root
           mountPath: /tmp
-        securityContext:
-          privileged: true
       volumes:
       - name: hostpath-root
         hostPath:

--- a/pkg/controller/csidriverdeployment/testdata/04-noop/in-daemonset.yaml
+++ b/pkg/controller/csidriverdeployment/testdata/04-noop/in-daemonset.yaml
@@ -58,8 +58,6 @@ spec:
               fieldPath: spec.nodeName
         image: quay.io/k8scsi/driver-registrar:v0.3.0
         name: csi-driver-registrar
-        securityContext:
-          privileged: true
         volumeMounts:
         - mountPath: /csi
           name: csi-driver

--- a/pkg/controller/csidriverdeployment/testdata/04-noop/in-deployment.yaml
+++ b/pkg/controller/csidriverdeployment/testdata/04-noop/in-deployment.yaml
@@ -41,8 +41,6 @@ spec:
         - containerPort: 9808
           name: csi-probe
           protocol: TCP
-        securityContext:
-          privileged: true
         volumeMounts:
         - mountPath: /tmp
           name: hostpath-root

--- a/pkg/controller/csidriverdeployment/testdata/05-overwrite-changes/in-csidriverdeployment.yaml
+++ b/pkg/controller/csidriverdeployment/testdata/05-overwrite-changes/in-csidriverdeployment.yaml
@@ -21,8 +21,6 @@ spec:
         volumeMounts:
         - name: hostpath-root
           mountPath: /tmp
-        securityContext:
-          privileged: true
       volumes:
       - name: hostpath-root
         hostPath:

--- a/pkg/controller/csidriverdeployment/testdata/05-overwrite-changes/in-daemonset.yaml
+++ b/pkg/controller/csidriverdeployment/testdata/05-overwrite-changes/in-daemonset.yaml
@@ -60,8 +60,6 @@ spec:
               fieldPath: spec.nodeName
         image: quay.io/k8scsi/driver-registrar:v0.3.0
         name: csi-driver-registrar
-        securityContext:
-          privileged: true
         volumeMounts:
         - mountPath: /csi
           name: csi-driver

--- a/pkg/controller/csidriverdeployment/testdata/05-overwrite-changes/in-deployment.yaml
+++ b/pkg/controller/csidriverdeployment/testdata/05-overwrite-changes/in-deployment.yaml
@@ -43,8 +43,6 @@ spec:
         - containerPort: 9808
           name: csi-probe
           protocol: TCP
-        securityContext:
-          privileged: true
         volumeMounts:
         - mountPath: /tmp
           name: hostpath-root

--- a/pkg/controller/csidriverdeployment/testdata/05-overwrite-changes/out-csidriverdeployment.yaml
+++ b/pkg/controller/csidriverdeployment/testdata/05-overwrite-changes/out-csidriverdeployment.yaml
@@ -21,8 +21,6 @@ spec:
         volumeMounts:
         - name: hostpath-root
           mountPath: /tmp
-        securityContext:
-          privileged: true
       volumes:
       - name: hostpath-root
         hostPath:

--- a/pkg/controller/csidriverdeployment/testdata/05-overwrite-changes/out-daemonset.yaml
+++ b/pkg/controller/csidriverdeployment/testdata/05-overwrite-changes/out-daemonset.yaml
@@ -60,8 +60,6 @@ spec:
               fieldPath: spec.nodeName
         image: quay.io/k8scsi/driver-registrar:v0.3.0
         name: csi-driver-registrar
-        securityContext:
-          privileged: true
         volumeMounts:
         - mountPath: /csi
           name: csi-driver

--- a/pkg/controller/csidriverdeployment/testdata/06-user-changes/in-csidriverdeployment.yaml
+++ b/pkg/controller/csidriverdeployment/testdata/06-user-changes/in-csidriverdeployment.yaml
@@ -21,8 +21,6 @@ spec:
         volumeMounts:
         - name: hostpath-root
           mountPath: /tmp
-        securityContext:
-          privileged: true
       volumes:
       - name: hostpath-root
         hostPath:

--- a/pkg/controller/csidriverdeployment/testdata/06-user-changes/in-daemonset.yaml
+++ b/pkg/controller/csidriverdeployment/testdata/06-user-changes/in-daemonset.yaml
@@ -58,8 +58,6 @@ spec:
               fieldPath: spec.nodeName
         image: quay.io/k8scsi/driver-registrar:v0.3.0
         name: csi-driver-registrar
-        securityContext:
-          privileged: true
         volumeMounts:
         - mountPath: /csi
           name: csi-driver

--- a/pkg/controller/csidriverdeployment/testdata/06-user-changes/in-deployment.yaml
+++ b/pkg/controller/csidriverdeployment/testdata/06-user-changes/in-deployment.yaml
@@ -41,8 +41,6 @@ spec:
         - containerPort: 9808
           name: csi-probe
           protocol: TCP
-        securityContext:
-          privileged: true
         volumeMounts:
         - mountPath: /tmp
           name: hostpath-root

--- a/pkg/controller/csidriverdeployment/testdata/06-user-changes/out-csidriverdeployment.yaml
+++ b/pkg/controller/csidriverdeployment/testdata/06-user-changes/out-csidriverdeployment.yaml
@@ -21,8 +21,6 @@ spec:
         volumeMounts:
         - name: hostpath-root
           mountPath: /tmp
-        securityContext:
-          privileged: true
       volumes:
       - name: hostpath-root
         hostPath:

--- a/pkg/controller/csidriverdeployment/testdata/06-user-changes/out-daemonset.yaml
+++ b/pkg/controller/csidriverdeployment/testdata/06-user-changes/out-daemonset.yaml
@@ -58,8 +58,6 @@ spec:
               fieldPath: spec.nodeName
         image: quay.io/k8scsi/driver-registrar:v0.3.0
         name: csi-driver-registrar
-        securityContext:
-          privileged: true
         volumeMounts:
         - mountPath: /csi
           name: csi-driver

--- a/pkg/controller/csidriverdeployment/testdata/06-user-changes/out-deployment.yaml
+++ b/pkg/controller/csidriverdeployment/testdata/06-user-changes/out-deployment.yaml
@@ -41,8 +41,6 @@ spec:
         - containerPort: 9808
           name: csi-probe
           protocol: TCP
-        securityContext:
-          privileged: true
         volumeMounts:
         - mountPath: /tmp
           name: hostpath-root

--- a/pkg/controller/csidriverdeployment/testdata/07-storageclass-changes/in-csidriverdeployment.yaml
+++ b/pkg/controller/csidriverdeployment/testdata/07-storageclass-changes/in-csidriverdeployment.yaml
@@ -21,8 +21,6 @@ spec:
         volumeMounts:
         - name: hostpath-root
           mountPath: /tmp
-        securityContext:
-          privileged: true
       volumes:
       - name: hostpath-root
         hostPath:

--- a/pkg/controller/csidriverdeployment/testdata/07-storageclass-changes/in-daemonset.yaml
+++ b/pkg/controller/csidriverdeployment/testdata/07-storageclass-changes/in-daemonset.yaml
@@ -58,8 +58,6 @@ spec:
               fieldPath: spec.nodeName
         image: quay.io/k8scsi/driver-registrar:v0.3.0
         name: csi-driver-registrar
-        securityContext:
-          privileged: true
         volumeMounts:
         - mountPath: /csi
           name: csi-driver

--- a/pkg/controller/csidriverdeployment/testdata/07-storageclass-changes/in-deployment.yaml
+++ b/pkg/controller/csidriverdeployment/testdata/07-storageclass-changes/in-deployment.yaml
@@ -41,8 +41,6 @@ spec:
         - containerPort: 9808
           name: csi-probe
           protocol: TCP
-        securityContext:
-          privileged: true
         volumeMounts:
         - mountPath: /tmp
           name: hostpath-root

--- a/pkg/controller/csidriverdeployment/testdata/08-deletion/in-csidriverdeployment.yaml
+++ b/pkg/controller/csidriverdeployment/testdata/08-deletion/in-csidriverdeployment.yaml
@@ -22,8 +22,6 @@ spec:
         volumeMounts:
         - name: hostpath-root
           mountPath: /tmp
-        securityContext:
-          privileged: true
       volumes:
       - name: hostpath-root
         hostPath:

--- a/pkg/controller/csidriverdeployment/testdata/08-deletion/in-daemonset.yaml
+++ b/pkg/controller/csidriverdeployment/testdata/08-deletion/in-daemonset.yaml
@@ -58,8 +58,6 @@ spec:
               fieldPath: spec.nodeName
         image: quay.io/k8scsi/driver-registrar:v0.3.0
         name: csi-driver-registrar
-        securityContext:
-          privileged: true
         volumeMounts:
         - mountPath: /csi
           name: csi-driver

--- a/pkg/controller/csidriverdeployment/testdata/08-deletion/in-deployment.yaml
+++ b/pkg/controller/csidriverdeployment/testdata/08-deletion/in-deployment.yaml
@@ -41,8 +41,6 @@ spec:
         - containerPort: 9808
           name: csi-probe
           protocol: TCP
-        securityContext:
-          privileged: true
         volumeMounts:
         - mountPath: /tmp
           name: hostpath-root

--- a/pkg/controller/csidriverdeployment/testdata/08-deletion/out-csidriverdeployment.yaml
+++ b/pkg/controller/csidriverdeployment/testdata/08-deletion/out-csidriverdeployment.yaml
@@ -20,8 +20,6 @@ spec:
         volumeMounts:
         - name: hostpath-root
           mountPath: /tmp
-        securityContext:
-          privileged: true
       volumes:
       - name: hostpath-root
         hostPath:

--- a/pkg/controller/csidriverdeployment/testdata/09-deletion-noop/in-csidriverdeployment.yaml
+++ b/pkg/controller/csidriverdeployment/testdata/09-deletion-noop/in-csidriverdeployment.yaml
@@ -22,8 +22,6 @@ spec:
         volumeMounts:
         - name: hostpath-root
           mountPath: /tmp
-        securityContext:
-          privileged: true
       volumes:
       - name: hostpath-root
         hostPath:

--- a/pkg/controller/csidriverdeployment/testdata/09-deletion-noop/in-daemonset.yaml
+++ b/pkg/controller/csidriverdeployment/testdata/09-deletion-noop/in-daemonset.yaml
@@ -58,8 +58,6 @@ spec:
               fieldPath: spec.nodeName
         image: quay.io/k8scsi/driver-registrar:v0.3.0
         name: csi-driver-registrar
-        securityContext:
-          privileged: true
         volumeMounts:
         - mountPath: /csi
           name: csi-driver

--- a/pkg/controller/csidriverdeployment/testdata/09-deletion-noop/in-deployment.yaml
+++ b/pkg/controller/csidriverdeployment/testdata/09-deletion-noop/in-deployment.yaml
@@ -41,8 +41,6 @@ spec:
         - containerPort: 9808
           name: csi-probe
           protocol: TCP
-        securityContext:
-          privileged: true
         volumeMounts:
         - mountPath: /tmp
           name: hostpath-root

--- a/pkg/controller/csidriverdeployment/testdata/09-deletion-noop/out-csidriverdeployment.yaml
+++ b/pkg/controller/csidriverdeployment/testdata/09-deletion-noop/out-csidriverdeployment.yaml
@@ -20,8 +20,6 @@ spec:
         volumeMounts:
         - name: hostpath-root
           mountPath: /tmp
-        securityContext:
-          privileged: true
       volumes:
       - name: hostpath-root
         hostPath:

--- a/pkg/controller/csidriverdeployment/testdata/10-unmanaged/in-csidriverdeployment.yaml
+++ b/pkg/controller/csidriverdeployment/testdata/10-unmanaged/in-csidriverdeployment.yaml
@@ -21,8 +21,6 @@ spec:
         volumeMounts:
         - name: hostpath-root
           mountPath: /tmp
-        securityContext:
-          privileged: true
       volumes:
       - name: hostpath-root
         hostPath:

--- a/pkg/controller/csidriverdeployment/testdata/11-sync-status-deployment/in-csidriverdeployment.yaml
+++ b/pkg/controller/csidriverdeployment/testdata/11-sync-status-deployment/in-csidriverdeployment.yaml
@@ -21,8 +21,6 @@ spec:
         volumeMounts:
         - name: hostpath-root
           mountPath: /tmp
-        securityContext:
-          privileged: true
       volumes:
       - name: hostpath-root
         hostPath:

--- a/pkg/controller/csidriverdeployment/testdata/11-sync-status-deployment/in-daemonset.yaml
+++ b/pkg/controller/csidriverdeployment/testdata/11-sync-status-deployment/in-daemonset.yaml
@@ -58,8 +58,6 @@ spec:
               fieldPath: spec.nodeName
         image: quay.io/k8scsi/driver-registrar:v0.3.0
         name: csi-driver-registrar
-        securityContext:
-          privileged: true
         volumeMounts:
         - mountPath: /csi
           name: csi-driver

--- a/pkg/controller/csidriverdeployment/testdata/11-sync-status-deployment/in-deployment.yaml
+++ b/pkg/controller/csidriverdeployment/testdata/11-sync-status-deployment/in-deployment.yaml
@@ -41,8 +41,6 @@ spec:
         - containerPort: 9808
           name: csi-probe
           protocol: TCP
-        securityContext:
-          privileged: true
         volumeMounts:
         - mountPath: /tmp
           name: hostpath-root

--- a/pkg/controller/csidriverdeployment/testdata/11-sync-status-deployment/out-csidriverdeployment.yaml
+++ b/pkg/controller/csidriverdeployment/testdata/11-sync-status-deployment/out-csidriverdeployment.yaml
@@ -21,8 +21,6 @@ spec:
         volumeMounts:
         - name: hostpath-root
           mountPath: /tmp
-        securityContext:
-          privileged: true
       volumes:
       - name: hostpath-root
         hostPath:

--- a/pkg/controller/csidriverdeployment/testdata/12-sync-status-daemonset/in-csidriverdeployment.yaml
+++ b/pkg/controller/csidriverdeployment/testdata/12-sync-status-daemonset/in-csidriverdeployment.yaml
@@ -21,8 +21,6 @@ spec:
         volumeMounts:
         - name: hostpath-root
           mountPath: /tmp
-        securityContext:
-          privileged: true
       volumes:
       - name: hostpath-root
         hostPath:

--- a/pkg/controller/csidriverdeployment/testdata/12-sync-status-daemonset/in-daemonset.yaml
+++ b/pkg/controller/csidriverdeployment/testdata/12-sync-status-daemonset/in-daemonset.yaml
@@ -58,8 +58,6 @@ spec:
               fieldPath: spec.nodeName
         image: quay.io/k8scsi/driver-registrar:v0.3.0
         name: csi-driver-registrar
-        securityContext:
-          privileged: true
         volumeMounts:
         - mountPath: /csi
           name: csi-driver

--- a/pkg/controller/csidriverdeployment/testdata/12-sync-status-daemonset/in-deployment.yaml
+++ b/pkg/controller/csidriverdeployment/testdata/12-sync-status-daemonset/in-deployment.yaml
@@ -41,8 +41,6 @@ spec:
         - containerPort: 9808
           name: csi-probe
           protocol: TCP
-        securityContext:
-          privileged: true
         volumeMounts:
         - mountPath: /tmp
           name: hostpath-root

--- a/pkg/controller/csidriverdeployment/testdata/12-sync-status-daemonset/out-csidriverdeployment.yaml
+++ b/pkg/controller/csidriverdeployment/testdata/12-sync-status-daemonset/out-csidriverdeployment.yaml
@@ -21,8 +21,6 @@ spec:
         volumeMounts:
         - name: hostpath-root
           mountPath: /tmp
-        securityContext:
-          privileged: true
       volumes:
       - name: hostpath-root
         hostPath:

--- a/pkg/controller/csidriverdeployment/testdata/13-security-context/in-csidriverdeployment.yaml
+++ b/pkg/controller/csidriverdeployment/testdata/13-security-context/in-csidriverdeployment.yaml
@@ -1,15 +1,11 @@
 apiVersion: csidriver.storage.openshift.io/v1alpha1
 kind: CSIDriverDeployment
 metadata:
-  finalizers:
-  - csidriver.storage.openshift.io
   name: test
   namespace: default
   uid: "1234567890"
   generation: 1
 spec:
-  managementState: Unmanaged
-
   driverName: csi-test
   driverControllerTemplate:
     spec:
@@ -21,6 +17,8 @@ spec:
         volumeMounts:
         - name: hostpath-root
           mountPath: /tmp
+        securityContext:
+          privileged: true
       volumes:
       - name: hostpath-root
         hostPath:
@@ -33,6 +31,8 @@ spec:
         - --test-argument=bar
         image: quay.io/k8scsi/hostpathplugin:v0.2.0
         name: csi-driver
+        securityContext:
+          privileged: true
 
   driverSocket: /csi/csi.sock
   nodeUpdateStrategy: Rolling
@@ -50,25 +50,3 @@ spec:
         name: sc2
       parameters:
         foo1: bar1
-
-status:
-  children:
-  - group: apps
-    lastGeneration: 0
-    name: test-node
-    namespace: "default"
-    resource: DaemonSet
-  - group: apps
-    lastGeneration: 0
-    name: test-controller
-    namespace: "default"
-    resource: Deployment
-  conditions:
-  - lastTransitionTime: "2018-01-01T00:00:00Z"
-    status: "True"
-    type: Available
-  - lastTransitionTime: "2018-01-01T00:00:00Z"
-    status: "True"
-    type: SyncSuccessful
-  observedGeneration: 1
-  state: Unmanaged

--- a/pkg/controller/csidriverdeployment/testdata/13-security-context/out-clusterrolebinding.yaml
+++ b/pkg/controller/csidriverdeployment/testdata/13-security-context/out-clusterrolebinding.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    csidriver.storage.openshift.io/owner-name: test
+    csidriver.storage.openshift.io/owner-namespace: "default"
+  name: csidriverdeployment-1234567890
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:openshift:csi-driver
+subjects:
+- kind: ServiceAccount
+  name: test
+  namespace: default

--- a/pkg/controller/csidriverdeployment/testdata/13-security-context/out-csidriverdeployment.yaml
+++ b/pkg/controller/csidriverdeployment/testdata/13-security-context/out-csidriverdeployment.yaml
@@ -8,7 +8,7 @@ metadata:
   uid: "1234567890"
   generation: 1
 spec:
-  managementState: Unmanaged
+  managementState: Managed
 
   driverName: csi-test
   driverControllerTemplate:
@@ -21,6 +21,8 @@ spec:
         volumeMounts:
         - name: hostpath-root
           mountPath: /tmp
+        securityContext:
+          privileged: true
       volumes:
       - name: hostpath-root
         hostPath:
@@ -33,6 +35,8 @@ spec:
         - --test-argument=bar
         image: quay.io/k8scsi/hostpathplugin:v0.2.0
         name: csi-driver
+        securityContext:
+          privileged: true
 
   driverSocket: /csi/csi.sock
   nodeUpdateStrategy: Rolling
@@ -71,4 +75,4 @@ status:
     status: "True"
     type: SyncSuccessful
   observedGeneration: 1
-  state: Unmanaged
+  state: Managed

--- a/pkg/controller/csidriverdeployment/testdata/13-security-context/out-daemonset.yaml
+++ b/pkg/controller/csidriverdeployment/testdata/13-security-context/out-daemonset.yaml
@@ -1,13 +1,11 @@
 apiVersion: apps/v1
-kind: Deployment
+kind: DaemonSet
 metadata:
   labels:
     csidriver.storage.openshift.io/owner-name: test
     csidriver.storage.openshift.io/owner-namespace: "default"
-    newLabel: newValue # user change
-  name: test-controller
+  name: test-node
   namespace: default
-  generation: 1 # Simulate user change
   ownerReferences:
   - apiVersion: csidriver.storage.openshift.io/v1alpha1
     controller: true
@@ -15,20 +13,17 @@ metadata:
     name: test
     uid: "1234567890"
 spec:
-  replicas: 1
   selector:
     matchLabels:
-      csidriver.storage.openshift.io/deployment: test-controller
-  strategy:
-    type: RollingUpdate
+      csidriver.storage.openshift.io/daemonset: test-node
   template:
     metadata:
       labels:
-        csidriver.storage.openshift.io/deployment: test-controller
+        csidriver.storage.openshift.io/daemonset: test-node
     spec:
       containers:
       - args:
-        - --test-argument=foo
+        - --test-argument=bar
         image: quay.io/k8scsi/hostpathplugin:v0.2.0
         livenessProbe:
           failureThreshold: 3
@@ -44,33 +39,34 @@ spec:
           name: csi-probe
           protocol: TCP
         volumeMounts:
-        - mountPath: /tmp
-          name: hostpath-root
         - mountPath: /csi
           name: csi-driver
-      - args:
-        - --v=5
-        - --csi-address=$(ADDRESS)
-        - --provisioner=csi-test
-        env:
-        - name: ADDRESS
-          value: /csi/csi.sock
-        image: quay.io/k8scsi/csi-provisioner:v0.3.1
-        name: csi-provisioner
-        volumeMounts:
-        - mountPath: /csi
-          name: csi-driver
+        - mountPath: /var/lib/kubelet
+          mountPropagation: Bidirectional
+          name: kubelet-root
+        securityContext:
+          privileged: true
       - args:
         - --v=5
         - --csi-address=$(ADDRESS)
         env:
         - name: ADDRESS
           value: /csi/csi.sock
-        image: quay.io/k8scsi/csi-attacher:v0.3.0
-        name: csi-attacher
+        - name: DRIVER_REG_SOCK_PATH
+          value: /var/lib/kubelet/plugins/csi-test/csi.sock
+        - name: KUBE_NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        image: quay.io/k8scsi/driver-registrar:v0.3.0
+        name: csi-driver-registrar
         volumeMounts:
         - mountPath: /csi
           name: csi-driver
+        - mountPath: /registration
+          name: registration-dir
+        securityContext:
+          privileged: true
       - args:
         - --v=5
         - --csi-address=$(ADDRESS)
@@ -83,12 +79,21 @@ spec:
         volumeMounts:
         - mountPath: /csi
           name: csi-driver
+        securityContext:
+          privileged: true
       serviceAccountName: test
       volumes:
       - hostPath:
-          path: /tmp
+          path: /var/lib/kubelet/plugins
           type: Directory
-        name: hostpath-root
-      - emptyDir: {}
+        name: registration-dir
+      - hostPath:
+          path: /var/lib/kubelet/plugins/csi-test
+          type: DirectoryOrCreate
         name: csi-driver
-status: {}
+      - hostPath:
+          path: /var/lib/kubelet
+          type: Directory
+        name: kubelet-root
+  updateStrategy:
+    type: RollingUpdate

--- a/pkg/controller/csidriverdeployment/testdata/13-security-context/out-deployment.yaml
+++ b/pkg/controller/csidriverdeployment/testdata/13-security-context/out-deployment.yaml
@@ -4,10 +4,8 @@ metadata:
   labels:
     csidriver.storage.openshift.io/owner-name: test
     csidriver.storage.openshift.io/owner-namespace: "default"
-    newLabel: newValue # user change
   name: test-controller
   namespace: default
-  generation: 1 # Simulate user change
   ownerReferences:
   - apiVersion: csidriver.storage.openshift.io/v1alpha1
     controller: true
@@ -48,6 +46,8 @@ spec:
           name: hostpath-root
         - mountPath: /csi
           name: csi-driver
+        securityContext:
+          privileged: true
       - args:
         - --v=5
         - --csi-address=$(ADDRESS)
@@ -60,6 +60,8 @@ spec:
         volumeMounts:
         - mountPath: /csi
           name: csi-driver
+        securityContext:
+          privileged: true
       - args:
         - --v=5
         - --csi-address=$(ADDRESS)
@@ -71,6 +73,8 @@ spec:
         volumeMounts:
         - mountPath: /csi
           name: csi-driver
+        securityContext:
+          privileged: true
       - args:
         - --v=5
         - --csi-address=$(ADDRESS)
@@ -83,6 +87,8 @@ spec:
         volumeMounts:
         - mountPath: /csi
           name: csi-driver
+        securityContext:
+          privileged: true
       serviceAccountName: test
       volumes:
       - hostPath:

--- a/pkg/controller/csidriverdeployment/testdata/13-security-context/out-rolebinding.yaml
+++ b/pkg/controller/csidriverdeployment/testdata/13-security-context/out-rolebinding.yaml
@@ -1,0 +1,23 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    csidriver.storage.openshift.io/owner-name: test
+    csidriver.storage.openshift.io/owner-namespace: "default"
+  name: leader-election-test
+  namespace: default
+  ownerReferences:
+  - apiVersion: csidriver.storage.openshift.io/v1alpha1
+    controller: true
+    kind: CSIDriverDeployment
+    name: test
+    namespace: default
+    uid: "1234567890"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:openshift:csi-driver-controller-leader-election
+subjects:
+- kind: ServiceAccount
+  name: test
+  namespace: default

--- a/pkg/controller/csidriverdeployment/testdata/13-security-context/out-serviceaccount.yaml
+++ b/pkg/controller/csidriverdeployment/testdata/13-security-context/out-serviceaccount.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  creationTimestamp: null
+  labels:
+    csidriver.storage.openshift.io/owner-name: test
+    csidriver.storage.openshift.io/owner-namespace: "default"
+  name: test
+  namespace: default
+  ownerReferences:
+  - apiVersion: csidriver.storage.openshift.io/v1alpha1
+    controller: true
+    kind: CSIDriverDeployment
+    name: test
+    uid: "1234567890"

--- a/pkg/controller/csidriverdeployment/testdata/13-security-context/out-storageclass1.yaml
+++ b/pkg/controller/csidriverdeployment/testdata/13-security-context/out-storageclass1.yaml
@@ -1,0 +1,14 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "true"
+  creationTimestamp: null
+  labels:
+    csidriver.storage.openshift.io/owner-name: test
+    csidriver.storage.openshift.io/owner-namespace: "default"
+  name: sc1
+provisioner: csi-test
+reclaimPolicy: Delete
+allowVolumeExpansion: true
+volumeBindingMode: Immediate

--- a/pkg/controller/csidriverdeployment/testdata/13-security-context/out-storageclass2.yaml
+++ b/pkg/controller/csidriverdeployment/testdata/13-security-context/out-storageclass2.yaml
@@ -1,0 +1,12 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "false"
+  labels:
+    csidriver.storage.openshift.io/owner-name: test
+    csidriver.storage.openshift.io/owner-namespace: "default"
+  name: sc2
+provisioner: csi-test
+parameters:
+  foo1: bar1

--- a/pkg/controller/csidriverdeployment/testdata/13-security-context/readme.txt
+++ b/pkg/controller/csidriverdeployment/testdata/13-security-context/readme.txt
@@ -1,0 +1,1 @@
+Simple CRD with SecurityContext -> all objects are created with SecurityContext copied from the driver.


### PR DESCRIPTION
Copy SecurityContext from the driver container to all sidecar containers in the same pod, just in case the driver container runs with specific UID or as privileged. The sidecar containers must be able to talk to UNIX domain socket created by the driver and running with the same UID / GID / privileges is the only 100% reliable way.