### PR TITLE
OCPBUGS-33776: Adjust port for registrar sidecar in aws-ebs csi driver container

### DIFF
--- a/assets/overlays/aws-ebs/generated/hypershift/node.yaml
+++ b/assets/overlays/aws-ebs/generated/hypershift/node.yaml
@@ -78,7 +78,7 @@ spec:
       - args:
         - --csi-address=/csi/csi.sock
         - --kubelet-registration-path=/var/lib/kubelet/plugins/ebs.csi.aws.com/csi.sock
-        - --http-endpoint=:10304
+        - --http-endpoint=:10309
         - --v=${LOG_LEVEL}
         env: []
         image: ${NODE_DRIVER_REGISTRAR_IMAGE}
@@ -100,7 +100,7 @@ spec:
           timeoutSeconds: 3
         name: csi-node-driver-registrar
         ports:
-        - containerPort: 10304
+        - containerPort: 10309
           name: rhealthz
           protocol: TCP
         resources:

--- a/assets/overlays/aws-ebs/generated/standalone/node.yaml
+++ b/assets/overlays/aws-ebs/generated/standalone/node.yaml
@@ -78,7 +78,7 @@ spec:
       - args:
         - --csi-address=/csi/csi.sock
         - --kubelet-registration-path=/var/lib/kubelet/plugins/ebs.csi.aws.com/csi.sock
-        - --http-endpoint=:10304
+        - --http-endpoint=:10309
         - --v=${LOG_LEVEL}
         env: []
         image: ${NODE_DRIVER_REGISTRAR_IMAGE}
@@ -100,7 +100,7 @@ spec:
           timeoutSeconds: 3
         name: csi-node-driver-registrar
         ports:
-        - containerPort: 10304
+        - containerPort: 10309
           name: rhealthz
           protocol: TCP
         resources:

--- a/pkg/driver/aws-ebs/aws_ebs.go
+++ b/pkg/driver/aws-ebs/aws_ebs.go
@@ -102,7 +102,7 @@ func GetAWSEBSGeneratorConfig() *generator.CSIDriverGeneratorConfig {
 			DaemonSetTemplateAssetName: "overlays/aws-ebs/patches/node_add_driver.yaml",
 			LivenessProbePort:          10300,
 			// 10305 is used for healthcheck of efs-operator
-			NodeRegistrarHealthCheckPort: 10304,
+			NodeRegistrarHealthCheckPort: 10309,
 			Sidecars: []generator.SidecarConfig{
 				commongenerator.DefaultNodeDriverRegistrar,
 				commongenerator.DefaultLivenessProbe.WithExtraArguments(


### PR DESCRIPTION
Port 10304 collides with aws-efs driver from 4.15. Let's use unused port 10309.