### PR TITLE
OCPBUGS-37488: add init container in EBS CSI controller pod

### DIFF
--- a/assets/overlays/aws-ebs/generated/hypershift/controller.yaml
+++ b/assets/overlays/aws-ebs/generated/hypershift/controller.yaml
@@ -431,6 +431,7 @@ spec:
           # If credentials key exists in ebs-cloud-credentials secret, then use it as the auth file
           if [ -e "$CREDENTIALS_FILE" ]; then
               cp "$CREDENTIALS_FILE" "$AUTH_CREDENTIALS_FILE"
+              echo "Kubernetes Secret already contains credentials file, copied to the right place: $AUTH_CREDENTIALS_FILE"
               exit 0
           fi
 
@@ -446,6 +447,7 @@ spec:
           aws_access_key_id=$(cat "$AWS_ACCESS_KEY_ID_FILE")
           aws_secret_access_key=$(cat "$AWS_SECRET_ACCESS_KEY_FILE")
           EOF
+          echo "Kubernetes Secret does not have credentials file, created a fresh one at $AUTH_CREDENTIALS_FILE"
         image: ${TOOLS_IMAGE}
         name: init-aws-credentials-file
         volumeMounts:

--- a/assets/overlays/aws-ebs/generated/hypershift/controller.yaml
+++ b/assets/overlays/aws-ebs/generated/hypershift/controller.yaml
@@ -422,10 +422,29 @@ spec:
         - sh
         - -c
         - |
-          cat <<EOF > /var/run/aws/auth/credentials
+          # Define file path variables
+          CREDENTIALS_FILE=/var/run/aws/keys/credentials
+          AUTH_CREDENTIALS_FILE=/var/run/aws/auth/credentials
+          AWS_ACCESS_KEY_ID_FILE=/var/run/aws/keys/aws_access_key_id
+          AWS_SECRET_ACCESS_KEY_FILE=/var/run/aws/keys/aws_secret_access_key
+
+          # If credentials key exists in ebs-cloud-credentials secret, then use it as the auth file
+          if [ -e "$CREDENTIALS_FILE" ]; then
+              cp "$CREDENTIALS_FILE" "$AUTH_CREDENTIALS_FILE"
+              exit 0
+          fi
+
+          # Otherwise, make sure the access keys are mounted in the pod...
+          if [ ! -e "$AWS_ACCESS_KEY_ID_FILE" ] || [ ! -e "$AWS_SECRET_ACCESS_KEY_FILE" ]; then
+              echo "AWS keys not found"
+              exit 1
+          fi
+
+          # And create an auth file based on those keys
+          cat <<-EOF > "$AUTH_CREDENTIALS_FILE"
           [default]
-          aws_access_key_id=$(cat /var/run/aws/keys/aws_access_key_id)
-          aws_secret_access_key=$(cat /var/run/aws/keys/aws_secret_access_key)
+          aws_access_key_id=$(cat "$AWS_ACCESS_KEY_ID_FILE")
+          aws_secret_access_key=$(cat "$AWS_SECRET_ACCESS_KEY_FILE")
           EOF
         image: ${TOOLS_IMAGE}
         name: init-aws-credentials-file

--- a/assets/overlays/aws-ebs/generated/hypershift/controller.yaml
+++ b/assets/overlays/aws-ebs/generated/hypershift/controller.yaml
@@ -47,7 +47,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: bound-sa-token,socket-dir
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: aws-auth,aws-keys,bound-sa-token,socket-dir
         openshift.io/required-scc: restricted-v2
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
@@ -102,7 +102,7 @@ spec:
         - name: AWS_SDK_LOAD_CONFIG
           value: "1"
         - name: AWS_CONFIG_FILE
-          value: /var/run/secrets/aws/credentials
+          value: /var/run/aws/auth/credentials
         image: ${DRIVER_IMAGE}
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -124,8 +124,11 @@ spec:
             memory: 50Mi
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
-        - mountPath: /var/run/secrets/aws
-          name: aws-credentials
+        - mountPath: /var/run/aws/keys
+          name: aws-keys
+          readOnly: true
+        - mountPath: /var/run/aws/auth
+          name: aws-auth
           readOnly: true
         - mountPath: /var/run/secrets/openshift/serviceaccount
           name: bound-sa-token
