### PR TITLE
STOR-1713: Add Dockerfile.openshift symlink to Azure Disk

### DIFF
--- a/Dockerfile.openshift
+++ b/Dockerfile.openshift
@@ -1,0 +1,1 @@
+Dockerfile.azure-disk


### PR DESCRIPTION
This is a temporary hack to fix CI builds.

CI syncs Dockerfile names from ART. ART metadata still has `openshift/azure-disk-csi-driver-operator/Dockerfile.openshift` as the Dockerfile. So create `Dockerfile.openshift` symlink, so CI can find `openshift/csi-operator/Dockerfile.openshift` and build Azure Disk from there temporarily, until ART medata is fixed.

This link must be removed after https://github.com/openshift-eng/ocp-build-data/pull/4148 merges and CI starts using Dockerfile.azure-disk.