### PR TITLE
STOR-1726: Add OLM metadata for SMB operator

### DIFF
--- a/config/samba/bundle.Dockerfile
+++ b/config/samba/bundle.Dockerfile
@@ -1,0 +1,9 @@
+FROM scratch
+LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
+LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
+LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
+LABEL operators.operatorframework.io.bundle.package.v1=smb-csi-driver-operator
+LABEL operators.operatorframework.io.bundle.channels.v1=preview
+LABEL operators.operatorframework.io.bundle.channel.default.v1=preview
+COPY manifests/preview/smb-csi-driver-operator.clusterserviceversion.yaml /manifests/smb-csi-driver-operator.clusterserviceversion.yaml
+COPY metadata/annotations.yaml /metadata/annotations.yaml

--- a/config/samba/manifests/art.yaml
+++ b/config/samba/manifests/art.yaml
@@ -1,0 +1,18 @@
+updates:
+  - file: "preview/smb-csi-driver-operator.clusterserviceversion.yaml" # relative to this file
+    update_list:
+    # replace metadata.name value
+    - search: "smb-csi-driver-operator.v{MAJOR}.{MINOR}.0"
+      replace: "smb-csi-driver-operator.v{FULL_VER}"
+    # replace entire version line, otherwise would replace 4.3.0 anywhere
+    - search: "version: {MAJOR}.{MINOR}.0"
+      replace: "version: {FULL_VER}"
+    - search: 'olm.skipRange: ">=4.16.0-0 <{MAJOR}.{MINOR}.0"'
+      replace: 'olm.skipRange: ">=4.16.0-0 <{FULL_VER}"'
+    # Update links in the CSV description to exact OCP version
+    - search: 'https://docs.openshift.com/container-platform/latest/'
+      replace: 'https://docs.openshift.com/container-platform/{MAJOR}.{MINOR}/'
+  - file: "smb-csi-driver-operator.package.yaml"
+    update_list:
+    - search: "currentCSV: smb-csi-driver-operator.v{MAJOR}.{MINOR}.0"
+      replace: "currentCSV: smb-csi-driver-operator.{FULL_VER}"

--- a/config/samba/manifests/preview/image-references
+++ b/config/samba/manifests/preview/image-references
@@ -1,0 +1,29 @@
+---
+kind: ImageStream
+apiVersion: image.openshift.io/v1
+spec:
+  tags:
+  - name: smb-csi-driver-rhel9-operator
+    from:
+      kind: DockerImage
+      name: quay.io/openshift/origin-smb-csi-driver-operator:latest
+  - name: smb-csi-driver-container-rhel9
+    from:
+      kind: DockerImage
+      name: quay.io/openshift/origin-csi-driver-smb:latest
+  - name: csi-external-provisioner
+    from:
+      kind: DockerImage
+      name: quay.io/openshift/origin-csi-external-provisioner:latest
+  - name: csi-node-driver-registrar
+    from:
+      kind: DockerImage
+      name: quay.io/openshift/origin-csi-node-driver-registrar:latest
+  - name: csi-livenessprobe
+    from:
+      kind: DockerImage
+      name: quay.io/openshift/origin-csi-livenessprobe:latest
+  - name: kube-rbac-proxy
+    from:
+      kind: DockerImage
+      name: quay.io/openshift/origin-kube-rbac-proxy:latest

