### PR TITLE
Update all generated assets in a single run

### DIFF
--- a/hack/update-generated-assets.sh
+++ b/hack/update-generated-assets.sh
@@ -6,7 +6,4 @@ REPO_ROOT="$(dirname $0)/.."
 
 cd "${REPO_ROOT}"
 GENERATOR="go run github.com/openshift/csi-operator/cmd/generator"
-
-# TODO: loop over flavours and drivers
-${GENERATOR} -flavour standalone -path assets/overlays/aws-ebs/generated/standalone
-${GENERATOR} -flavour hypershift -path assets/overlays/aws-ebs/generated/hypershift
+${GENERATOR} -path assets


### PR DESCRIPTION
Generator now re-generates all assets of all CSI drivers in a single call. So we don't need to list the drivers in `hack/update-generated-assets.sh`.

It should be more obvious to maintain one `main.go` instead of `hack/` script.