### PR TITLE
OCPBUGS-31044: Add cluster-wide proxy in the azure-file driver node container

### DIFF
--- a/pkg/driver/azure-file/azure_file.go
+++ b/pkg/driver/azure-file/azure_file.go
@@ -157,7 +157,7 @@ func GetAzureFileOperatorControllerConfig(ctx context.Context, flavour generator
 	cfg.DeploymentWatchedSecretNames = append(cfg.DeploymentWatchedSecretNames, cloudCredSecretName, metricsCertSecretName)
 
 	// Hooks for daemonset or on the node
-	cfg.AddDaemonSetHookBuilders(c, withCABundleDaemonSetHook)
+	cfg.AddDaemonSetHookBuilders(c, withClusterWideProxyDaemonSetHook, withCABundleDaemonSetHook)
 	cfg.DaemonSetWatchedSecretNames = append(cfg.DaemonSetWatchedSecretNames, cloudCredSecretName)
 
 	if flavour == generator.FlavourHyperShift {
@@ -273,4 +273,10 @@ func withCABundleDaemonSetHook(c *clients.Clients) (csidrivernodeservicecontroll
 		c.GetConfigMapInformer(clients.CSIDriverNamespace).Informer(),
 	}
 	return hook, informers
+}
+
+// withClusterWideProxyHook adds the cluster-wide proxy config to the DaemonSet.
+func withClusterWideProxyDaemonSetHook(_ *clients.Clients) (csidrivernodeservicecontroller.DaemonSetHookFunc, []factory.Informer) {
+	hook := csidrivernodeservicecontroller.WithObservedProxyDaemonSetHook()
+	return hook, nil
 }


### PR DESCRIPTION
### Add cluster-wide proxy in the azure-file driver container in the node

- Root cause
 The `config.openshift.io/inject-proxy: csi-driver` annotation exist in the daemonset but the proxy does not inject to the csi-driver container)
- Ref
https://github.com/openshift/azure-file-csi-driver-operator/blob/main/pkg/operator/starter.go#L171
