### PR TITLE
STOR-1726: Delete static resources when ClusterCSIDriver is removed

### DIFF
--- a/pkg/driver/aws-ebs/aws_ebs.go
+++ b/pkg/driver/aws-ebs/aws_ebs.go
@@ -127,6 +127,7 @@ func GetAWSEBSOperatorConfig() *config.OperatorConfig {
 		AssetReader:                     assets.ReadFile,
 		AssetDir:                        generatedAssetBase,
 		OperatorControllerConfigBuilder: GetAWSEBSOperatorControllerConfig,
+		Removable:                       false,
 	}
 }
 

--- a/pkg/driver/azure-disk/azure_disk.go
+++ b/pkg/driver/azure-disk/azure_disk.go
@@ -147,6 +147,7 @@ func GetAzureDiskOperatorConfig() *config.OperatorConfig {
 		AssetDir:                        generatedAssetBase,
 		CloudConfigNamespace:            openshiftDefaultCloudConfigNamespace,
 		OperatorControllerConfigBuilder: GetAzureDiskOperatorControllerConfig,
+		Removable:                       false,
 	}
 }
 

--- a/pkg/driver/azure-file/azure_file.go
+++ b/pkg/driver/azure-file/azure_file.go
@@ -120,6 +120,7 @@ func GetAzureFileOperatorConfig() *config.OperatorConfig {
 		AssetDir:                        generatedAssetBase,
 		CloudConfigNamespace:            openshiftDefaultCloudConfigNamespace,
 		OperatorControllerConfigBuilder: GetAzureFileOperatorControllerConfig,
+		Removable:                       false,
 	}
 }
 

--- a/pkg/driver/samba/samba.go
+++ b/pkg/driver/samba/samba.go
@@ -26,6 +26,7 @@ func GetSambaOperatorConfig() *config.OperatorConfig {
 		AssetReader:                     assets.ReadFile,
 		AssetDir:                        generatedAssetBase,
 		OperatorControllerConfigBuilder: GetSambaOperatorControllerConfig,
+		Removable:                       true,
 	}
 }
 

--- a/pkg/operator/config/config.go
+++ b/pkg/operator/config/config.go
@@ -28,6 +28,8 @@ type OperatorConfig struct {
 	OperatorControllerConfigBuilder func(context.Context, generator.ClusterFlavour, *clients.Clients) (*OperatorControllerConfig, error)
 	// CloudConfigNamespace defines namespace in which cloud-configuration exists
 	CloudConfigNamespace string
+	// Removable should be true if the operator and its operand can be removed
+	Removable bool
 }
 
 // OperatorControllerConfig is configuration of controllers that are used to deploy CSI drivers.

--- a/pkg/operator/starter_test.go
+++ b/pkg/operator/starter_test.go
@@ -1,0 +1,73 @@
+package operator
+
+import (
+	"testing"
+
+	opv1 "github.com/openshift/api/operator/v1"
+	"github.com/openshift/library-go/pkg/operator/v1helpers"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type FakeOperator struct {
+	metav1.ObjectMeta
+	Spec   opv1.OperatorSpec
+	Status opv1.OperatorStatus
+}
+
+func TestGetOperatorSyncState(t *testing.T) {
+	deletionTimestamp := metav1.Now()
+	testProvider := "test-driver.csi.k8s.io"
+
+	cases := []struct {
+		name          string
+		operator      *FakeOperator
+		expectedState opv1.ManagementState
+	}{
+		{
+			name: "should return managed when the operator state is managed",
+			operator: &FakeOperator{
+				ObjectMeta: metav1.ObjectMeta{Name: testProvider},
+				Spec:       opv1.OperatorSpec{ManagementState: opv1.Managed},
+			},
+
+			expectedState: opv1.Managed,
+		},
+		{
+			name: "should return unmanaged when the operator state is unmanaged",
+			operator: &FakeOperator{
+				ObjectMeta: metav1.ObjectMeta{Name: testProvider},
+				Spec:       opv1.OperatorSpec{ManagementState: opv1.Unmanaged},
+			},
+			expectedState: opv1.Unmanaged,
+		},
+		{
+			name: "should return removed when the operator state is removed",
+			operator: &FakeOperator{
+				ObjectMeta: metav1.ObjectMeta{Name: testProvider},
+				Spec:       opv1.OperatorSpec{ManagementState: opv1.Removed},
+			},
+			expectedState: opv1.Removed,
+		},
+		{
+			name: "should return removed when the deletion timestamp is set",
+			operator: &FakeOperator{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              testProvider,
+					DeletionTimestamp: &deletionTimestamp,
+				},
+				Spec: opv1.OperatorSpec{ManagementState: opv1.Managed},
+			},
+			expectedState: opv1.Removed,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			operatorClient := v1helpers.NewFakeOperatorClientWithObjectMeta(&tc.operator.ObjectMeta, &tc.operator.Spec, &tc.operator.Status, nil)
+			state := getOperatorSyncState(operatorClient)
+			if state != tc.expectedState {
+				t.Fatalf("expected sync state to be %v, got %v", tc.expectedState, state)
+			}
+		})
+	}
+}