@@ -414,6 +417,24 @@ spec:
         - mountPath: /etc/hosted-kubernetes
           name: hosted-kubeconfig
           readOnly: true
+      initContainers:
+      - command:
+        - sh
+        - -c
+        - |
+          cat <<EOF > /var/run/aws/auth/credentials
+          [default]
+          aws_access_key_id=$(cat /var/run/aws/keys/aws_access_key_id)
+          aws_secret_access_key=$(cat /var/run/aws/keys/aws_secret_access_key)
+          EOF
+        image: ${TOOLS_IMAGE}
+        name: init-aws-credentials-file
+        volumeMounts:
+        - mountPath: /var/run/aws/keys
+          name: aws-keys
+          readOnly: true
+        - mountPath: /var/run/aws/auth
+          name: aws-auth
       priorityClassName: hypershift-control-plane
       serviceAccount: aws-ebs-csi-driver-controller-sa
       tolerations:
@@ -431,9 +452,11 @@ spec:
       - name: metrics-serving-cert
         secret:
           secretName: aws-ebs-csi-driver-controller-metrics-serving-cert
-      - name: aws-credentials
+      - name: aws-keys
         secret:
           secretName: ebs-cloud-credentials
+      - emptyDir: {}
+        name: aws-auth
       - emptyDir:
           medium: Memory
         name: bound-sa-token

--- a/assets/overlays/aws-ebs/generated/standalone/controller.yaml
+++ b/assets/overlays/aws-ebs/generated/standalone/controller.yaml
@@ -354,6 +354,7 @@ spec:
           # If credentials key exists in ebs-cloud-credentials secret, then use it as the auth file
           if [ -e "$CREDENTIALS_FILE" ]; then
               cp "$CREDENTIALS_FILE" "$AUTH_CREDENTIALS_FILE"
+              echo "Kubernetes Secret already contains credentials file, copied to the right place: $AUTH_CREDENTIALS_FILE"
               exit 0
           fi
 
@@ -369,6 +370,7 @@ spec:
           aws_access_key_id=$(cat "$AWS_ACCESS_KEY_ID_FILE")
           aws_secret_access_key=$(cat "$AWS_SECRET_ACCESS_KEY_FILE")
           EOF
+          echo "Kubernetes Secret does not have credentials file, created a fresh one at $AUTH_CREDENTIALS_FILE"
         image: ${TOOLS_IMAGE}
         name: init-aws-credentials-file
         volumeMounts:

--- a/assets/overlays/aws-ebs/generated/standalone/controller.yaml
+++ b/assets/overlays/aws-ebs/generated/standalone/controller.yaml
@@ -42,7 +42,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: bound-sa-token,socket-dir
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: aws-auth,aws-keys,bound-sa-token,socket-dir
         openshift.io/required-scc: restricted-v2
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
@@ -72,7 +72,7 @@ spec:
         - name: AWS_SDK_LOAD_CONFIG
           value: "1"
         - name: AWS_CONFIG_FILE
-          value: /var/run/secrets/aws/credentials
+          value: /var/run/aws/auth/credentials
         image: ${DRIVER_IMAGE}
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -94,8 +94,11 @@ spec:
             memory: 50Mi
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
-        - mountPath: /var/run/secrets/aws
-          name: aws-credentials
+        - mountPath: /var/run/aws/keys
+          name: aws-keys
+          readOnly: true
+        - mountPath: /var/run/aws/auth
+          name: aws-auth
           readOnly: true
         - mountPath: /var/run/secrets/openshift/serviceaccount
           name: bound-sa-token
@@ -337,6 +340,24 @@ spec:
         volumeMounts:
         - mountPath: /csi
           name: socket-dir
+      initContainers:
+      - command:
+        - sh
+        - -c
+        - |
+          cat <<EOF > /var/run/aws/auth/credentials
+          [default]
+          aws_access_key_id=$(cat /var/run/aws/keys/aws_access_key_id)
+          aws_secret_access_key=$(cat /var/run/aws/keys/aws_secret_access_key)
+          EOF
+        image: ${TOOLS_IMAGE}
+        name: init-aws-credentials-file
+        volumeMounts:
+        - mountPath: /var/run/aws/keys
+          name: aws-keys
+          readOnly: true
+        - mountPath: /var/run/aws/auth
+          name: aws-auth
       nodeSelector:
         node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
