### PR TITLE
STOR-1726: Minimal implementation of CIFS/Samba CSI driver operator

### DIFF
--- a/assets/overlays/samba/generated/standalone/configmap_and_secret_reader_provisioner_binding.yaml
+++ b/assets/overlays/samba/generated/standalone/configmap_and_secret_reader_provisioner_binding.yaml
@@ -1,0 +1,14 @@
+# Allow the provisioner to read any secret in the cluster
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: smb-csi-provisioner-configmap-and-secret-reader-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: openshift-csi-provisioner-configmap-and-secret-reader-role
+subjects:
+- kind: ServiceAccount
+  name: smb-csi-driver-controller-sa
+  namespace: openshift-cluster-csi-drivers

--- a/assets/overlays/samba/generated/standalone/controller.yaml
+++ b/assets/overlays/samba/generated/standalone/controller.yaml
@@ -1,0 +1,112 @@
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: smb-csi-driver-controller
+  namespace: openshift-cluster-csi-drivers
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: smb-csi-driver-controller
+  template:
+    metadata:
+      labels:
+        app: smb-csi-driver-controller
+    spec:
+      #hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet  # available values: Default, ClusterFirstWithHostNet, ClusterFirst
+      serviceAccountName: smb-csi-driver-controller-sa
+      nodeSelector:
+        kubernetes.io/os: linux
+      priorityClassName: system-cluster-critical
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
+      tolerations:
+        - key: "node-role.kubernetes.io/master"
+          operator: "Exists"
+          effect: "NoSchedule"
+        - key: "node-role.kubernetes.io/controlplane"
+          operator: "Exists"
+          effect: "NoSchedule"
+        - key: "node-role.kubernetes.io/control-plane"
+          operator: "Exists"
+          effect: "NoSchedule"
+      containers:
+        - name: csi-provisioner
+          image: ${PROVISIONER_IMAGE}
+          args:
+            - "-v=2"
+            - "--csi-address=$(ADDRESS)"
+            - "--leader-election"
+            - "--leader-election-namespace=openshift-cluster-csi-drivers"
+            - "--extra-create-metadata=true"
+          env:
+            - name: ADDRESS
+              value: /csi/csi.sock
+          volumeMounts:
+            - mountPath: /csi
+              name: socket-dir
+          resources:
+            limits:
+              cpu: 1
+              memory: 300Mi
+            requests:
+              cpu: 10m
+              memory: 20Mi
+        - name: liveness-probe
+          image: ${LIVENESS_PROBE_IMAGE}
+          args:
+            - --csi-address=/csi/csi.sock
+            - --probe-timeout=3s
+            - --health-port=29642
+            - --v=2
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /csi
+          resources:
+            limits:
+              cpu: 1
+              memory: 100Mi
+            requests:
+              cpu: 10m
+              memory: 20Mi
+        - name: smb
+          image: ${DRIVER_IMAGE}
+          imagePullPolicy: IfNotPresent
+          args:
+            - "--v=5"
+            - "--endpoint=$(CSI_ENDPOINT)"
+            - "--metrics-address=0.0.0.0:29644"
+          ports:
+            - containerPort: 29642
+              name: healthz
+              protocol: TCP
+            - containerPort: 29644
+              name: metrics
+              protocol: TCP
+          livenessProbe:
+            failureThreshold: 5
+            httpGet:
+              path: /healthz
+              port: healthz
+            initialDelaySeconds: 30
+            timeoutSeconds: 10
+            periodSeconds: 30
+          env:
+            - name: CSI_ENDPOINT
+              value: unix:///csi/csi.sock
+          securityContext:
+            privileged: true
+          volumeMounts:
+            - mountPath: /csi
+              name: socket-dir
+          resources:
+            limits:
+              memory: 200Mi
+            requests:
+              cpu: 10m
+              memory: 20Mi
+      volumes:
+        - name: socket-dir
+          emptyDir: {}