--- a/config/samba/manifests/preview/smb-csi-driver-operator.clusterserviceversion.yaml
+++ b/config/samba/manifests/preview/smb-csi-driver-operator.clusterserviceversion.yaml
@@ -1,0 +1,325 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  name: smb-csi-driver-operator.v4.16.0
+  namespace: placeholder
+  annotations:
+    categories: Storage
+    "operatorframework.io/suggested-namespace": openshift-cluster-csi-drivers
+    capabilities: Full Lifecycle
+    containerImage: quay.io/openshift/origin-smb-csi-driver-operator:latest
+    support: Red Hat
+    operators.openshift.io/infrastructure-features: '["csi"]'
+    repository: https://github.com/openshift/csi-operator
+    createdAt: "2021-07-14T00:00:00Z"
+    description: Install and configure CIFS/SMB CSI driver.
+    olm.skipRange: ">=4.15.0-0 <4.16.0"
+    features.operators.openshift.io/disconnected: "true"
+    features.operators.openshift.io/fips-compliant: "false"
+    features.operators.openshift.io/proxy-aware: "true"
+    features.operators.openshift.io/tls-profiles: "true"
+    features.operators.openshift.io/csi: "true"
+    features.operators.openshift.io/token-auth-aws: "false"
+    features.operators.openshift.io/token-auth-azure: "false"
+    features.operators.openshift.io/token-auth-gcp: "false"
+
+  labels:
+    operator-metering: "true"
+    "operatorframework.io/arch.amd64": supported
+    "operatorframework.io/arch.arm64": supported
+spec:
+  displayName: CIFS/SMB CSI Driver Operator
+  description: |
+    CIFS/SMB CSI Driver Operator provides Server Message Block (SMB) CSI Driver that enables you to create and mount CIFS/SMB PersistentVolumes.
+
+  icon:
+    - base64data: PHN2ZyBpZD0iTGF5ZXJfMSIgZGF0YS1uYW1lPSJMYXllciAxIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxOTIgMTQ1Ij48ZGVmcz48c3R5bGU+LmNscy0xe2ZpbGw6I2UwMDt9PC9zdHlsZT48L2RlZnM+PHRpdGxlPlJlZEhhdC1Mb2dvLUhhdC1Db2xvcjwvdGl0bGU+PHBhdGggZD0iTTE1Ny43Nyw2Mi42MWExNCwxNCwwLDAsMSwuMzEsMy40MmMwLDE0Ljg4LTE4LjEsMTcuNDYtMzAuNjEsMTcuNDZDNzguODMsODMuNDksNDIuNTMsNTMuMjYsNDIuNTMsNDRhNi40Myw2LjQzLDAsMCwxLC4yMi0xLjk0bC0zLjY2LDkuMDZhMTguNDUsMTguNDUsMCwwLDAtMS41MSw3LjMzYzAsMTguMTEsNDEsNDUuNDgsODcuNzQsNDUuNDgsMjAuNjksMCwzNi40My03Ljc2LDM2LjQzLTIxLjc3LDAtMS4wOCwwLTEuOTQtMS43My0xMC4xM1oiLz48cGF0aCBjbGFzcz0iY2xzLTEiIGQ9Ik0xMjcuNDcsODMuNDljMTIuNTEsMCwzMC42MS0yLjU4LDMwLjYxLTE3LjQ2YTE0LDE0LDAsMCwwLS4zMS0zLjQybC03LjQ1LTMyLjM2Yy0xLjcyLTcuMTItMy4yMy0xMC4zNS0xNS43My0xNi42QzEyNC44OSw4LjY5LDEwMy43Ni41LDk3LjUxLjUsOTEuNjkuNSw5MCw4LDgzLjA2LDhjLTYuNjgsMC0xMS42NC01LjYtMTcuODktNS42LTYsMC05LjkxLDQuMDktMTIuOTMsMTIuNSwwLDAtOC40MSwyMy43Mi05LjQ5LDI3LjE2QTYuNDMsNi40MywwLDAsMCw0Mi41Myw0NGMwLDkuMjIsMzYuMywzOS40NSw4NC45NCwzOS40NU0xNjAsNzIuMDdjMS43Myw4LjE5LDEuNzMsOS4wNSwxLjczLDEwLjEzLDAsMTQtMTUuNzQsMjEuNzctMzYuNDMsMjEuNzdDNzguNTQsMTA0LDM3LjU4LDc2LjYsMzcuNTgsNTguNDlhMTguNDUsMTguNDUsMCwwLDEsMS41MS03LjMzQzIyLjI3LDUyLC41LDU1LC41LDc0LjIyYzAsMzEuNDgsNzQuNTksNzAuMjgsMTMzLjY1LDcwLjI4LDQ1LjI4LDAsNTYuNy0yMC40OCw1Ni43LTM2LjY1LDAtMTIuNzItMTEtMjcuMTYtMzAuODMtMzUuNzgiLz48L3N2Zz4=
+      mediatype: image/svg+xml
+  keywords:
+    - storage
+    - smb
+    - cifs
+  links:
+    - name: Documentation
+      url: https://github.com/openshift/csi-operator
+    - name: Source Repository
+      url: https://github.com/openshift/csi-operator
+  version: 4.16.0
+  maturity: preview
+  maintainers:
+    - email: aos-storage-staff@redhat.com
+      name: Red Hat
+  minKubeVersion: 1.29.0
+  provider:
+    name: Red Hat
+  labels:
+    alm-owner-metering: smb-csi-driver-operator
+    alm-status-descriptors: smb-csi-driver-operator.v4.16.0
+  selector:
+    matchLabels:
+      alm-owner-metering: smb-csi-driver-operator
+  installModes:
+  - type: OwnNamespace
+    supported: false
+  - type: SingleNamespace
+    supported: false
+  - type: MultiNamespace
+    supported: false
+  - type: AllNamespaces
+    supported: true
+  install:
+    strategy: deployment
+    spec:
+      permissions:
+        - rules:
+          - apiGroups:
+            - ''
+            resources:
+            - pods
+            - services
+            - endpoints
+            - events
+            - configmaps
+            - secrets
+            - serviceaccounts
+            verbs:
+            - '*'
+          - apiGroups:
+            - apps
+            resources:
+            - deployments
+            - daemonsets
+            - replicasets
+            verbs:
+            - '*'
+          - apiGroups:
+            - monitoring.coreos.com
+            resources:
+            - servicemonitors
+            verbs:
+            - '*'
+          - apiGroups:
+            - policy
+            resources:
+            - poddisruptionbudgets
+            verbs:
+            - get
+            - list
+            - watch
+            - create
+            - update
+            - patch
+            - delete
+          - apiGroups:
+            - coordination.k8s.io
+            resources:
+            - leases
+            verbs:
+            - '*'
+          serviceAccountName: smb-csi-driver-operator
+      clusterPermissions:
+        - rules:
+          - apiGroups:
+            - security.openshift.io
+            resourceNames:
+            - privileged
+            resources:
+            - securitycontextconstraints
+            verbs:
+            - use
+          - apiGroups:
+            - operator.openshift.io
+            resources:
+            - clustercsidrivers
+            verbs:
+            - get
+            - list
+            - watch
+            # The Config Observer controller updates the CR's spec
+            - update
+            - patch
+          - apiGroups:
+            - operator.openshift.io
+            resources:
+            - clustercsidrivers/status
+            verbs:
+            - get
+            - list
+            - watch
+            - update
+            - patch
+          - apiGroups:
+            - ''
+            resourceNames:
+            - extension-apiserver-authentication
+            resources:
+            - configmaps
+            verbs:
+            - '*'
+          - apiGroups:
+            - rbac.authorization.k8s.io
+            resources:
+            - clusterroles
+            - clusterrolebindings
+            - roles
+            - rolebindings
+            verbs:
+            - watch
+            - list
+            - get
+            - create
+            - delete
+            - patch
+            - update
+          - apiGroups:
+            - ''
+            resources:
+            - secrets
+            verbs:
+            - get
+            - list
+            - watch
+          - apiGroups:
+            - ''
+            resources:
+            - persistentvolumes
+            verbs:
+            - create
+            - delete
+            - list
+            - get
+            - watch
+            - update
+            - patch
+          - apiGroups:
+            - ''
+            resources:
+            - persistentvolumeclaims
+            verbs:
+            - get
+            - list
+            - watch
+            - update
+          - apiGroups:
+            - storage.k8s.io
+            resources:
+            - storageclasses
+            - csinodes
+            verbs:
+            - create
+            - get
+            - list
+            - watch
+            - update
+            - delete
+          - apiGroups:
+            - '*'
+            resources:
+            - events
+            verbs:
+            - get
+            - patch
+            - create
+            - list
+            - watch
+            - update
+            - delete
+          - apiGroups:
+            - storage.k8s.io
+            resources:
+            - csidrivers
+            verbs:
+            - create
+            - get
+            - list
+            - watch
+            - update
+            - delete
+          - apiGroups:
+            - config.openshift.io
+            resources:
+            - infrastructures
+            - proxies
+            - apiservers
+            verbs:
+            - get
+            - list
+            - watch
+          - apiGroups:
+            - authentication.k8s.io
+            resources:
+            - tokenreviews
+            verbs:
+            - create
+          - apiGroups:
+            - ""
+            resources:
+            - nodes
+            verbs:
+            - get
+            - list
+            - watch
+          serviceAccountName: smb-csi-driver-operator
+      deployments:
+        - name: smb-csi-driver-operator
+          spec:
+            replicas: 1
+            selector:
+              matchLabels:
+                app: smb-csi-driver-operator
+            template:
+              metadata:
+                annotations:
+                  target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+                labels:
+                  app: smb-csi-driver-operator
+              spec:
+                serviceAccountName: smb-csi-driver-operator
+                containers:
+                - name: smb-csi-driver-operator
+                  image: quay.io/openshift/origin-smb-csi-driver-operator:latest
+                  imagePullPolicy: IfNotPresent
+                  args:
+                    - "start"
+                    - "-v=2"
+                  env:
+                    - name: POD_NAME
+                      valueFrom:
+                        fieldRef:
+                          fieldPath: metadata.name
+                    - name: DRIVER_IMAGE
+                      value: quay.io/openshift/origin-csi-driver-smb:latest
+                    - name: PROVISIONER_IMAGE
+                      value: quay.io/openshift/origin-csi-external-provisioner:latest
+                    - name: NODE_DRIVER_REGISTRAR_IMAGE
+                      value: quay.io/openshift/origin-csi-node-driver-registrar:latest
+                    - name: LIVENESS_PROBE_IMAGE
+                      value: quay.io/openshift/origin-csi-livenessprobe:latest
+                    - name: OPERATOR_NAME
+                      value: smb-csi-driver-operator
+                    - name: KUBE_RBAC_PROXY_IMAGE
+                      value: quay.io/openshift/origin-kube-rbac-proxy:latest
+                  resources:
+                    requests:
+                      memory: 50Mi
+                      cpu: 10m
+                priorityClassName: system-cluster-critical
+                # Strongly prefer a master node, but don't require it.
+                # We want the same Deployment to work on hypershift,
+                # without any master nodes.
+                affinity:
+                  nodeAffinity:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                    - weight: 100
+                      preference:
+                        matchExpressions:
+                        - key: node-role.kubernetes.io/master
+                          operator: In
+                          values:
+                          - ""
+                tolerations:
+                  - key: CriticalAddonsOnly
+                    operator: Exists
+                  - key: node-role.kubernetes.io/master
+                    operator: Exists
+                    effect: "NoSchedule"

