### PR TITLE
NO-JIRA: Rename efscreate package

### DIFF
--- a/cmd/create-efs-volume/main.go
+++ b/cmd/create-efs-volume/main.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/openshift/library-go/pkg/controller/controllercmd"
 
-	"github.com/openshift/csi-operator/pkg/efscreate"
+	"github.com/openshift/csi-operator/pkg/create-efs-volume"
 	"github.com/openshift/csi-operator/pkg/version"
 )
 
@@ -53,5 +53,5 @@ func NewOperatorCommand() *cobra.Command {
 }
 
 func runOperatorWithCredentialsConfig(ctx context.Context, controllerConfig *controllercmd.ControllerContext) error {
-	return efscreate.RunOperator(ctx, controllerConfig, useLocalAWSCredentials)
+	return create_efs_volume.RunOperator(ctx, controllerConfig, useLocalAWSCredentials)
 }

--- a/pkg/create-efs-volume/create.go
+++ b/pkg/create-efs-volume/create.go
@@ -1,4 +1,4 @@
-package efscreate
+package create_efs_volume
 
 import (
 	"context"

--- a/pkg/create-efs-volume/efs.go
+++ b/pkg/create-efs-volume/efs.go
@@ -1,4 +1,4 @@
-package efscreate
+package create_efs_volume
 
 import (
 	"fmt"


### PR DESCRIPTION
Align with the name of the binary as is done for everything else.

Signed-off-by: Stephen Finucane <stephenfin@redhat.com>