--- a/assets/overlays/samba/generated/standalone/controller_pdb.yaml
+++ b/assets/overlays/samba/generated/standalone/controller_pdb.yaml
@@ -1,0 +1,10 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: smb-csi-driver-controller-pdb
+  namespace: ${NAMESPACE}
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: smb-csi-driver-controller

--- a/assets/overlays/samba/generated/standalone/controller_privileged_binding.yaml
+++ b/assets/overlays/samba/generated/standalone/controller_privileged_binding.yaml
@@ -1,0 +1,14 @@
+# Allow the controller to run privileged pods
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: csi-smb-controller-privileged-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: smb-privileged-role
+subjects:
+- kind: ServiceAccount
+  name: smb-csi-driver-controller-sa
+  namespace: openshift-cluster-csi-drivers

--- a/assets/overlays/samba/generated/standalone/controller_sa.yaml
+++ b/assets/overlays/samba/generated/standalone/controller_sa.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: smb-csi-driver-controller-sa
+  namespace: ${NAMESPACE}

--- a/assets/overlays/samba/generated/standalone/csidriver.yaml
+++ b/assets/overlays/samba/generated/standalone/csidriver.yaml
@@ -1,0 +1,7 @@
+apiVersion: storage.k8s.io/v1
+kind: CSIDriver
+metadata:
+  name: smb.csi.k8s.io
+spec:
+  attachRequired: false
+  podInfoOnMount: true

--- a/assets/overlays/samba/generated/standalone/lease_leader_election_binding.yaml
+++ b/assets/overlays/samba/generated/standalone/lease_leader_election_binding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: smb-csi-driver-lease-leader-election
+  namespace: openshift-cluster-csi-drivers
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: smb-csi-driver-lease-leader-election
+subjects:
+- kind: ServiceAccount
+  name: smb-csi-driver-controller-sa
+  namespace: openshift-cluster-csi-drivers

--- a/assets/overlays/samba/generated/standalone/lease_leader_election_role.yaml
+++ b/assets/overlays/samba/generated/standalone/lease_leader_election_role.yaml
@@ -1,0 +1,17 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: smb-csi-driver-lease-leader-election
+  namespace: openshift-cluster-csi-drivers
+rules:
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - watch
+  - list
+  - delete
+  - update
+  - create

--- a/assets/overlays/samba/generated/standalone/main_provisioner_binding.yaml
+++ b/assets/overlays/samba/generated/standalone/main_provisioner_binding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: smb-csi-main-provisioner-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: openshift-csi-main-provisioner-role
+subjects:
+- kind: ServiceAccount
+  name: smb-csi-driver-controller-sa
+  namespace: openshift-cluster-csi-drivers

--- a/assets/overlays/samba/generated/standalone/manifests.yaml
+++ b/assets/overlays/samba/generated/standalone/manifests.yaml
@@ -1,0 +1,15 @@
+controllerStaticAssetNames:
+- controller.yaml
+- controller_pdb.yaml
+- controller_sa.yaml
+guestStaticAssetNames:
+- configmap_and_secret_reader_provisioner_binding.yaml
+- controller_privileged_binding.yaml
+- csidriver.yaml
+- lease_leader_election_binding.yaml
+- lease_leader_election_role.yaml
+- main_provisioner_binding.yaml
+- node.yaml
+- node_privileged_binding.yaml
+- node_sa.yaml
+- privileged_role.yaml

