### PR TITLE
HOSTEDCP-1308: Adding KAS access label to aws-ebs-csi-driver-controll…

### DIFF
--- a/assets/common/hypershift/controller_add_affinity_tolerations.yaml
+++ b/assets/common/hypershift/controller_add_affinity_tolerations.yaml
@@ -1,4 +1,5 @@
 # Add HyperShift specific tolerations + affinity to Deployment running in a hosted control plane namespace
+# Add Hypershift specific label for KAS management access
 kind: Deployment
 apiVersion: apps/v1
 spec:
@@ -6,6 +7,7 @@ spec:
     metadata:
       labels:
         hypershift.openshift.io/hosted-control-plane: ${NAMESPACE}
+        hypershift.openshift.io/need-management-kas-access: "true"
     spec:
       affinity:
         nodeAffinity:

--- a/assets/overlays/aws-ebs/generated/hypershift/controller.yaml
+++ b/assets/overlays/aws-ebs/generated/hypershift/controller.yaml
@@ -52,6 +52,7 @@ spec:
       labels:
         app: aws-ebs-csi-driver-controller
         hypershift.openshift.io/hosted-control-plane: ${NAMESPACE}
+        hypershift.openshift.io/need-management-kas-access: "true"
     spec:
       affinity:
         nodeAffinity:


### PR DESCRIPTION
Adding KAS access label to aws-ebs-csi-driver-controller deployment in Hypershift 
Jira: [HOSTEDCP-1308](https://issues.redhat.com/browse/HOSTEDCP-1308)