--- a/pkg/operator/starter_test.go
+++ b/pkg/operator/starter_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	opv1 "github.com/openshift/api/operator/v1"
+	"github.com/openshift/library-go/pkg/operator/management"
 	"github.com/openshift/library-go/pkg/operator/v1helpers"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -21,6 +22,7 @@ func TestGetOperatorSyncState(t *testing.T) {
 	cases := []struct {
 		name          string
 		operator      *FakeOperator
+		removable     bool
 		expectedState opv1.ManagementState
 	}{
 		{
@@ -29,7 +31,7 @@ func TestGetOperatorSyncState(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Name: testProvider},
 				Spec:       opv1.OperatorSpec{ManagementState: opv1.Managed},
 			},
-
+			removable:     true,
 			expectedState: opv1.Managed,
 		},
 		{
@@ -38,18 +40,20 @@ func TestGetOperatorSyncState(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Name: testProvider},
 				Spec:       opv1.OperatorSpec{ManagementState: opv1.Unmanaged},
 			},
+			removable:     true,
 			expectedState: opv1.Unmanaged,
 		},
 		{
-			name: "should return removed when the operator state is removed",
+			name: "should return unmanaged when the operator state is removed",
 			operator: &FakeOperator{
 				ObjectMeta: metav1.ObjectMeta{Name: testProvider},
 				Spec:       opv1.OperatorSpec{ManagementState: opv1.Removed},
 			},
-			expectedState: opv1.Removed,
+			removable:     true,
+			expectedState: opv1.Unmanaged,
 		},
 		{
-			name: "should return removed when the deletion timestamp is set",
+			name: "should return removed when the deletion timestamp is set and operator is removable",
 			operator: &FakeOperator{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:              testProvider,
@@ -57,13 +61,31 @@ func TestGetOperatorSyncState(t *testing.T) {
 				},
 				Spec: opv1.OperatorSpec{ManagementState: opv1.Managed},
 			},
+			removable:     true,
 			expectedState: opv1.Removed,
+		},
+		{
+			name: "should return managed when the deletion timestamp is set and operator is not removable",
+			operator: &FakeOperator{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              testProvider,
+					DeletionTimestamp: &deletionTimestamp,
+				},
+				Spec: opv1.OperatorSpec{ManagementState: opv1.Managed},
+			},
+			removable:     false,
+			expectedState: opv1.Managed,
 		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			operatorClient := v1helpers.NewFakeOperatorClientWithObjectMeta(&tc.operator.ObjectMeta, &tc.operator.Spec, &tc.operator.Status, nil)
