### PR TITLE
OCPBUGS-42325: Add ARO HCP Managed Identity Sidecar Containers

### DIFF
--- a/assets/overlays/azure-disk/patches/controller_add_hypershift_controller.yaml
+++ b/assets/overlays/azure-disk/patches/controller_add_hypershift_controller.yaml
@@ -12,4 +12,4 @@ spec:
           secretName: service-network-admin-kubeconfig
       - name: cloud-config
         secret:
-          secretName: azure-cloud-config
+          secretName: azure-disk-csi-config

--- a/assets/overlays/azure-file/patches/controller_add_hypershift_controller.yaml
+++ b/assets/overlays/azure-file/patches/controller_add_hypershift_controller.yaml
@@ -12,4 +12,4 @@ spec:
           secretName: service-network-admin-kubeconfig
       - name: cloud-config
         secret:
-          secretName: azure-cloud-config
+          secretName: azure-file-csi-config

--- a/pkg/driver/azure-disk/azure_disk.go
+++ b/pkg/driver/azure-disk/azure_disk.go
@@ -10,6 +10,7 @@ import (
 	"github.com/openshift/csi-operator/assets"
 	"github.com/openshift/csi-operator/pkg/clients"
 	"github.com/openshift/csi-operator/pkg/driver/common/operator"
+	"github.com/openshift/csi-operator/pkg/driver/common/util"
 	"github.com/openshift/csi-operator/pkg/generator"
 	"github.com/openshift/csi-operator/pkg/operator/config"
 	"github.com/openshift/csi-operator/pkg/operator/volume_snapshot_class"
@@ -215,6 +216,10 @@ func GetAzureDiskOperatorControllerConfig(ctx context.Context, flavour generator
 			return nil, err
 		}
 		cfg.ExtraControlPlaneControllers = append(cfg.ExtraControlPlaneControllers, configMapSyncer)
+
+		if os.Getenv("AZURE_ADAPTER_INIT_IMAGE") != "" {
+			cfg.AddDeploymentHook(util.WithAROHCPSidecarContainers())
+		}
 	} else {
 		standAloneConfigSyncer, err := syncCloudConfigStandAlone(c)
 		if err != nil {
@@ -282,7 +287,7 @@ func injectEnvAndMounts(spec *coreV1.PodSpec) {
 }
 
 func syncCloudConfigGuest(c *clients.Clients) (factory.Controller, error) {
-	// syncs cloud-config from openshif-config namespace to openshift-cluster-csi-drivers namespace
+	// syncs cloud-config from openshift-config namespace to openshift-cluster-csi-drivers namespace
 	srcConfigMap := resourcesynccontroller.ResourceLocation{
 		Namespace: openshiftDefaultCloudConfigNamespace,
 		Name:      configMapName,

--- a/pkg/driver/azure-file/azure_file.go
+++ b/pkg/driver/azure-file/azure_file.go
@@ -9,6 +9,7 @@ import (
 	"github.com/openshift/csi-operator/assets"
 	"github.com/openshift/csi-operator/pkg/clients"
 	"github.com/openshift/csi-operator/pkg/driver/common/operator"
+	"github.com/openshift/csi-operator/pkg/driver/common/util"
 	"github.com/openshift/csi-operator/pkg/generator"
 	"github.com/openshift/csi-operator/pkg/operator/config"
 	"github.com/openshift/library-go/pkg/controller/factory"
@@ -172,6 +173,10 @@ func GetAzureFileOperatorControllerConfig(ctx context.Context, flavour generator
 			return nil, err
 		}
 		cfg.ExtraControlPlaneControllers = append(cfg.ExtraControlPlaneControllers, configMapSyncer)
+
+		if os.Getenv("AZURE_ADAPTER_INIT_IMAGE") != "" {
+			cfg.AddDeploymentHook(util.WithAROHCPSidecarContainers())
+		}
 	} else {
 		standAloneConfigSyncer, err := syncCloudConfigStandAlone(c)
 		if err != nil {
@@ -204,6 +209,7 @@ func withCABundleDeploymentHook(c *clients.Clients) (dc.DeploymentHookFunc, []fa
 	return hook, informers
 }
 
+// syncCloudConfigGuest is only called on HyperShift flavors
 func syncCloudConfigGuest(c *clients.Clients) (factory.Controller, error) {
 	// syncs cloud-config from openshif-config namespace to openshift-cluster-csi-drivers namespace
 	srcConfigMap := resourcesynccontroller.ResourceLocation{

--- a/pkg/driver/common/util/util.go
+++ b/pkg/driver/common/util/util.go
@@ -1,0 +1,73 @@
+package util
+
+import (
+	"os"
+
+	opv1 "github.com/openshift/api/operator/v1"
+	dc "github.com/openshift/library-go/pkg/operator/deploymentcontroller"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+)
+
+// WithAROHCPSidecarContainers injects the Microsoft Managed Identity sidecars needed for ARO HCP deployments on the
+// hosted control plane.
+func WithAROHCPSidecarContainers() dc.DeploymentHookFunc {
+	hook := func(_ *opv1.OperatorSpec, deployment *appsv1.Deployment) error {
+		// Add the adapter-init container
+		if deployment.Spec.Template.Spec.InitContainers == nil {
+			deployment.Spec.Template.Spec.InitContainers = []corev1.Container{}
+		}
+		deployment.Spec.Template.Spec.InitContainers = append(deployment.Spec.Template.Spec.InitContainers, adapterInitContainer(os.Getenv("AZURE_ADAPTER_INIT_IMAGE")))
+
+		// Add adapter-server sidecar container
+		deployment.Spec.Template.Spec.Containers = append(deployment.Spec.Template.Spec.Containers,
+			adapterServerContainer(
+				os.Getenv("AZURE_ADAPTER_SERVER_IMAGE"),
+				os.Getenv("ARO_HCP_DISK_MI_CLIENT_ID"),
+				os.Getenv("CLIENT_ID_SECRET"),
+				os.Getenv("TENANT_ID")))
+
+		return nil
+	}
+	return hook
+}
+
+// adapterInitContainer returns the Microsoft adapter-init init container. This container needs the NET_ADMIN permission
+// so the adapter-server sidecar container can intercept the Managed Identity Azure API authentication calls.
+func adapterInitContainer(adapterImage string) corev1.Container {
+	return corev1.Container{
+		Name:            "adapter-init",
+		Image:           adapterImage,
+		ImagePullPolicy: corev1.PullIfNotPresent,
+		SecurityContext: &corev1.SecurityContext{
+			Capabilities: &corev1.Capabilities{
+				Add: []corev1.Capability{
+					"NET_ADMIN",
+				},
+			},
+		}}
+}
+
+// adapterServerContainer returns the Microsoft adapter-server sidecar container. Currently, this container mimics Azure
+// Managed Identity approval and returns an authentication token. The container currently needs a Service Principal to
+// do this. Future versions of this container will be able to take a Managed Identity instead.
+func adapterServerContainer(adapterImage, clientID, clientSecret, tenantID string) corev1.Container {
+	return corev1.Container{Name: "adapter-server",
+		Image:           adapterImage,
+		ImagePullPolicy: corev1.PullIfNotPresent,
+		Args:            []string{"sp"},
+		Env: []corev1.EnvVar{
+			{
+				Name:  "AZURE_CLIENT_ID",
+				Value: clientID,
+			},
+			{
+				Name:  "AZURE_CLIENT_SECRET",
+				Value: clientSecret,
+			},
+			{
+				Name:  "AZURE_TENANT_ID",
+				Value: tenantID,
+			},
+		}}
+}


### PR DESCRIPTION
This commit adds the adapter-init and adapter-server sidecar containers to the azure-disk-csi-controller and azure-file-csi-controller. These containers are needed for ARO HCP to authenticate with managed identities with Azure API.