### PR TITLE
OCPBUGS-38578: Update aws-efs-csi-driver-operator image-references name

### DIFF
--- a/config/aws-efs/manifests/stable/image-references
+++ b/config/aws-efs/manifests/stable/image-references
@@ -27,7 +27,7 @@ spec:
     from:
       kind: DockerImage
       name: quay.io/openshift/origin-kube-rbac-proxy:latest
-  - name: ose-tools
+  - name: ose-tools-rhel9
     from:
       kind: DockerImage
       name: quay.io/openshift/origin-tools:latest


### PR DESCRIPTION
change reference `ose-tools` to `ose-tools-rhel9`
related to https://github.com/openshift-eng/ocp-build-data/pull/5283