### PR TITLE
OCPBUGS-32785: add token audience for Azure File

### DIFF
--- a/assets/overlays/azure-file/base/csidriver.yaml
+++ b/assets/overlays/azure-file/base/csidriver.yaml
@@ -14,3 +14,5 @@ spec:
   volumeLifecycleModes:
     - Persistent
     - Ephemeral
+  tokenRequests:
+    - audience: api://AzureADTokenExchange

--- a/assets/overlays/azure-file/generated/hypershift/csidriver.yaml
+++ b/assets/overlays/azure-file/generated/hypershift/csidriver.yaml
@@ -16,6 +16,8 @@ spec:
   attachRequired: false
   fsGroupPolicy: None
   podInfoOnMount: true
+  tokenRequests:
+  - audience: api://AzureADTokenExchange
   volumeLifecycleModes:
   - Persistent
   - Ephemeral

--- a/assets/overlays/azure-file/generated/standalone/csidriver.yaml
+++ b/assets/overlays/azure-file/generated/standalone/csidriver.yaml
@@ -16,6 +16,8 @@ spec:
   attachRequired: false
   fsGroupPolicy: None
   podInfoOnMount: true
+  tokenRequests:
+  - audience: api://AzureADTokenExchange
   volumeLifecycleModes:
   - Persistent
   - Ephemeral


### PR DESCRIPTION
Without token audience static PVs fail to mount in workload identity clusters. This has been solved in AKS by adding token audience to CSIDriver:

https://github.com/kubernetes-sigs/azurefile-csi-driver/issues/1763

This API went GA in k/k 1.22:
https://github.com/kubernetes/kubernetes/pull/103001


## Testing static PV mount

1) Create a workload identity cluster with Flexy

2) Create a file share in Azure manually

3) Create static PV referencing the created file share

```
apiVersion: v1
kind: PersistentVolume
metadata:
  annotations:
    pv.kubernetes.io/provisioned-by: file.csi.azure.com
  name: pv-azurefile
spec:
  capacity:
    storage: 10Gi
  accessModes:
    - ReadWriteMany
  persistentVolumeReclaimPolicy: Retain
  storageClassName: azurefile-csi
  mountOptions:
    - dir_mode=0777
    - file_mode=0777
    - uid=0
    - gid=0
    - mfsymlinks
    - cache=strict
    - nosharesock
  csi:
    driver: file.csi.azure.com
    volumeHandle: unique_volume_id
    volumeAttributes:
      storageaccount: clusterqlbqi
      shareName: rbednartest
```

4) Create StatefulSet that mounts static PV

```
apiVersion: apps/v1
kind: StatefulSet
metadata:
  name: statefulset-azurefile
  namespace: default
  labels:
    app: nginx
spec:
  podManagementPolicy: Parallel 
  serviceName: statefulset-azurefile
  replicas: 1
  template:
    metadata:
      labels:
        app: nginx
    spec:
      nodeSelector:
        "kubernetes.io/os": linux
      containers:
        - name: statefulset-azurefile
          image: mcr.microsoft.com/oss/nginx/nginx:1.19.5
          command:
            - "/bin/bash"
            - "-c"
            - set -euo pipefail; while true; do echo $(date) >> /mnt/azurefile/outfile; sleep 1; done
          volumeMounts:
            - name: persistent-storage
              mountPath: /mnt/azurefile
  updateStrategy:
    type: RollingUpdate
  selector:
    matchLabels:
      app: nginx
  volumeClaimTemplates:
    - metadata:
        name: persistent-storage
      spec:
        storageClassName: azurefile-csi
        accessModes: ["ReadWriteMany"]
        resources:
          requests:
            storage: 10Gi
```

5) Check that `NodePublishVolume` succeeds in node driver logs

