### PR TITLE
STOR-1794: add location for azcopy logs

### DIFF
--- a/assets/overlays/azure-file/generated/hypershift/controller.yaml
+++ b/assets/overlays/azure-file/generated/hypershift/controller.yaml
@@ -99,6 +99,10 @@ spec:
           value: /etc/kubernetes/cloud.conf
         - name: CSI_ENDPOINT
           value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
+        - name: AZCOPY_LOG_LOCATION
+          value: /tmp/azcopy
+        - name: AZCOPY_JOB_PLAN_LOCATION
+          value: /tmp/azcopy
         - name: KUBECONFIG
           value: /etc/hosted-kubernetes/kubeconfig
         image: ${DRIVER_IMAGE}

--- a/assets/overlays/azure-file/generated/standalone/controller.yaml
+++ b/assets/overlays/azure-file/generated/standalone/controller.yaml
@@ -69,6 +69,10 @@ spec:
           value: /etc/kubernetes/cloud.conf
         - name: CSI_ENDPOINT
           value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
+        - name: AZCOPY_LOG_LOCATION
+          value: /tmp/azcopy
+        - name: AZCOPY_JOB_PLAN_LOCATION
+          value: /tmp/azcopy
         image: ${DRIVER_IMAGE}
         imagePullPolicy: IfNotPresent
         livenessProbe:

--- a/assets/overlays/azure-file/patches/controller_add_driver.yaml
+++ b/assets/overlays/azure-file/patches/controller_add_driver.yaml
@@ -29,6 +29,10 @@ spec:
               value: "/etc/kubernetes/cloud.conf"
             - name: CSI_ENDPOINT
               value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
+            - name: AZCOPY_LOG_LOCATION
+              value: /tmp/azcopy
+            - name: AZCOPY_JOB_PLAN_LOCATION
+              value: /tmp/azcopy
           ports:
             - name: healthz
               containerPort: 10303


### PR DESCRIPTION
`azcopy` tool needs a writeable location for logs:


Before fix:
```
sh-5.1$ azcopy 
2024/03/04 12:41:21 Problem making .azcopy directory. Try setting AZCOPY_LOG_LOCATION env variable. mkdir /.azcopy: permission denied
sh-5.1$ export AZCOPY_LOG_LOCATION=/tmp
sh-5.1$ azcopy
2024/03/04 12:41:34 Problem making .azcopy directory. Try setting AZCOPY_JOB_PLAN_LOCATION env variable. mkdir /.azcopy: permission denied
sh-5.1$ export AZCOPY_JOB_PLAN_LOCATION=/tmp
sh-5.1$ azcopy
AzCopy 10.22.1
```

After fix:
```
$ oc describe pvc/pvc-1-clone
Name:          pvc-1-clone
Namespace:     default
StorageClass:  azurefile-csi
Status:        Bound
Volume:        pvc-89a7a986-45e9-4357-a497-1a4fbd2dd229
Labels:        <none>
Annotations:   pv.kubernetes.io/bind-completed: yes
               pv.kubernetes.io/bound-by-controller: yes
               volume.beta.kubernetes.io/storage-provisioner: file.csi.azure.com
               volume.kubernetes.io/storage-provisioner: file.csi.azure.com
Finalizers:    [kubernetes.io/pvc-protection]
Capacity:      1Gi
Access Modes:  RWO
VolumeMode:    Filesystem
DataSource:
  APIGroup:
  Kind:      PersistentVolumeClaim
  Name:      pvc-1
Used By:     <none>
Events:
  Type    Reason                 Age                From                                                                                        Message
  ----    ------                 ----               ----                                                                                        -------
  Normal  Provisioning           36s                file.csi.azure.com_ci-ln-gq9mbdb-1d09d-xzg2r-master-0_5c14d541-1cc2-4733-afed-2db2cafab886  External provisioner is provisioning volume for claim "default/pvc-1-clone"
  Normal  ExternalProvisioning   35s (x2 over 36s)  persistentvolume-controller                                                                 Waiting for a volume to be created either by the external provisioner 'file.csi.azure.com' or manually by the system administrator. If volume creation is delayed, please verify that the provisioner is running and correctly registered.
  Normal  ProvisioningSucceeded  28s                file.csi.azure.com_ci-ln-gq9mbdb-1d09d-xzg2r-master-0_5c14d541-1cc2-4733-afed-2db2cafab886  Successfully provisioned volume pvc-89a7a986-45e9-4357-a497-1a4fbd2dd229
```

