### PR TITLE
OCPBUGS-34451: Bump go version to be consistent with ART

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: rhel-9-release-golang-1.21-openshift-4.17
+  tag: rhel-9-release-golang-1.22-openshift-4.17

--- a/Dockerfile.aws-ebs
+++ b/Dockerfile.aws-ebs
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.21-openshift-4.17 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.22-openshift-4.17 AS builder
 WORKDIR /go/src/github.com/openshift/csi-operator
 COPY . .
 RUN make

--- a/Dockerfile.aws-efs
+++ b/Dockerfile.aws-efs
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.21-openshift-4.17 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.22-openshift-4.17 AS builder
 WORKDIR /go/src/github.com/openshift/aws-efs-csi-driver-operator
 COPY legacy/aws-efs-csi-driver-operator .
 RUN make

--- a/Dockerfile.azure-disk
+++ b/Dockerfile.azure-disk
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.21-openshift-4.16 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.22-openshift-4.17 AS builder
 WORKDIR /go/src/github.com/openshift/csi-operator
 COPY . .
 RUN make

--- a/Dockerfile.azure-file
+++ b/Dockerfile.azure-file
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.21-openshift-4.16 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.22-openshift-4.17 AS builder
 WORKDIR /go/src/github.com/openshift/csi-operator
 COPY . .
 RUN make

--- a/Dockerfile.create_efs
+++ b/Dockerfile.create_efs
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.21-openshift-4.16 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.22-openshift-4.17 AS builder
 WORKDIR /go/src/github.com/openshift/aws-efs-csi-driver-operator
 COPY legacy/aws-efs-csi-driver-operator .
 RUN make

--- a/Dockerfile.samba
+++ b/Dockerfile.samba
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.21-openshift-4.16 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.22-openshift-4.17 AS builder
 WORKDIR /go/src/github.com/openshift/csi-operator
 COPY . .
 RUN make


### PR DESCRIPTION
Use go 1.22 in all images + .ci-operator.yaml
