### PR TITLE
Drop Guest prefix from client names

### DIFF
--- a/pkg/clients/builder.go
+++ b/pkg/clients/builder.go
@@ -99,8 +99,8 @@ func (b *Builder) BuildOrDie(ctx context.Context) *Clients {
 		}
 		clients.EventRecorder = events.NewKubeRecorder(guestKubeClient.CoreV1().Events(CSIDriverNamespace), b.userAgwent, controllerRef)
 	}
-	clients.GuestKubeClient = guestKubeClient
-	clients.GuestKubeInformers = v1helpers.NewKubeInformersForNamespaces(guestKubeClient, b.guestNamespaces...)
+	clients.KubeClient = guestKubeClient
+	clients.KubeInformers = v1helpers.NewKubeInformersForNamespaces(guestKubeClient, b.guestNamespaces...)
 
 	gvr := opv1.SchemeGroupVersion.WithResource("clustercsidrivers")
 	guestOperatorClient, guestOperatorDynamicInformers, err := goc.NewClusterScopedOperatorClientWithConfigName(guestKubeConfig, gvr, b.csiDriverName)
@@ -114,23 +114,23 @@ func (b *Builder) BuildOrDie(ctx context.Context) *Clients {
 	if err != nil {
 		panic(err)
 	}
-	clients.GuestAPIExtClient = guestAPIExtClient
-	clients.GuestAPIExtInformer = apiextinformers.NewSharedInformerFactory(guestAPIExtClient, b.resync)
+	clients.APIExtClient = guestAPIExtClient
+	clients.APIExtInformer = apiextinformers.NewSharedInformerFactory(guestAPIExtClient, b.resync)
 
 	guestDynamicClient, err := dynamic.NewForConfig(guestKubeConfig)
 	if err != nil {
 		panic(err)
 	}
-	clients.GuestDynamicClient = guestDynamicClient
+	clients.DynamicClient = guestDynamicClient
 
 	// TODO: non-filtered one for VolumeSnapshots?
-	clients.GuestDynamicInformer = dynamicinformer.NewFilteredDynamicSharedInformerFactory(guestDynamicClient, b.resync, CSIDriverNamespace, nil)
+	clients.DynamicInformer = dynamicinformer.NewFilteredDynamicSharedInformerFactory(guestDynamicClient, b.resync, CSIDriverNamespace, nil)
 
-	clients.GuestOperatorClientSet = opclient.NewForConfigOrDie(guestKubeConfig)
-	clients.GuestOperatorInformers = opinformers.NewSharedInformerFactory(clients.GuestOperatorClientSet, b.resync)
+	clients.OperatorClientSet = opclient.NewForConfigOrDie(guestKubeConfig)
+	clients.OperatorInformers = opinformers.NewSharedInformerFactory(clients.OperatorClientSet, b.resync)
 
-	clients.GuestConfigClientSet = cfgclientset.NewForConfigOrDie(guestKubeConfig)
-	clients.GuestConfigInformers = cfginformers.NewSharedInformerFactory(clients.GuestConfigClientSet, b.resync)
+	clients.ConfigClientSet = cfgclientset.NewForConfigOrDie(guestKubeConfig)
+	clients.ConfigInformers = cfginformers.NewSharedInformerFactory(clients.ConfigClientSet, b.resync)
 
 	return clients
 }