--- a/assets/overlays/samba/generated/standalone/node.yaml
+++ b/assets/overlays/samba/generated/standalone/node.yaml
@@ -1,0 +1,130 @@
+kind: DaemonSet
+apiVersion: apps/v1
+metadata:
+  name: csi-smb-node
+  namespace: openshift-cluster-csi-drivers
+spec:
+  updateStrategy:
+    rollingUpdate:
+      maxUnavailable: 1
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app: csi-smb-node
+  template:
+    metadata:
+      labels:
+        app: csi-smb-node
+    spec:
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet  # available values: Default, ClusterFirstWithHostNet, ClusterFirst
+      serviceAccountName: csi-smb-node-sa
+      nodeSelector:
+        kubernetes.io/os: linux
+      priorityClassName: system-node-critical
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
+      tolerations:
+        - operator: "Exists"
+      containers:
+        - name: liveness-probe
+          volumeMounts:
+            - mountPath: /csi
+              name: socket-dir
+          image: ${LIVENESS_PROBE_IMAGE}
+          args:
+            - --csi-address=/csi/csi.sock
+            - --probe-timeout=3s
+            - --health-port=29643
+            - --v=2
+          resources:
+            limits:
+              memory: 100Mi
+            requests:
+              cpu: 10m
+              memory: 20Mi
+        - name: node-driver-registrar
+          image: ${NODE_DRIVER_REGISTRAR_IMAGE}
+          args:
+            - --csi-address=$(ADDRESS)
+            - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
+            - --v=2
+          livenessProbe:
+            exec:
+              command:
+                - /csi-node-driver-registrar
+                - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
+                - --mode=kubelet-registration-probe
+            initialDelaySeconds: 30
+            timeoutSeconds: 15
+          env:
+            - name: ADDRESS
+              value: /csi/csi.sock
+            - name: DRIVER_REG_SOCK_PATH
+              value: /var/lib/kubelet/plugins/smb.csi.k8s.io/csi.sock
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /csi
+            - name: registration-dir
+              mountPath: /registration
+          resources:
+            limits:
+              memory: 100Mi
+            requests:
+              cpu: 10m
+              memory: 20Mi
+        - name: smb
+          image: ${DRIVER_IMAGE}
+          imagePullPolicy: IfNotPresent
+          args:
+            - "--v=5"
+            - "--endpoint=$(CSI_ENDPOINT)"
+            - "--nodeid=$(KUBE_NODE_NAME)"
+          ports:
+            - containerPort: 29643
+              name: healthz
+              protocol: TCP
+          livenessProbe:
+            failureThreshold: 5
+            httpGet:
+              path: /healthz
+              port: healthz
+            initialDelaySeconds: 30
+            timeoutSeconds: 10
+            periodSeconds: 30
+          env:
+            - name: CSI_ENDPOINT
+              value: unix:///csi/csi.sock
+            - name: KUBE_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: spec.nodeName
+          securityContext:
+            privileged: true
+          volumeMounts:
+            - mountPath: /csi
+              name: socket-dir
+            - mountPath: /var/lib/kubelet/
+              mountPropagation: Bidirectional
+              name: mountpoint-dir
+          resources:
+            limits:
+              memory: 200Mi
+            requests:
+              cpu: 10m
+              memory: 20Mi
+      volumes:
+        - hostPath:
+            path: /var/lib/kubelet/plugins/smb.csi.k8s.io
+            type: DirectoryOrCreate
+          name: socket-dir
+        - hostPath:
+            path: /var/lib/kubelet/
+            type: DirectoryOrCreate
+          name: mountpoint-dir
+        - hostPath:
+            path: /var/lib/kubelet/plugins_registry/
+            type: DirectoryOrCreate
+          name: registration-dir

--- a/assets/overlays/samba/generated/standalone/node_privileged_binding.yaml
+++ b/assets/overlays/samba/generated/standalone/node_privileged_binding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: csi-smb-node-privileged-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: smb-privileged-role
+subjects:
+- kind: ServiceAccount
+  name: csi-smb-node-sa
+  namespace: openshift-cluster-csi-drivers

--- a/assets/overlays/samba/generated/standalone/node_sa.yaml
+++ b/assets/overlays/samba/generated/standalone/node_sa.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: csi-smb-node-sa
+  namespace: openshift-cluster-csi-drivers

--- a/assets/overlays/samba/generated/standalone/privileged_role.yaml
+++ b/assets/overlays/samba/generated/standalone/privileged_role.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: smb-privileged-role
+rules:
+- apiGroups:
+  - security.openshift.io
+  resourceNames:
+  - privileged
+  resources:
+  - securitycontextconstraints
+  verbs:
+  - use