+			if tc.removable {
+				management.SetOperatorRemovable()
+			} else {
+				management.SetOperatorNotRemovable()
+			}
 			state := getOperatorSyncState(operatorClient)
 			if state != tc.expectedState {
 				t.Fatalf("expected sync state to be %v, got %v", tc.expectedState, state)


### PR DESCRIPTION
This PR allows the smb-csi-driver-operator to clean up its static resources when the ClusterCSIDriver is removed.

The approach is the same as https://github.com/openshift/secrets-store-csi-driver-operator/pull/8 (see also: [secrets-store enhancement](https://github.com/openshift/enhancements/blob/master/enhancements/storage/csi-secrets-store.md#uninstalling-csi-driver)). This should allow us to follow a standard approach when moving other OLM operators to csi-operator just by setting `Removable: true` in the `OperatorConfig`.

Operators which are _not_ removable will not define conditional functions, and will behave the same as before with the static resources controller.

Simple manual test:

1) Create ClusterCSIDriver and wait for operator to create static resources:
```
$ oc apply -f - <<EOF
apiVersion: operator.openshift.io/v1
kind: ClusterCSIDriver
metadata:
  name: smb.csi.k8s.io
spec:
  managementState: Managed
EOF
$ oc get pods -n openshift-cluster-csi-drivers
NAME                                             READY   STATUS    RESTARTS   AGE
aws-ebs-csi-driver-controller-7b6cdd676b-745sm   11/11   Running   0          5h55m
aws-ebs-csi-driver-controller-7b6cdd676b-rsnpk   11/11   Running   0          5h55m
aws-ebs-csi-driver-node-5q94r                    3/3     Running   0          5h52m
aws-ebs-csi-driver-node-chs2m                    3/3     Running   0          5h49m
aws-ebs-csi-driver-node-kz24v                    3/3     Running   0          5h55m
aws-ebs-csi-driver-node-q9dj6                    3/3     Running   0          5h55m
aws-ebs-csi-driver-node-qt29w                    3/3     Running   0          5h48m
aws-ebs-csi-driver-node-x2wb6                    3/3     Running   0          5h55m
aws-ebs-csi-driver-operator-5bf867fdd6-27x9f     1/1     Running   0          5h55m
smb-csi-driver-controller-84546d6b8c-cdb75       3/3     Running   0          25s
smb-csi-driver-controller-84546d6b8c-cmgln       3/3     Running   0          25s
smb-csi-driver-node-5dn4m                        3/3     Running   0          23s
smb-csi-driver-node-fg2sc                        3/3     Running   0          23s
smb-csi-driver-node-kb4h6                        3/3     Running   0          23s
smb-csi-driver-node-llnsv                        3/3     Running   0          23s
smb-csi-driver-node-qhfkw                        3/3     Running   0          23s
smb-csi-driver-node-s5c2p                        3/3     Running   0          23s
```

2) Delete ClusterCSIDriver and wait for operator to delete static resources:
```
$ oc delete clustercsidriver smb.csi.k8s.io
clustercsidriver.operator.openshift.io "smb.csi.k8s.io" deleted
$ oc get pods -n openshift-cluster-csi-drivers
NAME                                             READY   STATUS    RESTARTS   AGE
aws-ebs-csi-driver-controller-7b6cdd676b-745sm   11/11   Running   0          5h55m
aws-ebs-csi-driver-controller-7b6cdd676b-rsnpk   11/11   Running   0          5h55m
aws-ebs-csi-driver-node-5q94r                    3/3     Running   0          5h52m
aws-ebs-csi-driver-node-chs2m                    3/3     Running   0          5h49m
aws-ebs-csi-driver-node-kz24v                    3/3     Running   0          5h55m
aws-ebs-csi-driver-node-q9dj6                    3/3     Running   0          5h55m
aws-ebs-csi-driver-node-qt29w                    3/3     Running   0          5h49m
aws-ebs-csi-driver-node-x2wb6                    3/3     Running   0          5h55m
aws-ebs-csi-driver-operator-5bf867fdd6-27x9f     1/1     Running   0          5h56m
```

/cc @openshift/storage @jsafrane @mpatlasov
