### PR TITLE
STOR-1819: Add manifest with OCP specific test config

### DIFF
--- a/test/e2e/aws-ebs/ocp-manifest.yaml
+++ b/test/e2e/aws-ebs/ocp-manifest.yaml
@@ -1,0 +1,4 @@
+Driver: ebs.csi.aws.com
+LUNStressTest:
+  PodsTotal: 260
+  Timeout: "40m" # The test needs ~20 min in ideal conditions.

--- a/test/e2e/azure-disk/ocp-manifest.yaml
+++ b/test/e2e/azure-disk/ocp-manifest.yaml
@@ -1,0 +1,4 @@
+Driver: disk.csi.azure.com
+LUNStressTest:
+  PodsTotal: 260
+  Timeout: "60m" # The test needs ~40 min in ideal conditions.


### PR DESCRIPTION
The LUN stress test finished:
* In 20 minutes on AWS few times
* In 40 minutes on Azure.

Adding 20 minutes as a buffer.