```
I0503 10:10:56.425776 1 utils.go:77] GRPC call: /csi.v1.Node/NodeStageVolume

I0503 10:10:56.425809 1 utils.go:78] GRPC request: {"staging_target_path":"/var/lib/kubelet/plugins/kubernetes.io/csi/file.csi.azure.com/e53ce882ae47f30739a21cc04a37ac4a14a19894e1551e7d78909e7e1d52d167/globalmount","volume_capability":{"AccessType":{"Mount":{"mount_flags":["dir_mode=0777","file_mode=0777","uid=0","gid=0","mfsymlinks","cache=strict","nosharesock"]}},"access_mode":{"mode":5}},"volume_context":{"shareName":"rbednartest","storageaccount":"clusterqlbqi"},"volume_id":"unique_volume_id"}

W0503 10:10:56.426053 1 azurefile.go:729] parsing volumeID(unique_volume_id) return with error: error parsing volume id: "unique_volume_id", should at least contain two #

W0503 10:10:56.439976 1 azurefile.go:826] GetStorageAccountFromSecret(azure-storage-account-clusterqlbqi-secret, default) failed with error: could not get secret(azure-storage-account-clusterqlbqi-secret): secrets "azure-storage-account-clusterqlbqi-secret" is forbidden: User "system:serviceaccount:openshift-cluster-csi-drivers:azure-file-csi-driver-node-sa" cannot get resource "secrets" in API group "" in the namespace "default"

I0503 10:10:56.440039 1 azurefile.go:828] use cluster identity to get account key from (53b8f551-f0fc-4bea-8cba-6d1fefd54c8a, rbednar-wi-03-rg, clusterqlbqi)

I0503 10:10:56.533156 1 nodeserver.go:326] cifsMountPath(/var/lib/kubelet/plugins/kubernetes.io/csi/file.csi.azure.com/e53ce882ae47f30739a21cc04a37ac4a14a19894e1551e7d78909e7e1d52d167/globalmount) fstype() volumeID(unique_volume_id) context(map[shareName:rbednartest storageaccount:clusterqlbqi]) mountflags([dir_mode=0777 file_mode=0777 uid=0 gid=0 mfsymlinks cache=strict nosharesock]) mountOptions([dir_mode=0777 file_mode=0777 uid=0 gid=0 mfsymlinks cache=strict nosharesock actimeo=30]) volumeMountGroup()

I0503 10:10:56.541986 1 mount_linux.go:253] Cannot run systemd-run, assuming non-systemd OS

I0503 10:10:56.847913 1 nodeserver.go:360] volume(unique_volume_id) mount //clusterqlbqi.file.core.windows.net/rbednartest on /var/lib/kubelet/plugins/kubernetes.io/csi/file.csi.azure.com/e53ce882ae47f30739a21cc04a37ac4a14a19894e1551e7d78909e7e1d52d167/globalmount succeeded

I0503 10:10:56.847975 1 utils.go:84] GRPC response: {}

I0503 10:10:56.872817 1 utils.go:77] GRPC call: /csi.v1.Node/NodePublishVolume

I0503 10:10:56.872839 1 utils.go:78] GRPC request: {"staging_target_path":"/var/lib/kubelet/plugins/kubernetes.io/csi/file.csi.azure.com/e53ce882ae47f30739a21cc04a37ac4a14a19894e1551e7d78909e7e1d52d167/globalmount","target_path":"/var/lib/kubelet/pods/6b49d35b-8a91-4f75-93e5-fb76bb4c5cab/volumes/kubernetes.io~csi/pv-azurefile/mount","volume_capability":{"AccessType":{"Mount":{"mount_flags":["dir_mode=0777","file_mode=0777","uid=0","gid=0","mfsymlinks","cache=strict","nosharesock"]}},"access_mode":{"mode":5}},"volume_context":{"csi.storage.k8s.io/ephemeral":"false","csi.storage.k8s.io/pod.name":"statefulset-azurefile-0","csi.storage.k8s.io/pod.namespace":"default","csi.storage.k8s.io/pod.uid":"6b49d35b-8a91-4f75-93e5-fb76bb4c5cab","csi.storage.k8s.io/serviceAccount.name":"default","csi.storage.k8s.io/serviceAccount.tokens":"***stripped***","shareName":"rbednartest","storageaccount":"clusterqlbqi"},"volume_id":"unique_volume_id"}

I0503 10:10:56.873999 1 nodeserver.go:123] NodePublishVolume: mounting /var/lib/kubelet/plugins/kubernetes.io/csi/file.csi.azure.com/e53ce882ae47f30739a21cc04a37ac4a14a19894e1551e7d78909e7e1d52d167/globalmount at /var/lib/kubelet/pods/6b49d35b-8a91-4f75-93e5-fb76bb4c5cab/volumes/kubernetes.io~csi/pv-azurefile/mount with mountOptions: [bind]

I0503 10:10:56.877978 1 nodeserver.go:130] NodePublishVolume: mount /var/lib/kubelet/plugins/kubernetes.io/csi/file.csi.azure.com/e53ce882ae47f30739a21cc04a37ac4a14a19894e1551e7d78909e7e1d52d167/globalmount at /var/lib/kubelet/pods/6b49d35b-8a91-4f75-93e5-fb76bb4c5cab/volumes/kubernetes.io~csi/pv-azurefile/mount successfully

I0503 10:10:56.878004 1 utils.go:84] GRPC response: {}
```

6) Check mount on pod created by StatefulSet

```
# mount | grep azure
//clusterqlbqi.file.core.windows.net/rbednartest on /mnt/azurefile type cifs (rw,relatime,vers=3.1.1,cache=strict,username=clusterqlbqi,uid=0,noforceuid,gid=0,noforcegid,addr=20.60.220.40,file_mode=0777,dir_mode=0777,soft,persistenthandles,nounix,serverino,mapposix,mfsymlinks,rsize=1048576,wsize=1048576,bsize=1048576,echo_interval=60,actimeo=30,closetimeo=1)
```


NOTE: no additional permissions for azure driver were added for this test