### PR TITLE
WIP: STOR-1140: Use kubeconfig specific for AWS-EBS CSI diriver controller

### DIFF
--- a/assets/overlays/aws-ebs/generated/hypershift/controller.yaml
+++ b/assets/overlays/aws-ebs/generated/hypershift/controller.yaml
@@ -485,4 +485,4 @@ spec:
       - name: hosted-kubeconfig
         secret:
           defaultMode: 420
-          secretName: service-network-admin-kubeconfig
+          secretName: aws-ebs-csi-driver-controller-kubeconfig

--- a/assets/overlays/aws-ebs/patches/controller_add_hypershift_controller_minter.yaml
+++ b/assets/overlays/aws-ebs/patches/controller_add_hypershift_controller_minter.yaml
@@ -36,4 +36,4 @@ spec:
       - name: hosted-kubeconfig
         secret:
           defaultMode: 420
-          secretName: service-network-admin-kubeconfig
+          secretName: aws-ebs-csi-driver-controller-kubeconfig


### PR DESCRIPTION
Let's use fine-grained kubeconfig `aws-ebs-csi-driver-controller-kubeconfig` instead of omnipotent `service-network-admin-kubeconfig`.

This PR depends on: https://github.com/openshift/hypershift/pull/4790