### PR TITLE
NO-JIRA: Configure dependabot for security updates only

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -25,4 +25,7 @@ updates:
     - "docs-approved"
     - "qe-approved"
     - "jira/valid-reference"
-  open-pull-requests-limit: 10
+  # 0 means that only security updates are allowed.
+  # https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#open-pull-requests-limit
+  # https://docs.github.com/en/code-security/dependabot/dependabot-security-updates/configuring-dependabot-security-updates#overriding-the-default-behavior-with-a-configuration-file
+  open-pull-requests-limit: 0


### PR DESCRIPTION
Allow dependabot to open only security update PRs.

Dependabot [docs](https://docs.github.com/en/code-security/dependabot/dependabot-security-updates/configuring-dependabot-security-updates#overriding-the-default-behavior-with-a-configuration-file) say:

> If you only require security updates and want to exclude version updates,
> you can set open-pull-requests-limit to 0 in order to prevent version
> updates for a given package-ecosystem

I am curious what it does and how noisy is it going to be. Hoping for just few PRs per month, if any.