### PR TITLE
Fix hostpath image sample to support dynamic registration

### DIFF
--- a/deploy/samples/hostpath.yaml
+++ b/deploy/samples/hostpath.yaml
@@ -20,7 +20,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: spec.nodeName
-        image: quay.io/k8scsi/hostpathplugin:v0.2.0
+        image: quay.io/k8scsi/hostpathplugin:v0.4.1
         imagePullPolicy: IfNotPresent
         name: csi-driver
         volumeMounts:
@@ -49,7 +49,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: spec.nodeName
-        image: quay.io/k8scsi/hostpathplugin:v0.2.0
+        image: quay.io/k8scsi/hostpathplugin:v0.4.1
         imagePullPolicy: IfNotPresent
         name: csi-driver
         securityContext:


### PR DESCRIPTION
In Kubernetes 1.13, dynamic driver registration is preferred and CSI driver must report non-empty node name. This is fixed in newer hostpath drivers.