@@ -353,9 +374,11 @@ spec:
       - name: metrics-serving-cert
         secret:
           secretName: aws-ebs-csi-driver-controller-metrics-serving-cert
-      - name: aws-credentials
+      - name: aws-keys
         secret:
           secretName: ebs-cloud-credentials
+      - emptyDir: {}
+        name: aws-auth
       - name: bound-sa-token
         projected:
           sources:

--- a/assets/overlays/aws-ebs/generated/standalone/controller.yaml
+++ b/assets/overlays/aws-ebs/generated/standalone/controller.yaml
@@ -345,10 +345,29 @@ spec:
         - sh
         - -c
         - |
-          cat <<EOF > /var/run/aws/auth/credentials
+          # Define file path variables
+          CREDENTIALS_FILE=/var/run/aws/keys/credentials
+          AUTH_CREDENTIALS_FILE=/var/run/aws/auth/credentials
+          AWS_ACCESS_KEY_ID_FILE=/var/run/aws/keys/aws_access_key_id
+          AWS_SECRET_ACCESS_KEY_FILE=/var/run/aws/keys/aws_secret_access_key
+
+          # If credentials key exists in ebs-cloud-credentials secret, then use it as the auth file
+          if [ -e "$CREDENTIALS_FILE" ]; then
+              cp "$CREDENTIALS_FILE" "$AUTH_CREDENTIALS_FILE"
+              exit 0
+          fi
+
+          # Otherwise, make sure the access keys are mounted in the pod...
+          if [ ! -e "$AWS_ACCESS_KEY_ID_FILE" ] || [ ! -e "$AWS_SECRET_ACCESS_KEY_FILE" ]; then
+              echo "AWS keys not found"
+              exit 1
+          fi
+
+          # And create an auth file based on those keys
+          cat <<-EOF > "$AUTH_CREDENTIALS_FILE"
           [default]
-          aws_access_key_id=$(cat /var/run/aws/keys/aws_access_key_id)
-          aws_secret_access_key=$(cat /var/run/aws/keys/aws_secret_access_key)
+          aws_access_key_id=$(cat "$AWS_ACCESS_KEY_ID_FILE")
+          aws_secret_access_key=$(cat "$AWS_SECRET_ACCESS_KEY_FILE")
           EOF
         image: ${TOOLS_IMAGE}
         name: init-aws-credentials-file

--- a/assets/overlays/aws-ebs/patches/controller_add_driver.yaml
+++ b/assets/overlays/aws-ebs/patches/controller_add_driver.yaml
@@ -8,9 +8,46 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: bound-sa-token,socket-dir
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: aws-auth,aws-keys,bound-sa-token,socket-dir
         openshift.io/required-scc: restricted-v2
     spec:
+      initContainers:
+        - name: init-aws-credentials-file
+          image: ${TOOLS_IMAGE}
+          command:
+          - sh
+          - -c
+          - |
+            # Define file path variables
+            CREDENTIALS_FILE=/var/run/aws/keys/credentials
+            AUTH_CREDENTIALS_FILE=/var/run/aws/auth/credentials
+            AWS_ACCESS_KEY_ID_FILE=/var/run/aws/keys/aws_access_key_id
+            AWS_SECRET_ACCESS_KEY_FILE=/var/run/aws/keys/aws_secret_access_key
+
+            # If credentials key exists in ebs-cloud-credentials secret, then use it as the auth file
+            if [ -e "$CREDENTIALS_FILE" ]; then
+                cp "$CREDENTIALS_FILE" "$AUTH_CREDENTIALS_FILE"
+                exit 0
+            fi
+
+            # Otherwise, make sure the access keys are mounted in the pod...
+            if [ ! -e "$AWS_ACCESS_KEY_ID_FILE" ] || [ ! -e "$AWS_SECRET_ACCESS_KEY_FILE" ]; then
+                echo "AWS keys not found"
+                exit 1
+            fi
+
+            # And create an auth file based on those keys
+            cat <<-EOF > "$AUTH_CREDENTIALS_FILE"
+            [default]
+            aws_access_key_id=$(cat "$AWS_ACCESS_KEY_ID_FILE")
+            aws_secret_access_key=$(cat "$AWS_SECRET_ACCESS_KEY_FILE")
+            EOF
+          volumeMounts:
+            - name: aws-keys
+              mountPath: /var/run/aws/keys
+              readOnly: true
+            - name: aws-auth
+              mountPath: /var/run/aws/auth
       containers:
         - name: csi-driver
           image: ${DRIVER_IMAGE}
