### PR TITLE
OCPBUGS-31306: Azure Disk: Add cluster-wide proxy in the driver container in the node

### DIFF
--- a/pkg/driver/azure-disk/azure_disk.go
+++ b/pkg/driver/azure-disk/azure_disk.go
@@ -196,7 +196,7 @@ func GetAzureDiskOperatorControllerConfig(ctx context.Context, flavour generator
 	cfg.DeploymentWatchedSecretNames = append(cfg.DeploymentWatchedSecretNames, cloudCredSecretName, metricsCertSecretName)
 
 	// Hooks for daemonset or on the node
-	cfg.AddDaemonSetHookBuilders(c, withCABundleDaemonSetHook)
+	cfg.AddDaemonSetHookBuilders(c, withClusterWideProxyDaemonSetHook, withCABundleDaemonSetHook)
 	cfg.DaemonSetWatchedSecretNames = append(cfg.DaemonSetWatchedSecretNames, cloudCredSecretName)
 	cfg.AddDaemonSetHook(withAzureStackHubDaemonSetHook(insideStackHub))
 
@@ -409,6 +409,12 @@ func withCABundleDaemonSetHook(c *clients.Clients) (csidrivernodeservicecontroll
 		c.GetConfigMapInformer(clients.CSIDriverNamespace).Informer(),
 	}
 	return hook, informers
+}
+
+// withClusterWideProxyHook adds the cluster-wide proxy config to the DaemonSet.
+func withClusterWideProxyDaemonSetHook(_ *clients.Clients) (csidrivernodeservicecontroller.DaemonSetHookFunc, []factory.Informer) {
+	hook := csidrivernodeservicecontroller.WithObservedProxyDaemonSetHook()
+	return hook, nil
 }
 
 func withAzureStackHubDaemonSetHook(runningOnAzureStackHub bool) csidrivernodeservicecontroller.DaemonSetHookFunc {


### PR DESCRIPTION
xref: https://github.com/openshift/azure-disk-csi-driver-operator/blob/f2d8d99d96e98c35fea10e28a9fc897112894b42/pkg/operator/starter.go#L202

CC @openshift/storage 