### PR TITLE
OCPBUGS-24588: use new workload controller with preconditions

### DIFF
--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -113,13 +113,15 @@ func RunOperator(ctx context.Context, controllerConfig *controllercmd.Controller
 	).WithCSIConfigObserverController(
 		csiOperatorControllerConfig.GetControllerName("DriverCSIConfigObserverController"),
 		c.ConfigInformers,
-	).WithCSIDriverControllerService(
+	).WithCSIDriverControllerServiceWorkload(
 		csiOperatorControllerConfig.GetControllerName("DriverControllerServiceController"),
+		controlPlaneNamespace,
 		a.GetAsset,
 		generated_assets.ControllerDeploymentAssetName,
 		c.ControlPlaneKubeClient,
-		c.ControlPlaneKubeInformers.InformersFor(controlPlaneNamespace),
+		c.ControlPlaneKubeInformers,
 		c.ConfigInformers,
+		csiOperatorControllerConfig.GetPreconditions(),
 		controlPlaneControllerInformers,
 		controllerHooks...,
 	)


### PR DESCRIPTION
ClusterCSIDriver condition when precondition fails:
```
  - lastTransitionTime: "2024-07-24T11:13:45Z"
    message: |
      dummy precondition 3 failed
    reason: PreconditionNotFulfilled
    status: "True"
    type: DeploymentDegraded
```

Controllers can be configured with csi-operator to have multiple preconditions, errors are then aggregated in ClusterCSIDriver:
```
- lastTransitionTime: "2024-07-24T11:13:45Z"
    message: |
      dummy error 2
      dummy error 3
    reason: PreconditionNotFulfilled
    status: "True"
    type: DeploymentDegraded
```