@@ -29,7 +66,7 @@ spec:
             - name: AWS_SDK_LOAD_CONFIG
               value: '1'
             - name: AWS_CONFIG_FILE
-              value: /var/run/secrets/aws/credentials
+              value: /var/run/aws/auth/credentials
           ports:
             - name: healthz
               containerPort: 10301
@@ -43,8 +80,11 @@ spec:
             periodSeconds: 10
             failureThreshold: 5
           volumeMounts:
-            - name: aws-credentials
-              mountPath: /var/run/secrets/aws
+            - name: aws-keys
+              mountPath: /var/run/aws/keys
+              readOnly: true
+            - name: aws-auth
+              mountPath: /var/run/aws/auth
               readOnly: true
             - name: bound-sa-token
               mountPath: /var/run/secrets/openshift/serviceaccount
@@ -57,9 +97,11 @@ spec:
               cpu: 10m
           terminationMessagePolicy: FallbackToLogsOnError
       volumes:
-        - name: aws-credentials
+        - name: aws-keys
           secret:
             secretName: ebs-cloud-credentials
+        - name: aws-auth
+          emptyDir: {}
         # This service account token can be used to provide identity outside the cluster.
         # For example, this token can be used with AssumeRoleWithWebIdentity to authenticate with AWS using IAM OIDC provider and STS.
         - name: bound-sa-token

--- a/assets/overlays/aws-ebs/patches/controller_add_driver.yaml
+++ b/assets/overlays/aws-ebs/patches/controller_add_driver.yaml
@@ -27,6 +27,7 @@ spec:
             # If credentials key exists in ebs-cloud-credentials secret, then use it as the auth file
             if [ -e "$CREDENTIALS_FILE" ]; then
                 cp "$CREDENTIALS_FILE" "$AUTH_CREDENTIALS_FILE"
+                echo "Kubernetes Secret already contains credentials file, copied to the right place: $AUTH_CREDENTIALS_FILE"
                 exit 0
             fi
 
@@ -42,6 +43,7 @@ spec:
             aws_access_key_id=$(cat "$AWS_ACCESS_KEY_ID_FILE")
             aws_secret_access_key=$(cat "$AWS_SECRET_ACCESS_KEY_FILE")
             EOF
+            echo "Kubernetes Secret does not have credentials file, created a fresh one at $AUTH_CREDENTIALS_FILE"
           volumeMounts:
             - name: aws-keys
               mountPath: /var/run/aws/keys

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/openshift/client-go v0.0.0-20240528061634-b054aa794d87
 	github.com/openshift/hypershift v0.1.39
 	github.com/openshift/hypershift/api v0.0.0-20240725153211-8b880bdd20d1
-	github.com/openshift/library-go v0.0.0-20240715191351-e0aa70d55678
+	github.com/openshift/library-go v0.0.0-20240731134552-8211143dfde7
 	github.com/prometheus/client_golang v1.19.1
 	github.com/spf13/cobra v1.8.1
 	gopkg.in/yaml.v2 v2.4.0

--- a/go.sum
+++ b/go.sum
@@ -155,8 +155,8 @@ github.com/openshift/hypershift v0.1.39 h1:0LEH7srbBFh/0N+mNvdDhiGQAsbtHt647bj4X
 github.com/openshift/hypershift v0.1.39/go.mod h1:q/TuRvv0WqAjpvCUX7jFRGtXP0aZn4x1Bg0ikiFx2Ds=
 github.com/openshift/hypershift/api v0.0.0-20240725153211-8b880bdd20d1 h1:jOikb/zB0IT79YTeepbJQ3VRcUF/fVIhfcWNTKxnyBQ=
 github.com/openshift/hypershift/api v0.0.0-20240725153211-8b880bdd20d1/go.mod h1:IDXXroBJeH+nIHkA17S3Yq2QDQg02tMnCWOXoyZVOLY=
