### PR TITLE
STOR-1726: Simple rename of objects in `assets/overlays/samba/generated/standalone/`

### DIFF
--- a/assets/overlays/samba/generated/standalone/node.yaml
+++ b/assets/overlays/samba/generated/standalone/node.yaml
@@ -1,7 +1,7 @@
 kind: DaemonSet
 apiVersion: apps/v1
 metadata:
-  name: csi-smb-node
+  name: smb-csi-driver-node
   namespace: openshift-cluster-csi-drivers
 spec:
   updateStrategy:
@@ -10,15 +10,15 @@ spec:
     type: RollingUpdate
   selector:
     matchLabels:
-      app: csi-smb-node
+      app: smb-csi-driver-node
   template:
     metadata:
       labels:
-        app: csi-smb-node
+        app: smb-csi-driver-node
     spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet  # available values: Default, ClusterFirstWithHostNet, ClusterFirst
-      serviceAccountName: csi-smb-node-sa
+      serviceAccountName: smb-csi-driver-node-sa
       nodeSelector:
         kubernetes.io/os: linux
       priorityClassName: system-node-critical

--- a/assets/overlays/samba/generated/standalone/node_privileged_binding.yaml
+++ b/assets/overlays/samba/generated/standalone/node_privileged_binding.yaml
@@ -1,12 +1,12 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: csi-smb-node-privileged-binding
+  name: smb-node-privileged-binding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: smb-privileged-role
 subjects:
 - kind: ServiceAccount
-  name: csi-smb-node-sa
+  name: smb-csi-driver-node-sa
   namespace: openshift-cluster-csi-drivers

--- a/assets/overlays/samba/generated/standalone/node_sa.yaml
+++ b/assets/overlays/samba/generated/standalone/node_sa.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: csi-smb-node-sa
+  name: smb-csi-driver-node-sa
   namespace: openshift-cluster-csi-drivers


### PR DESCRIPTION
`s/csi-smb-node-sa/smb-csi-driver-node` everywhere to be consistent with other driver's namings.