### PR TITLE
Verify generated assets in `make verify`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,11 @@ include $(addprefix ./vendor/github.com/openshift/build-machinery-go/make/, \
 
 test-unit: test-unit-aws-ebs
 
-verify: verify-aws-ebs
+verify: verify-aws-ebs verify-generated-assets
+
+verify-generated-assets: update-generated-assets
+	git diff --exit-code
+.PHONY: verify-generated-assets
 
 test-unit-aws-ebs:
 	cd legacy/aws-ebs-csi-driver-operator && $(MAKE) test-unit
@@ -22,5 +26,8 @@ verify-aws-ebs:
 	cd legacy/aws-ebs-csi-driver-operator && $(MAKE) verify
 .PHONY: verify-aws-ebs
 
-update:
+update: update-generated-assets
+
+update-generated-assets:
 	hack/update-generated-assets.sh
+.PHONY: update-generated-assets


### PR DESCRIPTION
Add `verify-generated-assets` make target that just re-generates the assets + calls `git diff`. It will produce false negatives when users have unstaged changes in their workdir, but it's good enough for CI. It's similar to what [openshift/api uses](https://github.com/openshift/api/blob/b8a18fdc040de6208d49111ac776ac08b98e6bb7/Makefile#L67).