### PR TITLE
[4.15] OCPBUGS-30621: move test manifest to top-level directory

### DIFF
--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,0 +1,5 @@
+# "src" is build by a prow job when building final images.
+# It contains full repository sources + jq + pyhon with yaml module.
+# Use it as test image for the operator.
+
+FROM src

--- a/Makefile
+++ b/Makefile
@@ -10,21 +10,11 @@ include $(addprefix ./vendor/github.com/openshift/build-machinery-go/make/, \
 	targets/openshift/images.mk \
 )
 
-test-unit: test-unit-aws-ebs
-
-verify: verify-aws-ebs verify-generated-assets
+verify: verify-generated-assets
 
 verify-generated-assets: update-generated-assets
 	git diff --exit-code
 .PHONY: verify-generated-assets
-
-test-unit-aws-ebs:
-	cd legacy/aws-ebs-csi-driver-operator && $(MAKE) test-unit
-.PHONY: test-unit-aws-ebs
-
-verify-aws-ebs:
-	cd legacy/aws-ebs-csi-driver-operator && $(MAKE) verify
-.PHONY: verify-aws-ebs
 
 update: update-generated-assets
 

--- a/test/e2e/aws-ebs/manifest.yaml
+++ b/test/e2e/aws-ebs/manifest.yaml
@@ -1,0 +1,29 @@
+# Test manifest for https://github.com/kubernetes/kubernetes/tree/master/test/e2e/storage/external
+ShortName: ebs
+StorageClass:
+  FromExistingClassName: gp2-csi
+SnapshotClass:
+  FromName: true
+DriverInfo:
+  Name: ebs.csi.aws.com
+  SupportedSizeRange:
+    Min: 1Gi
+    Max: 16Ti
+  SupportedFsType:
+    xfs: {}
+    ext4: {}
+  SupportedMountOption:
+    dirsync: {}
+  TopologyKeys: ["topology.ebs.csi.aws.com/zone"]
+  Capabilities:
+    persistence: true
+    fsGroup: true
+    block: true
+    exec: true
+    volumeLimits: false
+    controllerExpansion: true
+    nodeExpansion: true
+    snapshotDataSource: true
+    topology: true
+    multipods: true
+    multiplePVsSameID: true


### PR DESCRIPTION
This is sort of a backport of https://github.com/openshift/csi-operator/pull/194 to 4.15 where aws-ebs is built (before azure-disk and azure-file were added). The intent is to eventually remove the `legacy` directory, which means we have to move the manifests first.

It also creates Dockerfile.test which already exists in the master branch but not 4.15.

```
$ cp legacy/aws-ebs-csi-driver-operator/test/e2e/manifest.yaml test/e2e/aws-ebs/
$ cp Dockerfile.aws-ebs.test Dockerfile.test
```

Also remove the legacy test-unit and verify targets from the Makefile (we should be running these against the code we compile instead).

/cc @openshift/storage
