### PR TITLE
NO-JIRA: Add dependabot configuration

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,27 @@
+version: 2
+updates:
+- package-ecosystem: gomod
+  directory: "/"
+  allow:
+  - dependency-type: "all"
+  schedule:
+    interval: daily
+  groups:
+    golang-dependencies:
+      patterns:
+        - "github.com/golang*"
+        - "golang.org/*"
+    k8s-dependencies:
+      patterns:
+        - "k8s.io*"
+        - "sigs.k8s.io*"
+        - "github.com/kubernetes-csi*"
+    opentelemetry-dependencies:
+      patterns:
+        - "go.opentelemetry.io*"
+  labels:
+    - "ok-to-test"
+    - "px-approved"
+    - "docs-approved"
+    - "qe-approved"
+  open-pull-requests-limit: 10


### PR DESCRIPTION
Add dependabot configuration that opens PRs for *all* dependencies (not only the direct ones and not only CVEs). Group the largest groups together:
- golang.org/x/*
- k8s.io/* and related repos
- opentelemetry.io/*

The rest should be ungrouped (I hope, documentation is not clear).

The PRs get automatic `ok-to-test` and `*-approved` labels.

cc @openshift/storage