### PR TITLE
OCPBUGS-38922: add tag matching to Azure File storage class

### DIFF
--- a/assets/overlays/azure-file/base/storageclass.yaml
+++ b/assets/overlays/azure-file/base/storageclass.yaml
@@ -6,7 +6,9 @@ metadata:
 provisioner: file.csi.azure.com
 allowVolumeExpansion: true
 parameters:
+  matchTags: "true"
   skuName: Standard_LRS  # available values: Standard_LRS, Standard_GRS, Standard_ZRS, Standard_RAGRS, Premium_LRS
+  tags: storageClassName=azurefile-csi
 reclaimPolicy: Delete
 volumeBindingMode: Immediate
 mountOptions:

--- a/assets/overlays/azure-file/generated/hypershift/storageclass.yaml
+++ b/assets/overlays/azure-file/generated/hypershift/storageclass.yaml
@@ -16,7 +16,9 @@ mountOptions:
 - nosharesock
 - actimeo=30
 parameters:
+  matchTags: "true"
   skuName: Standard_LRS
+  tags: storageClassName=azurefile-csi
 provisioner: file.csi.azure.com
 reclaimPolicy: Delete
 volumeBindingMode: Immediate

--- a/assets/overlays/azure-file/generated/standalone/storageclass.yaml
+++ b/assets/overlays/azure-file/generated/standalone/storageclass.yaml
@@ -16,7 +16,9 @@ mountOptions:
 - nosharesock
 - actimeo=30
 parameters:
+  matchTags: "true"
   skuName: Standard_LRS
+  tags: storageClassName=azurefile-csi
 provisioner: file.csi.azure.com
 reclaimPolicy: Delete
 volumeBindingMode: Immediate


### PR DESCRIPTION
This should address two issues:
- prevent matching storage accounts that have private endpoints enabled - this is the original issue in bug report
- prevent matching storage accounts that are not created by our operator - this is a side effect of using the tags, but we intended to address it anyway

The used key/value pair for the tag is unlikely to ever match any other storage account, although still possible if it is tagged the same. Another alternative considered was to hardcode storage account name (`storageAccount` param), but that requires having the storage account created in advance which is non-trivial and would add code to the operator that might not be necessary.

cc @openshift/storage