### PR TITLE
NO-JIRA: keep smb test storageclass consistent with official doc

### DIFF
--- a/test/e2e/samba/samba-server.yaml
+++ b/test/e2e/samba/samba-server.yaml
@@ -204,4 +204,9 @@ parameters:
 reclaimPolicy: Delete
 volumeBindingMode: Immediate
 mountOptions:
+  - dir_mode=0777
+  - file_mode=0777
+  - noperm
   - mfsymlinks
+  - cache=strict
+  - noserverino


### PR DESCRIPTION
### Enhancement: keep smb test storageclass consistent with official doc

- As the **[discussion](https://redhat-internal.slack.com/archives/GK0DA0JR5/p1715845060021839)**  we descide to use  these mountOptions as a suggested configuration in our [official doc](https://github.com/openshift/openshift-docs/pull/75920/files#diff-9feef84bc4321a98266556e517c2970f8444dab6f0fffad1a728c905502ed8f7R70-R75). Update the CI configuration consistent with official doc