### PR TITLE
OCPBUGS-23260: Explicitly reserve 1 attachment for the root disk

### DIFF
--- a/assets/overlays/aws-ebs/generated/hypershift/node.yaml
+++ b/assets/overlays/aws-ebs/generated/hypershift/node.yaml
@@ -36,6 +36,7 @@ spec:
         - --endpoint=$(CSI_ENDPOINT)
         - --logtostderr
         - --v=${LOG_LEVEL}
+        - --reserved-volume-attachments=1
         env:
         - name: CSI_ENDPOINT
           value: unix:/csi/csi.sock

--- a/assets/overlays/aws-ebs/generated/standalone/node.yaml
+++ b/assets/overlays/aws-ebs/generated/standalone/node.yaml
@@ -36,6 +36,7 @@ spec:
         - --endpoint=$(CSI_ENDPOINT)
         - --logtostderr
         - --v=${LOG_LEVEL}
+        - --reserved-volume-attachments=1
         env:
         - name: CSI_ENDPOINT
           value: unix:/csi/csi.sock

--- a/assets/overlays/aws-ebs/patches/node_add_driver.yaml
+++ b/assets/overlays/aws-ebs/patches/node_add_driver.yaml
@@ -19,6 +19,7 @@ spec:
             - --endpoint=$(CSI_ENDPOINT)
             - --logtostderr
             - --v=${LOG_LEVEL}
+            - --reserved-volume-attachments=1
           env:
             - name: CSI_ENDPOINT
               value: unix:/csi/csi.sock


### PR DESCRIPTION
Using a newly introduced option --reserved-volume-attachments, explicitly reserve 1 AWS EBS volume attachment for the root disk and leave the other attachment to PVs/PVCs.

This disables bad heuristics in the CSI driver, see the linked bug.

/hold
for https://github.com/openshift/aws-ebs-csi-driver/pull/260 to be merged first