### PR TITLE
OCPBUGS-30620: move test manifests to top-level directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,21 +10,11 @@ include $(addprefix ./vendor/github.com/openshift/build-machinery-go/make/, \
 	targets/openshift/images.mk \
 )
 
-test-unit: test-unit-aws-ebs
-
-verify: verify-aws-ebs verify-generated-assets
+verify: verify-generated-assets
 
 verify-generated-assets: update-generated-assets
 	git diff --exit-code
 .PHONY: verify-generated-assets
-
-test-unit-aws-ebs:
-	cd legacy/aws-ebs-csi-driver-operator && $(MAKE) test-unit
-.PHONY: test-unit-aws-ebs
-
-verify-aws-ebs:
-	cd legacy/aws-ebs-csi-driver-operator && $(MAKE) verify
-.PHONY: verify-aws-ebs
 
 update: update-generated-assets
 

--- a/test/e2e/aws-ebs/manifest.yaml
+++ b/test/e2e/aws-ebs/manifest.yaml
@@ -1,0 +1,30 @@
+# Test manifest for https://github.com/kubernetes/kubernetes/tree/master/test/e2e/storage/external
+ShortName: ebs
+StorageClass:
+  FromExistingClassName: gp2-csi
+SnapshotClass:
+  FromName: true
+DriverInfo:
+  Name: ebs.csi.aws.com
+  SupportedSizeRange:
+    Min: 1Gi
+    Max: 16Ti
+  SupportedFsType:
+    xfs: {}
+    ext4: {}
+  SupportedMountOption:
+    dirsync: {}
+  TopologyKeys: ["topology.ebs.csi.aws.com/zone"]
+  Capabilities:
+    persistence: true
+    fsGroup: true
+    block: true
+    exec: true
+    volumeLimits: false
+    controllerExpansion: true
+    nodeExpansion: true
+    snapshotDataSource: true
+    topology: true
+    multipods: true
+    multiplePVsSameID: true
+    readWriteOncePod: true

--- a/test/e2e/azure-disk/manifest.yaml
+++ b/test/e2e/azure-disk/manifest.yaml
@@ -1,0 +1,36 @@
+# Test manifest for https://github.com/kubernetes/kubernetes/tree/master/test/e2e/storage/external
+ShortName: azuredisk
+StorageClass:
+  FromExistingClassName: managed-csi
+SnapshotClass:
+  FromName: true
+DriverInfo:
+  Name: disk.csi.azure.com
+  SupportedSizeRange:
+    Min: 1Gi
+    Max: 16Ti
+  SupportedFsType:
+    xfs: {}
+    ext4: {}
+  SupportedMountOption:
+    dirsync: {}
+  TopologyKeys: ["topology.disk.csi.azure.com/zone"]
+  Capabilities:
+    persistence: true
+    fsGroup: true
+    block: true
+    exec: true
+    volumeLimits: false
+    controllerExpansion: true
+    nodeExpansion: true
+    onlineExpansion: false
+    snapshotDataSource: true
+    pvcDataSource: true
+    topology: true
+    multipods: true
+    multiplePVsSameID: true
+    readWriteOncePod: true
+Timeouts:
+  PodStart: 15m
+  PodDelete: 15m
+  PVDelete: 20m

--- a/test/e2e/azure-file/manifest.yaml
+++ b/test/e2e/azure-file/manifest.yaml
@@ -1,0 +1,23 @@
+# Test manifest for https://github.com/kubernetes/kubernetes/tree/master/test/e2e/storage/external
+ShortName: azurefile
+StorageClass:
+  FromExistingClassName: azurefile-csi
+SnapshotClass:
+  FromName: true
+DriverInfo:
+  Name: file.csi.azure.com
+  Capabilities:
+    persistence: true
+    exec: true
+    multipods: true
+    RWX: true
+    fsGroup: true
+    volumeMountGroup: true
+    topology: false
+    controllerExpansion: true
+    nodeExpansion: true
+    volumeLimits: false
+    # Snapshots are not supported in this release
+    snapshotDataSource: false
+    multiplePVsSameID: true
+    readWriteOncePod: true


### PR DESCRIPTION
This PR copies the test manifests from the `legacy` dir to a top-level `test` dir so we can eventually remove the legacy dir (after updating CI jobs).

```
$ cp legacy/aws-ebs-csi-driver-operator/test/e2e/manifest.yaml test/e2e/aws-ebs/
$ cp legacy/azure-disk-csi-driver-operator/test/e2e/manifest.yaml test/e2e/azure-disk/
$ cp legacy/azure-file-csi-driver-operator/test/e2e/manifest.yaml test/e2e/azure-file/
```

Also remove the legacy test-unit and verify targets from the Makefile (we should be running these against the code we compile instead).

/cc @openshift/storage
