### PR TITLE
hack: remove existing path from .gitignore

### DIFF
--- a/legacy/aws-ebs-csi-driver-operator/.gitignore
+++ b/legacy/aws-ebs-csi-driver-operator/.gitignore
@@ -12,4 +12,3 @@
 *.out
 
 _output
-aws-ebs-csi-driver-operator


### PR DESCRIPTION
`aws-ebs-csi-driver-operator` in .gitignore` matches `legacy/aws-ebs-csi-driver-operator/cmd/aws-ebs-csi-driver-operator` which is in the repository and must not be ignored.

This is a temporary hack to test if ART build succeeds, I will post it to github.com/openshift/aws-ebs-csi-driver-operator and then squash the commit here afterwards.