### PR TITLE
OCPBUGS-31044: add azure file ds hook for proxy config

### DIFF
--- a/pkg/driver/azure-file/azure_file.go
+++ b/pkg/driver/azure-file/azure_file.go
@@ -157,7 +157,7 @@ func GetAzureFileOperatorControllerConfig(ctx context.Context, flavour generator
 	cfg.DeploymentWatchedSecretNames = append(cfg.DeploymentWatchedSecretNames, cloudCredSecretName, metricsCertSecretName)
 
 	// Hooks for daemonset or on the node
-	cfg.AddDaemonSetHookBuilders(c, withCABundleDaemonSetHook)
+	cfg.AddDaemonSetHookBuilders(c, withClusterWideProxyDaemonSetHook, withCABundleDaemonSetHook)
 	cfg.DaemonSetWatchedSecretNames = append(cfg.DaemonSetWatchedSecretNames, cloudCredSecretName)
 
 	if flavour == generator.FlavourHyperShift {
@@ -273,4 +273,10 @@ func withCABundleDaemonSetHook(c *clients.Clients) (csidrivernodeservicecontroll
 		c.GetConfigMapInformer(clients.CSIDriverNamespace).Informer(),
 	}
 	return hook, informers
+}
+
+// withClusterWideProxyHook adds the cluster-wide proxy config to the DaemonSet.
+func withClusterWideProxyDaemonSetHook(_ *clients.Clients) (csidrivernodeservicecontroller.DaemonSetHookFunc, []factory.Informer) {
+	hook := csidrivernodeservicecontroller.WithObservedProxyDaemonSetHook()
+	return hook, nil
 }


### PR DESCRIPTION

## Check cluster wide proxy setting

```
$ oc get proxy/cluster -o yaml
apiVersion: config.openshift.io/v1
kind: Proxy
metadata:
  creationTimestamp: "2024-04-12T10:15:59Z"
  generation: 2
  name: cluster
  resourceVersion: "72866"
  uid: bfd11540-8c30-426e-ad38-65ebaccd1081
spec:
  httpProxy: http://XXXXX@YYYYY:3128
  httpsProxy: http://XXXXX@YYYYY:3128
  trustedCA:
    name: ""
status:
  httpProxy: http://XXXXX@13.91.32.252:3128
  httpsProxy: http://XXXXX@13.91.32.252:3128
  noProxy: .cluster.local,.svc,10.0.0.0/16,10.128.0.0/14,127.0.0.1,169.254.169.254,172.30.0.0/16,api-int.rbednar-01.qe.azure.devcluster.openshift.com,localhost
```
## Validate hook updated daemonset

```
$ oc -n openshift-cluster-csi-drivers get daemonset.apps/azure-file-csi-driver-node -o json | jq '.spec.template.spec.containers[0].env[3,4]'
{
  "name": "HTTPS_PROXY",
  "value": "http://XXXXX@YYYYY:3128"
}
{
  "name": "HTTP_PROXY",
  "value": "http://XXXXX@YYYYY:3128"
}
```

## Verify volume mounts in pod
```
$ oc -n default get pod/busybox-pvc-pod -o yaml
apiVersion: v1
kind: Pod
metadata:
  annotations:
    k8s.ovn.org/pod-networks: '{"default":{"ip_addresses":["10.129.2.12/23"],"mac_address":"0a:58:0a:81:02:0c","gateway_ips":["10.129.2.1"],"routes":[{"dest":"10.128.0.0/14","nextHop":"10.129.2.1"},{"dest":"172.30.0.0/16","nextHop":"10.129.2.1"},{"dest":"100.64.0.0/16","nextHop":"10.129.2.1"}],"ip_address":"10.129.2.12/23","gateway_ip":"10.129.2.1"}}'
    k8s.v1.cni.cncf.io/network-status: |-
      [{
          "name": "ovn-kubernetes",
          "interface": "eth0",
          "ips": [
              "10.129.2.12"
          ],
          "mac": "0a:58:0a:81:02:0c",
          "default": true,
          "dns": {}
      }]
  creationTimestamp: "2024-04-12T13:08:19Z"
  name: busybox-pvc-pod
  namespace: default
  resourceVersion: "95838"
  uid: a201f5bb-5052-48c4-bef5-b745099e86b0
spec:
  containers:
  - command:
    - sh
    image: busybox:latest
    imagePullPolicy: Always
    name: busybox
    resources: {}
    terminationMessagePath: /dev/termination-log
    terminationMessagePolicy: File
    volumeMounts:
    - mountPath: /mnt/pvc
      name: pvc-storage
    - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
      name: kube-api-access-jj447
      readOnly: true
  dnsPolicy: ClusterFirst
  enableServiceLinks: true
  imagePullSecrets:
  - name: default-dockercfg-56wdj
  nodeName: rbednar-01-sxdtw-worker-westus-pdp6r
  preemptionPolicy: PreemptLowerPriority
  priority: 0
  restartPolicy: Never
  schedulerName: default-scheduler
  securityContext: {}
  serviceAccount: default
  serviceAccountName: default
  terminationGracePeriodSeconds: 30
  tolerations:
  - effect: NoExecute
    key: node.kubernetes.io/not-ready
    operator: Exists
    tolerationSeconds: 300
  - effect: NoExecute
    key: node.kubernetes.io/unreachable
    operator: Exists
    tolerationSeconds: 300
  volumes:
  - name: pvc-storage
    persistentVolumeClaim:
      claimName: pvc-1
  - name: kube-api-access-jj447
    projected:
      defaultMode: 420
      sources:
      - serviceAccountToken:
          expirationSeconds: 3607
          path: token
      - configMap:
          items:
          - key: ca.crt
            path: ca.crt
          name: kube-root-ca.crt
      - downwardAPI:
          items:
          - fieldRef:
              apiVersion: v1
              fieldPath: metadata.namespace
            path: namespace
      - configMap:
          items:
          - key: service-ca.crt
            path: service-ca.crt
          name: openshift-service-ca.crt
status:
  conditions:
  - lastProbeTime: null
    lastTransitionTime: "2024-04-12T13:08:24Z"
    status: "False"
    type: PodReadyToStartContainers
  - lastProbeTime: null
    lastTransitionTime: "2024-04-12T13:08:19Z"
    reason: PodCompleted
    status: "True"
    type: Initialized
  - lastProbeTime: null
    lastTransitionTime: "2024-04-12T13:08:19Z"
    reason: PodCompleted
    status: "False"
    type: Ready
  - lastProbeTime: null
    lastTransitionTime: "2024-04-12T13:08:19Z"
    reason: PodCompleted
    status: "False"
    type: ContainersReady
  - lastProbeTime: null
    lastTransitionTime: "2024-04-12T13:08:19Z"
    status: "True"
    type: PodScheduled
  containerStatuses:
  - containerID: cri-o://dbcdedbe15eaff20f47b7a54c411b9b7a5ded81c6224a346f8089aef095ad922
    image: docker.io/library/busybox:latest
    imageID: docker.io/library/busybox@sha256:4be429a5fbb2e71ae7958bfa558bc637cf3a61baf40a708cb8fff532b39e52d0
    lastState: {}
    name: busybox
    ready: false
    restartCount: 0
    started: false
    state:
      terminated:
        containerID: cri-o://dbcdedbe15eaff20f47b7a54c411b9b7a5ded81c6224a346f8089aef095ad922
        exitCode: 0
        finishedAt: "2024-04-12T13:08:22Z"
        reason: Completed
        startedAt: "2024-04-12T13:08:22Z"
  hostIP: 10.0.1.6
  hostIPs:
  - ip: 10.0.1.6
  phase: Succeeded
  podIP: 10.129.2.12
  podIPs:
  - ip: 10.129.2.12
  qosClass: BestEffort
  startTime: "2024-04-12T13:08:19Z"
rbednar-mac:~ rbednar$ oc get pvc
NAME    STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS    VOLUMEATTRIBUTESCLASS   AGE
pvc-1   Bound    pvc-25b2da16-1e1b-40c8-b6c6-30815ddf1ebe   5Gi        RWO            azurefile-csi   <unset>                 4m28s

$ oc get pv
NAME                                       CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS   CLAIM           STORAGECLASS    VOLUMEATTRIBUTESCLASS   REASON   AGE
pvc-25b2da16-1e1b-40c8-b6c6-30815ddf1ebe   5Gi        RWO            Delete           Bound    default/pvc-1   azurefile-csi   <unset>                          4m32s
```