### PR TITLE
Fix golint error

### DIFF
--- a/pkg/controller/csidriverdeployment/objects_test.go
+++ b/pkg/controller/csidriverdeployment/objects_test.go
@@ -16,14 +16,14 @@ import (
 )
 
 var (
-	defaultDriverContainer corev1.Container = corev1.Container{
+	defaultDriverContainer = corev1.Container{
 		Name:  "defaultDriverContainer",
 		Image: "defaultDriverImage",
 	}
 
 	sixty = int32(60)
 
-	defaultCR v1alpha1.CSIDriverDeployment = v1alpha1.CSIDriverDeployment{
+	defaultCR = v1alpha1.CSIDriverDeployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "default",
 			Namespace: "default",


### PR DESCRIPTION
Currently golint (`./hack/verify-golint.sh `) fails due to following error:

```
$ ./hack/verify-golint.sh 
!!! golint detected the following problems:
./pkg/controller/csidriverdeployment/objects_test.go:19:25: should omit type corev1.Container from declaration of var defaultDriverContainer; it will be inferred from the right-hand side
./pkg/controller/csidriverdeployment/objects_test.go:26:12: should omit type v1alpha1.CSIDriverDeployment from declaration of var defaultCR; it will be inferred from the right-hand side
```

This patch fixes the error.