### PR TITLE
OCPBUGS-24245: Add selinux

### DIFF
--- a/assets/overlays/aws-ebs/base/csidriver.yaml
+++ b/assets/overlays/aws-ebs/base/csidriver.yaml
@@ -11,5 +11,6 @@ spec:
   fsGroupPolicy: File
   requiresRepublish: false
   storageCapacity: false
+  seLinuxMount: true
   volumeLifecycleModes:
     - Persistent

--- a/assets/overlays/aws-ebs/generated/hypershift/csidriver.yaml
+++ b/assets/overlays/aws-ebs/generated/hypershift/csidriver.yaml
@@ -15,6 +15,7 @@ spec:
   fsGroupPolicy: File
   podInfoOnMount: false
   requiresRepublish: false
+  seLinuxMount: true
   storageCapacity: false
   volumeLifecycleModes:
   - Persistent

--- a/assets/overlays/aws-ebs/generated/standalone/csidriver.yaml
+++ b/assets/overlays/aws-ebs/generated/standalone/csidriver.yaml
@@ -15,6 +15,7 @@ spec:
   fsGroupPolicy: File
   podInfoOnMount: false
   requiresRepublish: false
+  seLinuxMount: true
   storageCapacity: false
   volumeLifecycleModes:
   - Persistent


### PR DESCRIPTION
Restore `seLinuxMount: true` in AWS EBS CSIDriver instance that we lost when moving to csi-operator repo.

cc @openshift/storage 