### PR TITLE
STOR-1500: Add log for the new operator

### DIFF
--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -27,6 +27,7 @@ const (
 )
 
 func RunOperator(ctx context.Context, controllerConfig *controllercmd.ControllerContext, guestKubeConfigString string, opConfig *config.OperatorConfig) error {
+	klog.V(2).Infof("Running openshift/csi-operator for %s", opConfig.CSIDriverName)
 	isHypershift := guestKubeConfigString != ""
 	controlPlaneNamespace := controllerConfig.OperatorNamespace
 


### PR DESCRIPTION
To make the new aws-ebs-csi-driver-operator easily distinguishable from the old one.

cc @openshift/storage 