### PR TITLE
STOR-1713: Don't ignore azure-disk-csi-driver-operator

### DIFF
--- a/legacy/azure-disk-csi-driver-operator/.gitignore
+++ b/legacy/azure-disk-csi-driver-operator/.gitignore
@@ -12,5 +12,4 @@
 *.out
 
 _output
-azure-disk-csi-driver-operator
 .idea


### PR DESCRIPTION
This is a copy of https://github.com/openshift/csi-operator/pull/110 to start a fresh build, as CI in #110 has cached the repo somewhere.

Fixes art build.