### PR TITLE
Add valid-reference label to dependabot PRs

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -24,4 +24,5 @@ updates:
     - "px-approved"
     - "docs-approved"
     - "qe-approved"
+    - "jira/valid-reference"
   open-pull-requests-limit: 10


### PR DESCRIPTION
The label is required to get a PR merged.

cc @openshift/storage 