--- a/pkg/clients/clients.go
+++ b/pkg/clients/clients.go
@@ -49,29 +49,29 @@ type Clients struct {
 	ControlPlaneDynamicInformer dynamicinformer.DynamicSharedInformerFactory
 
 	// Kubernetes API client for guest or standalone.
-	GuestKubeClient kubernetes.Interface
+	KubeClient kubernetes.Interface
 	// Kubernetes API client for guest or standalone. Per namespace.
-	GuestKubeInformers v1helpers.KubeInformersForNamespaces
+	KubeInformers v1helpers.KubeInformersForNamespaces
 
 	// CRD API client for guest or standalone. Used to check if volume snapshot CRDs are installed.
-	GuestAPIExtClient apiextclient.Interface
+	APIExtClient apiextclient.Interface
 	// CRD API informers for guest or standalone. Used to check if volume snapshot CRDs are installed.
-	GuestAPIExtInformer apiextinformers.SharedInformerFactory
+	APIExtInformer apiextinformers.SharedInformerFactory
 
 	// Dynamic client for the guest cluster. E.g. for VolumeSnapshotClass.
-	GuestDynamicClient dynamic.Interface
+	DynamicClient dynamic.Interface
 	// Dynamic informer for the guest cluster. E.g. for VolumeSnapshotClass.
-	GuestDynamicInformer dynamicinformer.DynamicSharedInformerFactory
+	DynamicInformer dynamicinformer.DynamicSharedInformerFactory
 
 	// operator.openshift.io client, e.g. for ClusterCSIDriver. Always in the guest or standalone cluster.
-	GuestOperatorClientSet opclient.Interface
+	OperatorClientSet opclient.Interface
 	// operator.openshift.io informers.  Always in the guest or standalone cluster.
-	GuestOperatorInformers opinformers.SharedInformerFactory
+	OperatorInformers opinformers.SharedInformerFactory
 
 	// config.openshift.io client, e.g. for Infrastructure. Always in the guest or standalone cluster.
-	GuestConfigClientSet cfgclientset.Interface
+	ConfigClientSet cfgclientset.Interface
 	// config.openshift.io informers. Always in the guest or standalone cluster.
-	GuestConfigInformers cfginformers.SharedInformerFactory
+	ConfigInformers cfginformers.SharedInformerFactory
 }
 
 // GetControlPlaneSecretInformer returns a Secret informer for given control plane namespace.
@@ -84,19 +84,19 @@ func (c *Clients) GetControlPlaneConfigMapInformer(namespace string) coreinforme
 	return c.ControlPlaneKubeInformers.InformersFor(namespace).Core().V1().ConfigMaps()
 }
 