-github.com/openshift/library-go v0.0.0-20240715191351-e0aa70d55678 h1:H08EzrqjY63m1jlZ+D4sTy9fSGlHsPwViyxFrWTIh4A=
-github.com/openshift/library-go v0.0.0-20240715191351-e0aa70d55678/go.mod h1:PdASVamWinll2BPxiUpXajTwZxV8A1pQbWEsCN1od7I=
+github.com/openshift/library-go v0.0.0-20240731134552-8211143dfde7 h1:FluOIEKNSUEc48dLJEWDin8vDHQ5JmnXycl6wx3M3io=
+github.com/openshift/library-go v0.0.0-20240731134552-8211143dfde7/go.mod h1:PdASVamWinll2BPxiUpXajTwZxV8A1pQbWEsCN1od7I=
 github.com/orisano/pixelmatch v0.0.0-20220722002657-fb0b55479cde/go.mod h1:nZgzbfBr3hhjoZnS66nKrHmduYNpc34ny7RK4z5/HM0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/pkg/driver/aws-ebs/aws_ebs_test.go
+++ b/pkg/driver/aws-ebs/aws_ebs_test.go
@@ -88,7 +88,7 @@ func Test_WithCustomEndPoint(t *testing.T) {
 			name:           "no endpoint",
 			infrastructure: infraNoEndpoint,
 			expectedEnvVars: map[string]string{
-				"AWS_CONFIG_FILE":     "/var/run/secrets/aws/credentials",
+				"AWS_CONFIG_FILE":     "/var/run/aws/auth/credentials",
 				"AWS_SDK_LOAD_CONFIG": "1",
 				"CSI_ENDPOINT":        "unix:///var/lib/csi/sockets/pluginproxy/csi.sock",
 			},
@@ -97,7 +97,7 @@ func Test_WithCustomEndPoint(t *testing.T) {
 			name:           "EC2 endpoint set",
 			infrastructure: infraWithEC2Endpoint,
 			expectedEnvVars: map[string]string{
-				"AWS_CONFIG_FILE":     "/var/run/secrets/aws/credentials",
+				"AWS_CONFIG_FILE":     "/var/run/aws/auth/credentials",
 				"AWS_SDK_LOAD_CONFIG": "1",
 				"CSI_ENDPOINT":        "unix:///var/lib/csi/sockets/pluginproxy/csi.sock",
 				"AWS_EC2_ENDPOINT":    "https://my-endpoint.org",
@@ -107,7 +107,7 @@ func Test_WithCustomEndPoint(t *testing.T) {
 			name:           "non-EC2 endpoints set",
 			infrastructure: infraWithoutEC2Endpoint,
 			expectedEnvVars: map[string]string{
-				"AWS_CONFIG_FILE":     "/var/run/secrets/aws/credentials",
+				"AWS_CONFIG_FILE":     "/var/run/aws/auth/credentials",
 				"AWS_SDK_LOAD_CONFIG": "1",
 				"CSI_ENDPOINT":        "unix:///var/lib/csi/sockets/pluginproxy/csi.sock",
 			},
@@ -244,7 +244,7 @@ func Test_WithCustomRegion(t *testing.T) {
 			name:           "no region",
 			infrastructure: infraNoRegion,
 			expectedEnvVars: map[string]string{
-				"AWS_CONFIG_FILE":     "/var/run/secrets/aws/credentials",
+				"AWS_CONFIG_FILE":     "/var/run/aws/auth/credentials",
 				"AWS_SDK_LOAD_CONFIG": "1",
 				"CSI_ENDPOINT":        "unix:///var/lib/csi/sockets/pluginproxy/csi.sock",
 			},
@@ -253,7 +253,7 @@ func Test_WithCustomRegion(t *testing.T) {
 			name:           "region set",
 			infrastructure: infraWithRegion,
 			expectedEnvVars: map[string]string{
-				"AWS_CONFIG_FILE":     "/var/run/secrets/aws/credentials",
+				"AWS_CONFIG_FILE":     "/var/run/aws/auth/credentials",
 				"AWS_SDK_LOAD_CONFIG": "1",
 				"CSI_ENDPOINT":        "unix:///var/lib/csi/sockets/pluginproxy/csi.sock",
 				"AWS_REGION":          "us-east-1",

--- a/pkg/driver/common/operator/replacer.go
+++ b/pkg/driver/common/operator/replacer.go
@@ -12,6 +12,7 @@ const (
 	snapshotterImageEnvName   = "SNAPSHOTTER_IMAGE"
 	livenessProbeImageEnvName = "LIVENESS_PROBE_IMAGE"
 	kubeRBACProxyImageEnvName = "KUBE_RBAC_PROXY_IMAGE"
+	toolsImageEnvName         = "TOOLS_IMAGE"
 	hyperShiftImageEnvName    = "HYPERSHIFT_IMAGE"
 )
 
@@ -52,6 +53,11 @@ func DefaultReplacements(controlPlaneNamespace string) []string {
 	kubeRBACProxy := os.Getenv(kubeRBACProxyImageEnvName)
 	if kubeRBACProxy != "" {
 		pairs = append(pairs, []string{"${KUBE_RBAC_PROXY_IMAGE}", kubeRBACProxy}...)
+	}
+
+	tools := os.Getenv(toolsImageEnvName)
+	if tools != "" {
+		pairs = append(pairs, []string{"${TOOLS_IMAGE}", tools}...)
 	}
 
 	hyperShiftImage := os.Getenv(hyperShiftImageEnvName)

--- a/pkg/driver/common/operator/test_manifests/aws_ebs_controller_hypershift.yaml
+++ b/pkg/driver/common/operator/test_manifests/aws_ebs_controller_hypershift.yaml
@@ -74,7 +74,7 @@ spec:
         - name: AWS_SDK_LOAD_CONFIG
           value: "1"
         - name: AWS_CONFIG_FILE
-          value: /var/run/secrets/aws/credentials
+          value: /var/run/aws/auth/credentials
         image: ${DRIVER_IMAGE}
         imagePullPolicy: IfNotPresent
         livenessProbe:

--- a/vendor/github.com/openshift/library-go/pkg/operator/csi/csidrivercontrollerservicecontroller/helpers.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/csi/csidrivercontrollerservicecontroller/helpers.go
@@ -35,6 +35,7 @@ const (
 	snapshotterImageEnvName   = "SNAPSHOTTER_IMAGE"
 	livenessProbeImageEnvName = "LIVENESS_PROBE_IMAGE"
 	kubeRBACProxyImageEnvName = "KUBE_RBAC_PROXY_IMAGE"
+	toolsImageEnvName         = "TOOLS_IMAGE"
 
 	infraConfigName = "cluster"
 )
@@ -206,6 +207,11 @@ func WithPlaceholdersHook(configInformer configinformers.SharedInformerFactory) 
 		kubeRBACProxy := os.Getenv(kubeRBACProxyImageEnvName)
 		if kubeRBACProxy != "" {
 			pairs = append(pairs, []string{"${KUBE_RBAC_PROXY_IMAGE}", kubeRBACProxy}...)
+		}
+
+		tools := os.Getenv(toolsImageEnvName)
+		if tools != "" {
+			pairs = append(pairs, []string{"${TOOLS_IMAGE}", tools}...)
 		}
 
 		// Cluster ID

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -382,7 +382,7 @@ github.com/openshift/hypershift/api/ibmcapi
 github.com/openshift/hypershift/api/scheduling
 github.com/openshift/hypershift/api/scheduling/v1alpha1
 github.com/openshift/hypershift/api/util/ipnet
-# github.com/openshift/library-go v0.0.0-20240715191351-e0aa70d55678
+# github.com/openshift/library-go v0.0.0-20240731134552-8211143dfde7
 ## explicit; go 1.22.0
 github.com/openshift/library-go/pkg/authorization/hardcodedauthorizer
 github.com/openshift/library-go/pkg/certs


### PR DESCRIPTION
The init container makes sure that `/var/run/secrets/aws/credentials` file exists and contains the AWS credentials. This is useful when CCO is in manual mode and doesn't create the `ebs-cloud-credentials` secret with the "credentials" key (this is supposed to be created manually). This key is projected as a file in the csi-driver container.

To be merged after https://github.com/openshift/cluster-storage-operator/pull/494 and https://github.com/openshift/library-go/pull/1769.

CC @openshift/storage 