### PR TITLE
OCPBUGS-37274: Add FIPS_ENABLED to env vars for aws-efs-csi-driver 

### DIFF
--- a/assets/overlays/aws-efs/generated/standalone/controller.yaml
+++ b/assets/overlays/aws-efs/generated/standalone/controller.yaml
@@ -72,6 +72,8 @@ spec:
           value: "1"
         - name: AWS_CONFIG_FILE
           value: /var/run/secrets/aws/credentials
+        - name: FIPS_ENABLED
+          value: ${FIPS_ENABLED}
         image: ${DRIVER_IMAGE}
         imagePullPolicy: IfNotPresent
         livenessProbe:

--- a/assets/overlays/aws-efs/generated/standalone/node.yaml
+++ b/assets/overlays/aws-efs/generated/standalone/node.yaml
@@ -39,6 +39,8 @@ spec:
         env:
         - name: CSI_ENDPOINT
           value: unix:/csi/csi.sock
+        - name: FIPS_ENABLED
+          value: ${FIPS_ENABLED}
         image: ${DRIVER_IMAGE}
         livenessProbe:
           failureThreshold: 5

--- a/assets/overlays/aws-efs/patches/controller_add_driver.yaml
+++ b/assets/overlays/aws-efs/patches/controller_add_driver.yaml
@@ -72,6 +72,8 @@ spec:
               value: '1'
             - name: AWS_CONFIG_FILE
               value: /var/run/secrets/aws/credentials
+            - name: FIPS_ENABLED
+              value: ${FIPS_ENABLED}
           ports:
             - name: healthz
               # Due to hostNetwork, this port is open on a node!

--- a/assets/overlays/aws-efs/patches/node_add_driver.yaml
+++ b/assets/overlays/aws-efs/patches/node_add_driver.yaml
@@ -43,6 +43,8 @@ spec:
           env:
             - name: CSI_ENDPOINT
               value: unix:/csi/csi.sock
+            - name: FIPS_ENABLED
+              value: ${FIPS_ENABLED}
           volumeMounts:
             - name: kubelet-dir
               mountPath: /var/lib/kubelet


### PR DESCRIPTION
https://github.com/openshift/aws-efs-csi-driver/pull/80 will use FIPS_ENABLED to create proper config file for stunnel.