--- a/config/samba/manifests/smb-csi-driver-operator.package.yaml
+++ b/config/samba/manifests/smb-csi-driver-operator.package.yaml
@@ -1,0 +1,4 @@
+packageName: smb-csi-driver-operator
+channels:
+- name: preview
+  currentCSV: smb-csi-driver-operator.v4.16.0

--- a/config/samba/metadata/annotations.yaml
+++ b/config/samba/metadata/annotations.yaml
@@ -1,0 +1,8 @@
+annotations:
+  operators.operatorframework.io.bundle.channel.default.v1: preview
+  operators.operatorframework.io.bundle.channels.v1: preview
+  operators.operatorframework.io.bundle.manifests.v1: manifests/
+  operators.operatorframework.io.bundle.mediatype.v1: registry+v1
+  operators.operatorframework.io.bundle.metadata.v1: metadata/
+  operators.operatorframework.io.bundle.package.v1: smb-csi-driver-operator
+

--- a/hack/.gitignore
+++ b/hack/.gitignore
@@ -1,0 +1,1 @@
+opm-bundle

--- a/hack/create-samba-bundle
+++ b/hack/create-samba-bundle
@@ -1,0 +1,72 @@
+#!/bin/sh
+
+# A hackish script to build bundle and index images for given driver + operator images.
+# The output is available in opm-bundle directory.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+if [ "$#" -ne "4" ]; then
+    echo "Usage: $0 <input_driver_image> <input_operator_image> <output_bundle_image> <output_index_image>"
+    exit 1
+fi
+
+DEFAULT_TOOL_BIN=$(which podman 2>/dev/null || which docker 2>/dev/null)
+if [ "$? " -ne "0" ]; then
+	echo "Error: No suitable container manipulation tool (podman, docker) found in \$PATH" 1>&2
+	exit 1
+fi
+TOOL_BIN=${TOOL_BIN:-$DEFAULT_TOOL_BIN}
+
+TOOL_NAME=$(basename $TOOL_BIN)
+DRIVER_IMAGE=$1
+OPERATOR_IMAGE=$2
+BUNDLE_IMAGE=$3
+INDEX_IMAGE=$4
+
+# Prepare output dir
+mkdir -p opm-bundle
+pushd opm-bundle
+cp -r -v ../../config/samba/* .
+
+MANIFEST=manifests/preview/smb-csi-driver-operator.clusterserviceversion.yaml
+
+# Replace images in the manifest - error prone, needs to be in sync with image-references.
+sed -i.bak -e "s~quay.io/openshift/origin-smb-csi-driver-operator:latest~$OPERATOR_IMAGE~" \
+  -e "s~quay.io/openshift/origin-csi-driver-smb:latest~$DRIVER_IMAGE~" \
+  $MANIFEST
+rm $MANIFEST.bak
+
+# Build the bundle and push it
+$TOOL_BIN build -t $BUNDLE_IMAGE -f bundle.Dockerfile .
+$TOOL_BIN push $BUNDLE_IMAGE
+
+# Build the index image and push it
+opm index add --bundles $BUNDLE_IMAGE --tag $INDEX_IMAGE --container-tool $TOOL_NAME
+$TOOL_BIN push $INDEX_IMAGE
+
+
+echo
+echo --------------------
+echo "Index image created"
+echo "Copy following snipped to apply it to your cluster"
+echo
+
+# Show oc apply -f - <<EOF to copy-paste into shell
+cat <<REAL_EOF
+oc apply -f - <<EOF
+apiVersion: operators.coreos.com/v1alpha1
+kind: CatalogSource
+metadata:
+  name: smb
+  namespace: openshift-marketplace
+spec:
+  sourceType: grpc
+  image: $INDEX_IMAGE
+EOF
+REAL_EOF
+
+echo
+
+popd


### PR DESCRIPTION
All metadata + scripts for the SMB CSI driver operator. This is copy + paste of AWS EFS metadata, I only had to add permissions to create/modify PodDisruptionBudgets that we don't use in EFS.

Tested using:
1. build the operator image + push it somewhere (`quay.io/jsafrane/scratch:smbo1`)
2. (using the upstream driver image, `registry.k8s.io/sig-storage/smbplugin:v1.14.0`):

```
./create-samba-bundle registry.k8s.io/sig-storage/smbplugin:v1.14.0 quay.io/jsafrane/scratch:smbo1 quay.io/jsafrane/scratch:bundle3  quay.io/jsafrane/scratch:index3
```
It will build the bundle + index image, push them to quay and generate CatalogSource on stdout.

3. Apply the generated CatalogSource:
```
oc apply -f - <<EOF
apiVersion: operators.coreos.com/v1alpha1
kind: CatalogSource
metadata:
  name: smb
  namespace: openshift-marketplace
spec:
  sourceType: grpc
  image: quay.io/jsafrane/scratch:index3
EOF
```

4. Install the operator in OLM console.

~WIP: audit the permissions~