### PR TITLE
OCPBUGS-41265: Disable LUN stress test for azure-disk

### DIFF
--- a/test/e2e/azure-disk/ocp-manifest.yaml
+++ b/test/e2e/azure-disk/ocp-manifest.yaml
@@ -1,4 +1,4 @@
 Driver: disk.csi.azure.com
 LUNStressTest:
-  PodsTotal: 260
+  PodsTotal: 10 # See OCPBUGS-41265, Azure reboots a node under a heavy attach/detach load
   Timeout: "60m" # The test needs ~40 min in ideal conditions.


### PR DESCRIPTION
See OCPBUGS-41265, Azure reboots a node that is under heavy attach/detach load. Reduce the load dramatically until Azure provides a fix.

@openshift/storage 