-// GetGuestConfigMapInformer returns a ConfigMap informer for given guest namespace.
-func (c *Clients) GetGuestConfigMapInformer(namespace string) coreinformers.ConfigMapInformer {
-	return c.GuestKubeInformers.InformersFor(namespace).Core().V1().ConfigMaps()
+// GetConfigMapInformer returns a ConfigMap informer for given guest namespace.
+func (c *Clients) GetConfigMapInformer(namespace string) coreinformers.ConfigMapInformer {
+	return c.KubeInformers.InformersFor(namespace).Core().V1().ConfigMaps()
 }
 
-// GetGuestNodeInformer returns a Node informer.
-func (c *Clients) GetGuestNodeInformer() coreinformers.NodeInformer {
-	return c.GuestKubeInformers.InformersFor("").Core().V1().Nodes()
+// GetNodeInformer returns a Node informer.
+func (c *Clients) GetNodeInformer() coreinformers.NodeInformer {
+	return c.KubeInformers.InformersFor("").Core().V1().Nodes()
 }
 
-// GetGuestInfraInformer returns an Infrastructure informer.
-func (c *Clients) GetGuestInfraInformer() cfgv1informers.InfrastructureInformer {
-	return c.GuestConfigInformers.Config().V1().Infrastructures()
+// GetInfraInformer returns an Infrastructure informer.
+func (c *Clients) GetInfraInformer() cfgv1informers.InfrastructureInformer {
+	return c.ConfigInformers.Config().V1().Infrastructures()
 }
 
 // Start starts all informers.
@@ -106,11 +106,11 @@ func (c *Clients) Start(ctx context.Context) {
 	}
 	c.ControlPlaneKubeInformers.Start(ctx.Done())
 	c.ControlPlaneDynamicInformer.Start(ctx.Done())
-	c.GuestKubeInformers.Start(ctx.Done())
-	c.GuestAPIExtInformer.Start(ctx.Done())
-	c.GuestDynamicInformer.Start(ctx.Done())
-	c.GuestOperatorInformers.Start(ctx.Done())
-	c.GuestConfigInformers.Start(ctx.Done())
+	c.KubeInformers.Start(ctx.Done())
+	c.APIExtInformer.Start(ctx.Done())
+	c.DynamicInformer.Start(ctx.Done())
+	c.OperatorInformers.Start(ctx.Done())
+	c.ConfigInformers.Start(ctx.Done())
 }
 
 // WaitForCacheSync waits for all caches to sync.
@@ -123,11 +123,11 @@ func (c *Clients) WaitForCacheSync(ctx context.Context) {
 		c.ControlPlaneKubeInformers.InformersFor(ns).WaitForCacheSync(ctx.Done())
 	}
 	c.ControlPlaneDynamicInformer.WaitForCacheSync(ctx.Done())
-	for ns := range c.GuestKubeInformers.Namespaces() {
-		c.GuestKubeInformers.InformersFor(ns).WaitForCacheSync(ctx.Done())
+	for ns := range c.KubeInformers.Namespaces() {
+		c.KubeInformers.InformersFor(ns).WaitForCacheSync(ctx.Done())
 	}
-	c.GuestAPIExtInformer.WaitForCacheSync(ctx.Done())
-	c.GuestDynamicInformer.WaitForCacheSync(ctx.Done())
-	c.GuestOperatorInformers.WaitForCacheSync(ctx.Done())
-	c.GuestConfigInformers.WaitForCacheSync(ctx.Done())
+	c.APIExtInformer.WaitForCacheSync(ctx.Done())
+	c.DynamicInformer.WaitForCacheSync(ctx.Done())
+	c.OperatorInformers.WaitForCacheSync(ctx.Done())
+	c.ConfigInformers.WaitForCacheSync(ctx.Done())
 }

--- a/pkg/clients/fake.go
+++ b/pkg/clients/fake.go
@@ -76,16 +76,16 @@ func NewFakeClients(controllerNamespace string, cr *opv1.ClusterCSIDriver) *Clie
 		ControlPlaneDynamicClient:   controlPlaneDynamicClient,
 		ControlPlaneDynamicInformer: controlPlaneDynamicInformer,
 
-		GuestKubeClient:        guestKubeClient,
-		GuestKubeInformers:     guestKubeInformers,
-		GuestAPIExtClient:      guestAPIExtClient,
-		GuestAPIExtInformer:    guestAPIExtInformerFactory,
-		GuestDynamicClient:     guestDynamicClient,
-		GuestDynamicInformer:   guestDynamicInformer,
-		GuestOperatorClientSet: guestOperatorClient,
-		GuestOperatorInformers: guestOperatorInformerFactory,
-		GuestConfigClientSet:   guestConfigClient,
-		GuestConfigInformers:   guestConfigInformerFactory,
+		KubeClient:        guestKubeClient,
+		KubeInformers:     guestKubeInformers,
+		APIExtClient:      guestAPIExtClient,
+		APIExtInformer:    guestAPIExtInformerFactory,
+		DynamicClient:     guestDynamicClient,
+		DynamicInformer:   guestDynamicInformer,
+		OperatorClientSet: guestOperatorClient,
+		OperatorInformers: guestOperatorInformerFactory,
+		ConfigClientSet:   guestConfigClient,
+		ConfigInformers:   guestConfigInformerFactory,
 	}
 }
 

