### PR TITLE
STOR-1464: Enable RWOP tests in CI

### DIFF
--- a/legacy/aws-ebs-csi-driver-operator/test/e2e/manifest.yaml
+++ b/legacy/aws-ebs-csi-driver-operator/test/e2e/manifest.yaml
@@ -27,3 +27,4 @@ DriverInfo:
     topology: true
     multipods: true
     multiplePVsSameID: true
+    readWriteOncePod: true

--- a/legacy/azure-disk-csi-driver-operator/test/e2e/manifest.yaml
+++ b/legacy/azure-disk-csi-driver-operator/test/e2e/manifest.yaml
@@ -29,6 +29,7 @@ DriverInfo:
     topology: true
     multipods: true
     multiplePVsSameID: true
+    readWriteOncePod: true
 Timeouts:
   PodStart: 15m
   PodDelete: 15m

--- a/legacy/azure-file-csi-driver-operator/test/e2e/manifest.yaml
+++ b/legacy/azure-file-csi-driver-operator/test/e2e/manifest.yaml
@@ -20,3 +20,4 @@ DriverInfo:
     # Snapshots are not supported in this release
     snapshotDataSource: false
     multiplePVsSameID: true
+    readWriteOncePod: true


### PR DESCRIPTION
For all CSI drivers in this repository, i.e. aws-ebs, azure-disk and azure-file. The test manifests are still in the legacy/ folder.

@openshift/storage 