### PR TITLE
STOR-1856: add STS hook for EFS credentials request controller

### DIFF
--- a/doc/aws-efs/README.md
+++ b/doc/aws-efs/README.md
@@ -46,6 +46,8 @@ STORAGECLASS_LOCATION=sc.yaml MANIFEST_LOCATION=manifest.yaml ./bin/create-efs-v
 
 > **Note**: Creation of EFS volume, security groups and firewall rules is not idempotent and hence you must delete those manually if you want to recreate.
 
+> **Note**: For STS clusters you need to use --local-aws-creds option.
+
 This should give us a storageclass which can be applied and can be used for testing:
 
 ```shell

--- a/pkg/generated-assets/generated_assets.go
+++ b/pkg/generated-assets/generated_assets.go
@@ -36,7 +36,7 @@ const (
 
 var (
 	notStaticControllerAssets = sets.NewString(deploymentKind, credentialsRequestKind)
-	notStaticGuestAssets      = sets.NewString(daemonSetKind, storageClassKind, volumeSnapshotClassKind)
+	notStaticGuestAssets      = sets.NewString(daemonSetKind, storageClassKind, volumeSnapshotClassKind, credentialsRequestKind)
 )
 
 // CSIDriverAssets contains all the assets required to deploy the CSI driver in runtime.

--- a/pkg/operator/config/config.go
+++ b/pkg/operator/config/config.go
@@ -8,6 +8,7 @@ import (
 	"github.com/openshift/csi-operator/pkg/generator"
 	"github.com/openshift/csi-operator/pkg/operator/volume_snapshot_class"
 	"github.com/openshift/library-go/pkg/controller/factory"
+	"github.com/openshift/library-go/pkg/operator/csi/credentialsrequestcontroller"
 	"github.com/openshift/library-go/pkg/operator/csi/csidrivernodeservicecontroller"
 	"github.com/openshift/library-go/pkg/operator/csi/csistorageclasscontroller"
 	"github.com/openshift/library-go/pkg/operator/deploymentcontroller"
@@ -39,6 +40,8 @@ type OperatorControllerConfig struct {
 	// Prefix of all library-go style controllers.
 	ControllerNamePrefix string
 
+	// List of hooks to add to credentials request controller.
+	CredentialsRequestHooks []credentialsrequestcontroller.CredentialsRequestHook
 	// List of hooks to add to CSI driver controller Deployment.
 	DeploymentHooks []deploymentcontroller.DeploymentHookFunc
 	// List of informers that should be added to the Deployment controller.
@@ -65,6 +68,10 @@ type OperatorControllerConfig struct {
 
 	// ExtraReplacements defines additional replacements that should be made to assets
 	ExtraReplacementsFunc func() []string
+}
+
+func (o *OperatorControllerConfig) AddCredentialsRequestHook(hook credentialsrequestcontroller.CredentialsRequestHook) {
+	o.CredentialsRequestHooks = append(o.CredentialsRequestHooks, hook)
 }
 
 func (o *OperatorControllerConfig) AddDeploymentHook(hook deploymentcontroller.DeploymentHookFunc, informers ...factory.Informer) {

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -71,6 +71,7 @@ func RunOperator(ctx context.Context, controllerConfig *controllercmd.Controller
 	// Start controllers that manage resources in the MANAGEMENT cluster.
 	controlPlaneControllerInformers := csiOperatorControllerConfig.DeploymentInformers
 	controllerHooks := csiOperatorControllerConfig.DeploymentHooks
+	credentialsRequestHooks := csiOperatorControllerConfig.CredentialsRequestHooks
 
 	if len(csiOperatorControllerConfig.DeploymentWatchedSecretNames) > 0 {
 		controlPlaneSecretInformer := c.GetControlPlaneSecretInformer(controlPlaneNamespace)
@@ -146,6 +147,7 @@ func RunOperator(ctx context.Context, controllerConfig *controllercmd.Controller
 			generated_assets.CredentialRequestControllerAssetName,
 			c.ControlPlaneDynamicClient,
 			c.OperatorInformers,
+			credentialsRequestHooks...,
 		)
 	}
 


### PR DESCRIPTION
PR https://github.com/openshift/csi-operator/pull/237 for migrating EFS operator to csi-operator repo was missing credentials request hook - as a result EFS operator was not working in STS clusters due to missing secret:

```
MountVolume.SetUp failed for volume "aws-credentials" : secret "aws-efs-cloud-credentials" not found
```

Patch was tested to verify EFS dynamic provisioning on STS cluster and correct handling of role ARN provided via Operator Hub:

1) check provided ARN
```
$ oc -n openshift-cluster-csi-drivers get subscription/aws-efs-csi-driver-operator -o json | jq '.spec.config.env'
[
  {
    "name": "ROLEARN",
    "value": "arn:aws:iam::269733383066:role/rbednar-aws-efs-openshift-cluster-csi-drivers-aws-efs-cloud-cred"
  }
]
```

2) validate ARN propagated to cred. request by the hook
```
$ oc -n openshift-cloud-credential-operator get credentialsrequest/openshift-aws-efs-csi-driver -o json | jq '.spec.providerSpec.stsIAMRoleARN'
"arn:aws:iam::269733383066:role/rbednar-aws-efs-openshift-cluster-csi-drivers-aws-efs-cloud-cred"
```

3) verify secret was created by CCO
```
$ oc -n openshift-cluster-csi-drivers get secret/aws-efs-cloud-credentials
NAME                        TYPE     DATA   AGE
aws-efs-cloud-credentials   Opaque   1      48m
```

4) test dynamic provisioning with EFS
```
$ oc get pvc
NAME    STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   VOLUMEATTRIBUTESCLASS   AGE
pvc-1   Bound    pvc-32f11702-80db-4c3c-b52a-8ccce73e486a   1Gi        RWO            efs-sc         <unset>                 61s

$ oc get pv
NAME                                       CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS   CLAIM           STORAGECLASS   VOLUMEATTRIBUTESCLASS   REASON   AGE
pvc-32f11702-80db-4c3c-b52a-8ccce73e486a   1Gi        RWO            Delete           Bound    default/pvc-1   efs-sc         <unset>                          14s
```