--- a/pkg/driver/aws-ebs/aws_ebs.go
+++ b/pkg/driver/aws-ebs/aws_ebs.go
@@ -203,7 +203,7 @@ func getCustomAWSCABundleBuilder(cmName string) config.DeploymentHookBuilder {
 // infrastructure.Status.PlatformStatus.AWS.ServiceEndpoints.
 func withCustomEndPoint(c *clients.Clients) (dc.DeploymentHookFunc, []factory.Informer) {
 	hook := func(_ *opv1.OperatorSpec, deployment *appsv1.Deployment) error {
-		infraLister := c.GetGuestInfraInformer().Lister()
+		infraLister := c.GetInfraInformer().Lister()
 		infra, err := infraLister.Get(infrastructureName)
 		if err != nil {
 			return err
@@ -236,7 +236,7 @@ func withCustomEndPoint(c *clients.Clients) (dc.DeploymentHookFunc, []factory.In
 		return nil
 	}
 	informers := []factory.Informer{
-		c.GetGuestInfraInformer().Informer(),
+		c.GetInfraInformer().Informer(),
 	}
 	return hook, informers
 }
@@ -256,9 +256,9 @@ func newCustomAWSBundleSyncer(c *clients.Clients) (factory.Controller, error) {
 	}
 	certController := resourcesynccontroller.NewResourceSyncController(
 		c.OperatorClient,
-		c.GuestKubeInformers,
-		c.GuestKubeClient.CoreV1(),
-		c.GuestKubeClient.CoreV1(),
+		c.KubeInformers,
+		c.KubeClient.CoreV1(),
+		c.KubeClient.CoreV1(),
 		c.EventRecorder)
 	err := certController.SyncConfigMap(dstConfigMap, srcConfigMap)
 	if err != nil {
@@ -301,10 +301,10 @@ func withCABundleDaemonSetHook(c *clients.Clients) (csidrivernodeservicecontroll
 	hook := csidrivernodeservicecontroller.WithCABundleDaemonSetHook(
 		clients.CSIDriverNamespace,
 		trustedCAConfigMap,
-		c.GetGuestConfigMapInformer(clients.CSIDriverNamespace),
+		c.GetConfigMapInformer(clients.CSIDriverNamespace),
 	)
 	informers := []factory.Informer{
-		c.GetGuestConfigMapInformer(clients.CSIDriverNamespace).Informer(),
+		c.GetConfigMapInformer(clients.CSIDriverNamespace).Informer(),
 	}
 	return hook, informers
 }
@@ -313,7 +313,7 @@ func withCABundleDaemonSetHook(c *clients.Clients) (csidrivernodeservicecontroll
 // --extra-tags=<key1>=<value1>,<key2>=<value2>,...
 func withCustomTags(c *clients.Clients) (dc.DeploymentHookFunc, []factory.Informer) {
 	hook := func(spec *opv1.OperatorSpec, deployment *appsv1.Deployment) error {
-		infraLister := c.GetGuestInfraInformer().Lister()
+		infraLister := c.GetInfraInformer().Lister()
 		infra, err := infraLister.Get(infrastructureName)
 		if err != nil {
 			return err
@@ -345,7 +345,7 @@ func withCustomTags(c *clients.Clients) (dc.DeploymentHookFunc, []factory.Inform
 		return nil
 	}
 	informers := []factory.Informer{
-		c.GetGuestInfraInformer().Informer(),
+		c.GetInfraInformer().Informer(),
 	}
 	return hook, informers
 }
@@ -353,7 +353,7 @@ func withCustomTags(c *clients.Clients) (dc.DeploymentHookFunc, []factory.Inform
 // withAWSRegion sets AWS_REGION env. var from infrastructure.Status.PlatformStatus.AWS.Region
 func withAWSRegion(c *clients.Clients) (dc.DeploymentHookFunc, []factory.Informer) {
 	hook := func(_ *opv1.OperatorSpec, deployment *appsv1.Deployment) error {
-		infraLister := c.GetGuestInfraInformer().Lister()
+		infraLister := c.GetInfraInformer().Lister()
 		infra, err := infraLister.Get(infrastructureName)
 		if err != nil {
 			return err
@@ -381,7 +381,7 @@ func withAWSRegion(c *clients.Clients) (dc.DeploymentHookFunc, []factory.Informe
 		return nil
 	}
 	informers := []factory.Informer{
-		c.GetGuestInfraInformer().Informer(),
+		c.GetInfraInformer().Informer(),
 	}
 	return hook, informers
 }
@@ -391,7 +391,7 @@ func withAWSRegion(c *clients.Clients) (dc.DeploymentHookFunc, []factory.Informe
 // This allows the admin to specify a customer managed key to be used by default.
 func withKMSKeyHook(c *clients.Clients) csistorageclasscontroller.StorageClassHookFunc {
 	hook := func(_ *opv1.OperatorSpec, class *storagev1.StorageClass) error {
-		ccdLister := c.GuestOperatorInformers.Operator().V1().ClusterCSIDrivers().Lister()
+		ccdLister := c.OperatorInformers.Operator().V1().ClusterCSIDrivers().Lister()
 		ccd, err := ccdLister.Get(class.Provisioner)
 		if err != nil {
 			return err
@@ -418,6 +418,6 @@ func withKMSKeyHook(c *clients.Clients) csistorageclasscontroller.StorageClassHo
 	}
 	// Explicitly instantiate ClusterCSIDriver informer, so it is synced during WaitForCacheSync
 	// and thus its lister is populated
-	_ = c.GuestOperatorInformers.Operator().V1().ClusterCSIDrivers().Informer()
+	_ = c.OperatorInformers.Operator().V1().ClusterCSIDrivers().Informer()
 	return hook
 }

--- a/pkg/driver/aws-ebs/aws_ebs_test.go
+++ b/pkg/driver/aws-ebs/aws_ebs_test.go
@@ -126,7 +126,7 @@ func Test_WithCustomEndPoint(t *testing.T) {
 			hook, _ := withCustomEndPoint(c)
 			deployment := getTestDeployment()
 			// Arrange - inject custom infrastructure
-			c.GuestConfigClientSet.(*fakeconfig.Clientset).Tracker().Add(tt.infrastructure)
+			c.ConfigClientSet.(*fakeconfig.Clientset).Tracker().Add(tt.infrastructure)
 			clients.SyncFakeInformers(t, c)
 
 			// Act
@@ -202,7 +202,7 @@ func Test_WithCustomTags(t *testing.T) {
 			hook, _ := withCustomTags(c)
 			deployment := getTestDeployment()
 			// Arrange - inject custom infrastructure
-			c.GuestConfigClientSet.(*fakeconfig.Clientset).Tracker().Add(tt.infrastructure)
+			c.ConfigClientSet.(*fakeconfig.Clientset).Tracker().Add(tt.infrastructure)
 			clients.SyncFakeInformers(t, c)
 
 			// Act
@@ -277,7 +277,7 @@ func Test_WithCustomRegion(t *testing.T) {
 			hook, _ := withAWSRegion(c)
 			deployment := getTestDeployment()
 			// Arrange - inject custom infrastructure
-			c.GuestConfigClientSet.(*fakeconfig.Clientset).Tracker().Add(tt.infrastructure)
+			c.ConfigClientSet.(*fakeconfig.Clientset).Tracker().Add(tt.infrastructure)
 			clients.SyncFakeInformers(t, c)
 
 			// Act
@@ -351,7 +351,7 @@ func Test_WithKMSKeyHook(t *testing.T) {
 			hook := withKMSKeyHook(c)
 			sc := getTestStorageClass()
 			// Arrange - inject custom infrastructure
-			c.GuestOperatorClientSet.(*fakeoperator.Clientset).Tracker().Add(tt.clusterCSIDriver)
+			c.OperatorClientSet.(*fakeoperator.Clientset).Tracker().Add(tt.clusterCSIDriver)
 			clients.SyncFakeInformers(t, c)
 
 			// Act

--- a/pkg/driver/common/operator/hooks.go
+++ b/pkg/driver/common/operator/hooks.go
@@ -51,9 +51,9 @@ func withClusterWideProxy(c *clients.Clients) (dc.DeploymentHookFunc, []factory.
 
 // withStandaloneReplicas sets control-plane replica count to on a standalone cluster.
 func withStandaloneReplicas(c *clients.Clients) (dc.DeploymentHookFunc, []factory.Informer) {
-	hook := csidrivercontrollerservicecontroller.WithReplicasHook(c.GetGuestNodeInformer().Lister())
+	hook := csidrivercontrollerservicecontroller.WithReplicasHook(c.GetNodeInformer().Lister())
 	informers := []factory.Informer{
-		c.GetGuestNodeInformer().Informer(),
+		c.GetNodeInformer().Informer(),
 	}
 	return hook, informers
 }

--- a/pkg/driver/common/operator/hooks_test.go
+++ b/pkg/driver/common/operator/hooks_test.go
@@ -59,7 +59,7 @@ func Test_WithStandaloneReplicas(t *testing.T) {
 			cr := clients.GetFakeOperatorCR()
 			c := clients.NewFakeClients("test", cr)
 			// Arrange: inject desired nr. of nodes to the client
-			kubeTracker := c.GuestKubeClient.(*fake.Clientset).Tracker()
+			kubeTracker := c.KubeClient.(*fake.Clientset).Tracker()
 			nodeID := 0
 			for label, count := range tt.nodeCounts {
 				for i := 0; i < count; i++ {


### PR DESCRIPTION
Most of the clients are for the guest cluster, keep ControlPlane for the mgmt cluster.