--- a/cmd/smb-csi-driver-operator/main.go
+++ b/cmd/smb-csi-driver-operator/main.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"context"
+	"os"
+
+	smb "github.com/openshift/csi-operator/pkg/driver/samba"
+	"github.com/openshift/library-go/pkg/controller/controllercmd"
+	"github.com/spf13/cobra"
+	"k8s.io/component-base/cli"
+
+	"github.com/openshift/csi-operator/pkg/operator"
+	"github.com/openshift/csi-operator/pkg/version"
+)
+
+func main() {
+	command := NewOperatorCommand()
+	code := cli.Run(command)
+	os.Exit(code)
+}
+
+func NewOperatorCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "smb-csi-driver-operator",
+		Short: "OpenShift CIFS/SMB CSI Driver Operator",
+		Run: func(cmd *cobra.Command, args []string) {
+			cmd.Help()
+			os.Exit(1)
+		},
+	}
+
+	ctrlCmd := controllercmd.NewControllerCommandConfig(
+		"smb-csi-driver-operator",
+		version.Get(),
+		runCSIDriverOperator,
+	).NewCommand()
+
+	ctrlCmd.Use = "start"
+	ctrlCmd.Short = "Start the CIFS/SMB CSI Driver Operator"
+
+	cmd.AddCommand(ctrlCmd)
+
+	return cmd
+}
+
+func runCSIDriverOperator(ctx context.Context, controllerConfig *controllercmd.ControllerContext) error {
+	opConfig := smb.GetSambaOperatorConfig()
+	return operator.RunOperator(ctx, controllerConfig, "", opConfig)
+}

--- a/pkg/driver/samba/samba.go
+++ b/pkg/driver/samba/samba.go
@@ -1,0 +1,45 @@
+package samba
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/openshift/csi-operator/assets"
+	"github.com/openshift/csi-operator/pkg/clients"
+	"github.com/openshift/csi-operator/pkg/driver/common/operator"
+	"github.com/openshift/csi-operator/pkg/generator"
+	"github.com/openshift/csi-operator/pkg/operator/config"
+
+	opv1 "github.com/openshift/api/operator/v1"
+	"k8s.io/klog/v2"
+)
+
+const (
+	generatedAssetBase = "overlays/samba/generated"
+)
+
+// GetSambaOperatorConfig returns runtime configuration of the CSI driver operator.
+func GetSambaOperatorConfig() *config.OperatorConfig {
+	return &config.OperatorConfig{
+		CSIDriverName:                   opv1.SambaCSIDriver,
+		UserAgent:                       "smb-csi-driver-operator",
+		AssetReader:                     assets.ReadFile,
+		AssetDir:                        generatedAssetBase,
+		OperatorControllerConfigBuilder: GetSambaOperatorControllerConfig,
+	}
+}
+
+// GetSambaOperatorControllerConfig returns second half of runtime configuration of the CSI driver operator,
+// after a client connection + cluster flavour are established.
+func GetSambaOperatorControllerConfig(ctx context.Context, flavour generator.ClusterFlavour, c *clients.Clients) (*config.OperatorControllerConfig, error) {
+	if flavour != generator.FlavourStandalone {
+		klog.Error(nil, "Flavour HyperShift is not supported!")
+		return nil, fmt.Errorf("Flavour HyperShift is not supported!")
+	}
+
+	cfg := operator.NewDefaultOperatorControllerConfig(flavour, c, "Samba")
+
+	go c.ConfigInformers.Start(ctx.Done())
+
+	return cfg, nil
+}


### PR DESCRIPTION
This PR implements the minimal set of go-files and yaml-assets to enable the command
```
./bin/csi-driver-smb-operator start --kubeconfig $KUBECONFIG --namespace openshift-cluster-csi-drivers
```
to install and run CIFS/Samba CSI driver:
```
$ oc get po -n openshift-cluster-csi-drivers
csi-smb-node-5hvqm                           3/3     Running   0          14s
csi-smb-node-f7mn2                           3/3     Running   0          14s
smb-csi-driver-controller-8657649897-dw47d   3/3     Running   0          16s
smb-csi-driver-controller-8657649897-fht45   3/3     Running   0          16s
```

@openshift/storage 