```
# cat /tmp/azcopy/5745cdd2-5add-5041-4b01-7de392942e6c.log
2024/03/04 12:28:13 AzcopyVersion  10.22.1
2024/03/04 12:28:13 OS-Environment  linux
2024/03/04 12:28:13 OS-Architecture  amd64
2024/03/04 12:28:13 Log times are in UTC. Local time is 4 Mar 2024 12:28:13
2024/03/04 12:28:13 ISO 8601 START TIME: to copy files that changed before or after this job started, use the parameter --include-before=2024-03-04T12:28:08Z or --include-after=2024-03-04T12:28:08Z
2024/03/04 12:28:13 ==> REQUEST/RESPONSE (Try=1/28.00806ms, OpTime=66.817338ms) -- RESPONSE SUCCESSFULLY RECEIVED
   GET https://clusterxkbyc.file.core.windows.net/pvc-89a7a986-45e9-4357-a497-1a4fbd2dd229?restype=share&se=2024-03-05T12%3A28%3A08Z&sig=-REDACTED-&sp=rwl&spr=https&srt=sco&ss=f&st=2024-03-04T12%3A28%3A08Z&sv=2020-02-10
   X-Ms-Request-Id: [1fa3485e-301a-0005-222f-6e2341000000]

2024/03/04 12:28:13 Any empty folders will be processed, because source and destination both support folders
2024/03/04 12:28:13 Job-Command copy https://clusterxkbyc.file.core.windows.net/pvc-55255a01-b115-4084-b06e-9102e87a1580?se=2024-03-05t12%3A28%3A08z&sig=-REDACTED-&sp=rwl&spr=https&srt=sco&ss=f&st=2024-03-04t12%3A28%3A08z&sv=2020-02-10 https://clusterxkbyc.file.core.windows.net/pvc-89a7a986-45e9-4357-a497-1a4fbd2dd229?se=2024-03-05t12%3A28%3A08z&sig=-REDACTED-&sp=rwl&spr=https&srt=sco&ss=f&st=2024-03-04t12%3A28%3A08z&sv=2020-02-10 --recursive --check-length=false 
2024/03/04 12:28:13 Number of CPUs: 8
2024/03/04 12:28:13 Max file buffer RAM 4.000 GB
2024/03/04 12:28:13 Max concurrent network operations:  will be dynamically tuned up to 3000 (Based on auto-tuning limit. Set AZCOPY_CONCURRENCY_VALUE environment variable to override)
2024/03/04 12:28:13 Check CPU usage when dynamically tuning concurrency: true (Based on hard-coded default. Set AZCOPY_TUNE_TO_CPU environment variable to true or false override)
2024/03/04 12:28:13 Max concurrent transfer initiation routines: 64 (Based on hard-coded default. Set AZCOPY_CONCURRENT_FILES environment variable to override)
2024/03/04 12:28:13 Max enumeration routines: 16 (Based on hard-coded default. Set AZCOPY_CONCURRENT_SCAN environment variable to override)
2024/03/04 12:28:13 Parallelize getting file properties (file.Stat): false (Based on AZCOPY_PARALLEL_STAT_FILES environment variable)
2024/03/04 12:28:13 Max open files when downloading: 1048047 (auto-computed)
2024/03/04 12:28:13 No transfers were scheduled.
2024/03/04 12:28:13 Final job part has been created
2024/03/04 12:28:13 Trying 4 concurrent connections (initial starting point)
2024/03/04 12:28:15 PERF: primary performance constraint is Unknown. States: W:  0, F:  0, S:  0, E:  0, T:  0, GRs:  4
2024/03/04 12:28:15 100.0 %, 0 Done, 0 Failed, 0 Pending, 0 Skipped, 0 Total, 
2024/03/04 12:28:15 

Diagnostic stats:
IOPS: 0
End-to-end ms per request: 0
Network Errors: 0.00%
Server Busy: 0.00%


Job 5745cdd2-5add-5041-4b01-7de392942e6c summary
Elapsed Time (Minutes): 0.0333
Number of File Transfers: 0
Number of Folder Property Transfers: 0
Number of Symlink Transfers: 0
Total Number of Transfers: 0
Number of File Transfers Completed: 0
Number of Folder Transfers Completed: 0
Number of File Transfers Failed: 0
Number of Folder Transfers Failed: 0
Number of File Transfers Skipped: 0
Number of Folder Transfers Skipped: 0
TotalBytesTransferred: 0
Final Job Status: Completed

2024/03/04 12:28:15 Closing Log
```

cc @openshift/storage 