### PR TITLE
OSASINFRA-3620: Add manila csi

### DIFF
--- a/Dockerfile.openstack-manila
+++ b/Dockerfile.openstack-manila
@@ -1,10 +1,10 @@
 FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.22-openshift-4.18 AS builder
-WORKDIR /go/src/github.com/openshift/csi-driver-manila-operator
-COPY legacy/csi-driver-manila-operator .
+WORKDIR /go/src/github.com/openshift/csi-operator
+COPY . .
 RUN make
 
 FROM registry.ci.openshift.org/ocp/4.18:base-rhel9
-COPY --from=builder /go/src/github.com/openshift/csi-driver-manila-operator/csi-driver-manila-operator /usr/bin/
-ENTRYPOINT ["/usr/bin/csi-driver-manila-operator"]
+COPY --from=builder /go/src/github.com/openshift/csi-operator/bin/openstack-manila-csi-driver-operator /usr/bin/
+ENTRYPOINT ["/usr/bin/openstack-manila-csi-driver-operator"]
 LABEL io.k8s.display-name="OpenShift OpenStack Manila CSI Driver Operator" \
 	io.k8s.description="The OpenStack Manila CSI Driver Operator installs and maintains the OpenStack Manila CSI Driver on a cluster."

--- a/assets/overlays/openstack-manila/base/csidriver.yaml
+++ b/assets/overlays/openstack-manila/base/csidriver.yaml
@@ -1,0 +1,11 @@
+apiVersion: storage.k8s.io/v1
+kind: CSIDriver
+metadata:
+  name: manila.csi.openstack.org
+  annotations:
+      # This CSIDriver is managed by an OCP CSI operator
+      csi.openshift.io/managed: "true"
+spec:
+  attachRequired: false
+  podInfoOnMount: false
+  fsGroupPolicy: None

--- a/assets/overlays/openstack-manila/base/node_nfs.yaml
+++ b/assets/overlays/openstack-manila/base/node_nfs.yaml
@@ -1,0 +1,76 @@
+kind: DaemonSet
+apiVersion: apps/v1
+metadata:
+  name: csi-nodeplugin-nfsplugin
+  namespace: ${NODE_NAMESPACE}
+spec:
+  selector:
+    matchLabels:
+      app: openstack-manila-csi
+      component: nfs-nodeplugin
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 10%
+  template:
+    metadata:
+      labels:
+        app: openstack-manila-csi
+        component: nfs-nodeplugin
+      annotations:
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        openshift.io/required-scc: privileged
+    spec:
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
+      serviceAccount: manila-csi-driver-node-sa
+      priorityClassName: system-node-critical
+      tolerations:
+        - operator: Exists
+      containers:
+        - name: csi-driver
+          securityContext:
+            privileged: true
+          image: ${NFS_DRIVER_IMAGE}
+          resources:
+            requests:
+              memory: 50Mi
+              cpu: 10m
+          args:
+            - --v=${LOG_LEVEL}
+            - "--nodeid=$(NODE_ID)"
+            - "--endpoint=unix://plugin/csi.sock"
+            - "--mount-permissions=0777"
+          env:
+            - name: NODE_ID
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          volumeMounts:
+            - name: plugin-dir
+              mountPath: /plugin
+            - name: pods-mount-dir
+              mountPath: /var/lib/kubelet/pods
+              mountPropagation: Bidirectional
+            - name: etc-selinux
+              mountPath: /etc/selinux
+            - name: sys-fs
+              mountPath: /sys/fs
+          terminationMessagePolicy: FallbackToLogsOnError
+      volumes:
+        - name: plugin-dir
+          hostPath:
+            path: /var/lib/kubelet/plugins/csi-nfsplugin
+            type: DirectoryOrCreate
+        - name: pods-mount-dir
+          hostPath:
+            path: /var/lib/kubelet/pods
+            type: DirectoryOrCreate
+        - name: etc-selinux
+          hostPath:
+            path: /etc/selinux
+            type: DirectoryOrCreate
+        - name: sys-fs
+          hostPath:
+            path: /sys/fs
+            type: Directory

--- a/assets/overlays/openstack-manila/base/volumesnapshotclass.yaml
+++ b/assets/overlays/openstack-manila/base/volumesnapshotclass.yaml
@@ -1,0 +1,10 @@
+apiVersion: snapshot.storage.k8s.io/v1
+kind: VolumeSnapshotClass
+metadata:
+  name: csi-manila-standard
+driver: manila.csi.openstack.org
+deletionPolicy: Delete
+parameters:
+  force-create: "false"
+  csi.storage.k8s.io/snapshotter-secret-name: csi-manila-secrets
+  csi.storage.k8s.io/snapshotter-secret-namespace: ${NODE_NAMESPACE}

--- a/assets/overlays/openstack-manila/generated/standalone/cabundle_cm.yaml
+++ b/assets/overlays/openstack-manila/generated/standalone/cabundle_cm.yaml
@@ -1,0 +1,13 @@
+# Generated file. Do not edit. Update using "make update".
+#
+# Loaded from base/cabundle_cm.yaml
+#
+#
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    config.openshift.io/inject-trusted-cabundle: "true"
+  name: manila-csi-driver-trusted-ca-bundle
+  namespace: ${NAMESPACE}

--- a/assets/overlays/openstack-manila/generated/standalone/controller.yaml
+++ b/assets/overlays/openstack-manila/generated/standalone/controller.yaml
@@ -1,0 +1,320 @@
+# Generated file. Do not edit. Update using "make update".
+#
+# Loaded from base/controller.yaml
+# Applied strategic merge patch overlays/openstack-manila/patches/controller_add_driver.yaml
+# Applied strategic merge patch common/sidecars/controller_driver_kube_rbac_proxy.yaml
+# provisioner.yaml: Loaded from common/sidecars/provisioner.yaml
+# provisioner.yaml: Added arguments [--timeout=120s --feature-gates=Topology=true]
+# Applied strategic merge patch provisioner.yaml
+# resizer.yaml: Loaded from common/sidecars/resizer.yaml
+# Applied strategic merge patch resizer.yaml
+# snapshotter.yaml: Loaded from common/sidecars/snapshotter.yaml
+# Applied strategic merge patch snapshotter.yaml
+# livenessprobe.yaml: Loaded from common/sidecars/livenessprobe.yaml
+# livenessprobe.yaml: Added arguments [--probe-timeout=10s]
+# Applied strategic merge patch livenessprobe.yaml
+# Applied strategic merge patch common/standalone/controller_add_affinity.yaml
+#
+#
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    config.openshift.io/inject-proxy: csi-driver
+    config.openshift.io/inject-proxy-cabundle: csi-driver
+  name: openstack-manila-csi-controllerplugin
+  namespace: ${NAMESPACE}
+spec:
+  selector:
+    matchLabels:
+      app: openstack-manila-csi
+      component: controllerplugin
+  strategy:
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: socket-dir
+        openshift.io/required-scc: restricted-v2
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+      labels:
+        app: openstack-manila-csi
+        component: controllerplugin
+    spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: manila-csi-driver-controller
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+      containers:
+      - args:
+        - --v=${LOG_LEVEL}
+        - --cluster-id=${CLUSTER_ID}
+        - --nodeid=$(NODE_ID)
+        - --endpoint=$(CSI_ENDPOINT)
+        - --drivername=$(DRIVER_NAME)
+        - --share-protocol-selector=$(MANILA_SHARE_PROTO)
+        - --fwdendpoint=$(FWD_CSI_ENDPOINT)
+        env:
+        - name: DRIVER_NAME
+          value: manila.csi.openstack.org
+        - name: NODE_ID
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: CSI_ENDPOINT
+          value: unix:///plugin/csi.sock
+        - name: MANILA_SHARE_PROTO
+          value: NFS
+        - name: FWD_CSI_ENDPOINT
+          value: unix:///plugin/csi-nfs.sock
+        image: ${DRIVER_IMAGE}
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          failureThreshold: 5
+          httpGet:
+            path: /healthz
+            port: healthz
+          initialDelaySeconds: 10
+          periodSeconds: 30
+          timeoutSeconds: 10
+        name: csi-driver
+        ports:
+        - containerPort: 10306
+          name: healthz
+          protocol: TCP
+        resources:
+          requests:
+            cpu: 10m
+            memory: 50Mi
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /plugin
+          name: socket-dir
+        - mountPath: /etc/kubernetes/static-pod-resources/configmaps/cloud-config
+          name: cacert
+      - args:
+        - --nodeid=$(NODE_ID)
+        - --endpoint=unix://plugin/csi-nfs.sock
+        - --mount-permissions=0777
+        env:
+        - name: NODE_ID
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        image: ${NFS_DRIVER_IMAGE}
+        imagePullPolicy: IfNotPresent
+        name: csi-driver-nfs
+        resources:
+          requests:
+            cpu: 10m
+            memory: 50Mi
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /plugin
+          name: socket-dir
+      - args:
+        - --secure-listen-address=0.0.0.0:9202
+        - --upstream=http://127.0.0.1:8202/
+        - --tls-cert-file=/etc/tls/private/tls.crt
+        - --tls-private-key-file=/etc/tls/private/tls.key
+        - --tls-cipher-suites=${TLS_CIPHER_SUITES}
+        - --tls-min-version=${TLS_MIN_VERSION}
+        - --logtostderr=true
+        image: ${KUBE_RBAC_PROXY_IMAGE}
+        imagePullPolicy: IfNotPresent
+        name: kube-rbac-proxy-8202
+        ports:
+        - containerPort: 9202
+          name: driver-m
+          protocol: TCP
+        resources:
+          requests:
+            cpu: 10m
+            memory: 20Mi
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /etc/tls/private
+          name: metrics-serving-cert
+      - args:
+        - --csi-address=/var/lib/csi/sockets/pluginproxy/csi.sock
+        - --http-endpoint=localhost:8203
+        - --leader-election
+        - --leader-election-lease-duration=${LEADER_ELECTION_LEASE_DURATION}
+        - --leader-election-renew-deadline=${LEADER_ELECTION_RENEW_DEADLINE}
+        - --leader-election-retry-period=${LEADER_ELECTION_RETRY_PERIOD}
+        - --leader-election-namespace=${NODE_NAMESPACE}
+        - --v=${LOG_LEVEL}
+        - --timeout=120s
+        - --feature-gates=Topology=true
+        env: []
+        image: ${PROVISIONER_IMAGE}
+        imagePullPolicy: IfNotPresent
+        name: csi-provisioner
+        resources:
+          requests:
+            cpu: 10m
+            memory: 50Mi
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /var/lib/csi/sockets/pluginproxy/
+          name: socket-dir
+      - args:
+        - --secure-listen-address=0.0.0.0:9203
+        - --upstream=http://127.0.0.1:8203/
+        - --tls-cert-file=/etc/tls/private/tls.crt
+        - --tls-private-key-file=/etc/tls/private/tls.key
+        - --tls-cipher-suites=${TLS_CIPHER_SUITES}
+        - --tls-min-version=${TLS_MIN_VERSION}
+        - --logtostderr=true
+        image: ${KUBE_RBAC_PROXY_IMAGE}
+        imagePullPolicy: IfNotPresent
+        name: provisioner-kube-rbac-proxy
+        ports:
+        - containerPort: 9203
+          name: provisioner-m
+          protocol: TCP
+        resources:
+          requests:
+            cpu: 10m
+            memory: 20Mi
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /etc/tls/private
+          name: metrics-serving-cert
+      - args:
+        - --csi-address=/var/lib/csi/sockets/pluginproxy/csi.sock
+        - --http-endpoint=localhost:8204
+        - --leader-election
+        - --leader-election-lease-duration=${LEADER_ELECTION_LEASE_DURATION}
+        - --leader-election-renew-deadline=${LEADER_ELECTION_RENEW_DEADLINE}
+        - --leader-election-retry-period=${LEADER_ELECTION_RETRY_PERIOD}
+        - --leader-election-namespace=${NODE_NAMESPACE}
+        - --v=${LOG_LEVEL}
+        env: []
+        image: ${RESIZER_IMAGE}
+        imagePullPolicy: IfNotPresent
+        name: csi-resizer
+        resources:
+          requests:
+            cpu: 10m
+            memory: 50Mi
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /var/lib/csi/sockets/pluginproxy/
+          name: socket-dir
+      - args:
+        - --secure-listen-address=0.0.0.0:9204
+        - --upstream=http://127.0.0.1:8204/
+        - --tls-cert-file=/etc/tls/private/tls.crt
+        - --tls-private-key-file=/etc/tls/private/tls.key
+        - --tls-cipher-suites=${TLS_CIPHER_SUITES}
+        - --tls-min-version=${TLS_MIN_VERSION}
+        - --logtostderr=true
+        image: ${KUBE_RBAC_PROXY_IMAGE}
+        imagePullPolicy: IfNotPresent
+        name: resizer-kube-rbac-proxy
+        ports:
+        - containerPort: 9204
+          name: resizer-m
+          protocol: TCP
+        resources:
+          requests:
+            cpu: 10m
+            memory: 20Mi
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /etc/tls/private
+          name: metrics-serving-cert
+      - args:
+        - --csi-address=/var/lib/csi/sockets/pluginproxy/csi.sock
+        - --metrics-address=localhost:8205
+        - --leader-election
+        - --leader-election-lease-duration=${LEADER_ELECTION_LEASE_DURATION}
+        - --leader-election-renew-deadline=${LEADER_ELECTION_RENEW_DEADLINE}
+        - --leader-election-retry-period=${LEADER_ELECTION_RETRY_PERIOD}
+        - --leader-election-namespace=${NODE_NAMESPACE}
+        - --v=${LOG_LEVEL}
+        env: []
+        image: ${SNAPSHOTTER_IMAGE}
+        imagePullPolicy: IfNotPresent
+        name: csi-snapshotter
+        resources:
+          requests:
+            cpu: 10m
+            memory: 50Mi
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /var/lib/csi/sockets/pluginproxy/
+          name: socket-dir
+      - args:
+        - --secure-listen-address=0.0.0.0:9205
+        - --upstream=http://127.0.0.1:8205/
+        - --tls-cert-file=/etc/tls/private/tls.crt
+        - --tls-private-key-file=/etc/tls/private/tls.key
+        - --tls-cipher-suites=${TLS_CIPHER_SUITES}
+        - --tls-min-version=${TLS_MIN_VERSION}
+        - --logtostderr=true
+        image: ${KUBE_RBAC_PROXY_IMAGE}
+        imagePullPolicy: IfNotPresent
+        name: snapshotter-kube-rbac-proxy
+        ports:
+        - containerPort: 9205
+          name: snapshotter-m
+          protocol: TCP
+        resources:
+          requests:
+            cpu: 10m
+            memory: 20Mi
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /etc/tls/private
+          name: metrics-serving-cert
+      - args:
+        - --csi-address=/csi/csi.sock
+        - --health-port=10306
+        - --v=${LOG_LEVEL}
+        - --probe-timeout=10s
+        env: []
+        image: ${LIVENESS_PROBE_IMAGE}
+        imagePullPolicy: IfNotPresent
+        name: csi-liveness-probe
+        resources:
+          requests:
+            cpu: 10m
+            memory: 50Mi
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /csi
+          name: socket-dir
+      nodeSelector:
+        node-role.kubernetes.io/master: ""
+      priorityClassName: system-cluster-critical
+      serviceAccount: manila-csi-driver-controller-sa
+      tolerations:
+      - key: CriticalAddonsOnly
+        operator: Exists
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/master
+        operator: Exists
+      volumes:
+      - emptyDir: {}
+        name: socket-dir
+      - name: metrics-serving-cert
+        secret:
+          secretName: manila-csi-driver-controller-metrics-serving-cert
+      - configMap:
+          items:
+          - key: ca-bundle.pem
+            path: ca-bundle.pem
+          name: cloud-provider-config
+          optional: true
+        name: cacert

--- a/assets/overlays/openstack-manila/generated/standalone/controller_pdb.yaml
+++ b/assets/overlays/openstack-manila/generated/standalone/controller_pdb.yaml
@@ -1,0 +1,16 @@
+# Generated file. Do not edit. Update using "make update".
+#
+# Loaded from base/controller_pdb.yaml
+#
+#
+
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: manila-csi-driver-controller-pdb
+  namespace: ${NAMESPACE}
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: manila-csi-driver-controller

--- a/assets/overlays/openstack-manila/generated/standalone/controller_sa.yaml
+++ b/assets/overlays/openstack-manila/generated/standalone/controller_sa.yaml
@@ -1,0 +1,11 @@
+# Generated file. Do not edit. Update using "make update".
+#
+# Loaded from base/controller_sa.yaml
+#
+#
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: manila-csi-driver-controller-sa
+  namespace: ${NAMESPACE}

--- a/assets/overlays/openstack-manila/generated/standalone/csidriver.yaml
+++ b/assets/overlays/openstack-manila/generated/standalone/csidriver.yaml
@@ -1,0 +1,16 @@
+# Generated file. Do not edit. Update using "make update".
+#
+# Loaded from overlays/openstack-manila/base/csidriver.yaml
+#
+#
+
+apiVersion: storage.k8s.io/v1
+kind: CSIDriver
+metadata:
+  annotations:
+    csi.openshift.io/managed: "true"
+  name: manila.csi.openstack.org
+spec:
+  attachRequired: false
+  fsGroupPolicy: None
+  podInfoOnMount: false

--- a/assets/overlays/openstack-manila/generated/standalone/kube_rbac_proxy_binding.yaml
+++ b/assets/overlays/openstack-manila/generated/standalone/kube_rbac_proxy_binding.yaml
@@ -1,0 +1,19 @@
+# Generated file. Do not edit. Update using "make update".
+#
+# Loaded from base/rbac/kube_rbac_proxy_binding.yaml
+#
+#
+# Allow kube-rbac-proxies to create tokenreviews to check Prometheus identity when scraping metrics.
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: openstack-manila-kube-rbac-proxy-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: openstack-manila-kube-rbac-proxy-role
+subjects:
+- kind: ServiceAccount
+  name: manila-csi-driver-controller-sa
+  namespace: ${NAMESPACE}

--- a/assets/overlays/openstack-manila/generated/standalone/kube_rbac_proxy_role.yaml
+++ b/assets/overlays/openstack-manila/generated/standalone/kube_rbac_proxy_role.yaml
@@ -1,0 +1,18 @@
+# Generated file. Do not edit. Update using "make update".
+#
+# Loaded from base/rbac/kube_rbac_proxy_role.yaml
+#
+#
+# Allow kube-rbac-proxies to create tokenreviews to check Prometheus identity when scraping metrics.
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: openstack-manila-kube-rbac-proxy-role
+rules:
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create

--- a/assets/overlays/openstack-manila/generated/standalone/lease_leader_election_binding.yaml
+++ b/assets/overlays/openstack-manila/generated/standalone/lease_leader_election_binding.yaml
@@ -1,0 +1,20 @@
+# Generated file. Do not edit. Update using "make update".
+#
+# Loaded from base/rbac/lease_leader_election_binding.yaml
+#
+#
+# Grant controller access to leases
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: manila-csi-driver-lease-leader-election
+  namespace: ${NODE_NAMESPACE}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: manila-csi-driver-lease-leader-election
+subjects:
+- kind: ServiceAccount
+  name: manila-csi-driver-controller-sa
+  namespace: ${NODE_NAMESPACE}

--- a/assets/overlays/openstack-manila/generated/standalone/lease_leader_election_role.yaml
+++ b/assets/overlays/openstack-manila/generated/standalone/lease_leader_election_role.yaml
@@ -1,0 +1,24 @@
+# Generated file. Do not edit. Update using "make update".
+#
+# Loaded from base/rbac/lease_leader_election_role.yaml
+#
+#
+# Role for electing leader by the operator
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: manila-csi-driver-lease-leader-election
+  namespace: ${NODE_NAMESPACE}
+rules:
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - watch
+  - list
+  - delete
+  - update
+  - create

--- a/assets/overlays/openstack-manila/generated/standalone/main_provisioner_binding.yaml
+++ b/assets/overlays/openstack-manila/generated/standalone/main_provisioner_binding.yaml
@@ -1,0 +1,19 @@
+# Generated file. Do not edit. Update using "make update".
+#
+# Loaded from base/rbac/main_provisioner_binding.yaml
+#   because it's needed by controller sidecar common/sidecars/provisioner.yaml
+#
+#
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: openstack-manila-csi-main-provisioner-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: openshift-csi-main-provisioner-role
+subjects:
+- kind: ServiceAccount
+  name: manila-csi-driver-controller-sa
+  namespace: ${NODE_NAMESPACE}

--- a/assets/overlays/openstack-manila/generated/standalone/main_resizer_binding.yaml
+++ b/assets/overlays/openstack-manila/generated/standalone/main_resizer_binding.yaml
@@ -1,0 +1,19 @@
+# Generated file. Do not edit. Update using "make update".
+#
+# Loaded from base/rbac/main_resizer_binding.yaml
+#   because it's needed by controller sidecar common/sidecars/resizer.yaml
+#
+#
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: openstack-manila-csi-main-resizer-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: openshift-csi-main-resizer-role
+subjects:
+- kind: ServiceAccount
+  name: manila-csi-driver-controller-sa
+  namespace: ${NODE_NAMESPACE}

--- a/assets/overlays/openstack-manila/generated/standalone/main_snapshotter_binding.yaml
+++ b/assets/overlays/openstack-manila/generated/standalone/main_snapshotter_binding.yaml
@@ -1,0 +1,19 @@
+# Generated file. Do not edit. Update using "make update".
+#
+# Loaded from base/rbac/main_snapshotter_binding.yaml
+#   because it's needed by controller sidecar common/sidecars/snapshotter.yaml
+#
+#
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: openstack-manila-csi-main-snapshotter-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: openshift-csi-main-snapshotter-role
+subjects:
+- kind: ServiceAccount
+  name: manila-csi-driver-controller-sa
+  namespace: ${NODE_NAMESPACE}

--- a/assets/overlays/openstack-manila/generated/standalone/manifests.yaml
+++ b/assets/overlays/openstack-manila/generated/standalone/manifests.yaml
@@ -1,0 +1,26 @@
+controllerStaticAssetNames:
+- cabundle_cm.yaml
+- controller.yaml
+- controller_pdb.yaml
+- controller_sa.yaml
+- kube_rbac_proxy_binding.yaml
+- kube_rbac_proxy_role.yaml
+- prometheus_binding.yaml
+- prometheus_role.yaml
+- service.yaml
+- servicemonitor.yaml
+guestStaticAssetNames:
+- csidriver.yaml
+- lease_leader_election_binding.yaml
+- lease_leader_election_role.yaml
+- main_provisioner_binding.yaml
+- main_resizer_binding.yaml
+- main_snapshotter_binding.yaml
+- node.yaml
+- node_nfs.yaml
+- node_privileged_binding.yaml
+- node_sa.yaml
+- privileged_role.yaml
+- storageclass_reader_resizer_binding.yaml
+- volumesnapshot_reader_provisioner_binding.yaml
+- volumesnapshotclass.yaml

--- a/assets/overlays/openstack-manila/generated/standalone/node.yaml
+++ b/assets/overlays/openstack-manila/generated/standalone/node.yaml
@@ -1,0 +1,201 @@
+# Generated file. Do not edit. Update using "make update".
+#
+# Loaded from base/node.yaml
+# Applied strategic merge patch overlays/openstack-manila/patches/node_add_driver.yaml
+# livenessprobe.yaml: Loaded from common/sidecars/livenessprobe.yaml
+# livenessprobe.yaml: Added arguments [--probe-timeout=10s]
+# Applied strategic merge patch livenessprobe.yaml
+# node_driver_registrar.yaml: Loaded from common/sidecars/node_driver_registrar.yaml
+# Applied strategic merge patch node_driver_registrar.yaml
+#
+#
+
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  annotations:
+    config.openshift.io/inject-proxy: csi-driver
+    config.openshift.io/inject-proxy-cabundle: csi-driver
+  name: openstack-manila-csi-nodeplugin
+  namespace: ${NODE_NAMESPACE}
+spec:
+  selector:
+    matchLabels:
+      app: openstack-manila-csi
+      component: nodeplugin
+  template:
+    metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/enable-ds-eviction: "false"
+        openshift.io/required-scc: privileged
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+      labels:
+        app: openstack-manila-csi
+        component: nodeplugin
+    spec:
+      containers:
+      - args:
+        - --v=${LOG_LEVEL}
+        - --nodeid=$(NODE_ID)
+        - --endpoint=$(CSI_ENDPOINT)
+        - --drivername=$(DRIVER_NAME)
+        - --share-protocol-selector=$(MANILA_SHARE_PROTO)
+        - --fwdendpoint=$(FWD_CSI_ENDPOINT)
+        env:
+        - name: DRIVER_NAME
+          value: manila.csi.openstack.org
+        - name: NODE_ID
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: CSI_ENDPOINT
+          value: unix:///var/lib/kubelet/plugins/manila.csi.openstack.org/csi.sock
+        - name: FWD_CSI_ENDPOINT
+          value: unix:///var/lib/kubelet/plugins/csi-nfsplugin/csi.sock
+        - name: MANILA_SHARE_PROTO
+          value: NFS
+        image: ${DRIVER_IMAGE}
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          failureThreshold: 5
+          httpGet:
+            path: /healthz
+            port: healthz
+          initialDelaySeconds: 10
+          periodSeconds: 30
+          timeoutSeconds: 10
+        name: csi-driver
+        ports:
+        - containerPort: 10305
+          name: healthz
+          protocol: TCP
+        resources:
+          requests:
+            cpu: 10m
+            memory: 50Mi
+        securityContext:
+          privileged: true
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /var/lib/kubelet/plugins/manila.csi.openstack.org
+          name: plugin-dir
+        - mountPath: /var/lib/kubelet/plugins/csi-nfsplugin
+          name: fwd-plugin-dir
+        - mountPath: /etc/kubernetes/static-pod-resources/configmaps/cloud-config
+          name: cacert
+        - mountPath: /etc/selinux
+          name: etc-selinux
+        - mountPath: /sys/fs
+          name: sys-fs
+      - args:
+        - --csi-address=/csi/csi.sock
+        - --health-port=10305
+        - --v=${LOG_LEVEL}
+        - --probe-timeout=10s
+        env: []
+        image: ${LIVENESS_PROBE_IMAGE}
+        imagePullPolicy: IfNotPresent
+        name: csi-liveness-probe
+        resources:
+          requests:
+            cpu: 10m
+            memory: 50Mi
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /csi
+          name: socket-dir
+      - args:
+        - --csi-address=/csi/csi.sock
+        - --kubelet-registration-path=/var/lib/kubelet/plugins/manila.csi.openstack.org/csi.sock
+        - --http-endpoint=:10307
+        - --v=${LOG_LEVEL}
+        env: []
+        image: ${NODE_DRIVER_REGISTRAR_IMAGE}
+        imagePullPolicy: IfNotPresent
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - /bin/sh
+              - -c
+              - rm -rf /registration/manila.csi.openstack.org-reg.sock /csi/csi.sock
+        livenessProbe:
+          failureThreshold: 5
+          httpGet:
+            path: /healthz
+            port: rhealthz
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          timeoutSeconds: 3
+        name: csi-node-driver-registrar
+        ports:
+        - containerPort: 10307
+          name: rhealthz
+          protocol: TCP
+        resources:
+          requests:
+            cpu: 10m
+            memory: 50Mi
+        securityContext:
+          privileged: true
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /csi
+          name: socket-dir
+        - mountPath: /registration
+          name: registration-dir
+      dnsPolicy: ClusterFirstWithHostNet
+      hostNetwork: true
+      nodeSelector:
+        kubernetes.io/os: linux
+      priorityClassName: system-node-critical
+      serviceAccount: manila-csi-driver-node-sa
+      tolerations:
+      - operator: Exists
+      volumes:
+      - hostPath:
+          path: /var/lib/kubelet
+          type: Directory
+        name: kubelet-dir
+      - hostPath:
+          path: /var/lib/kubelet/plugins/manila.csi.openstack.org/
+          type: DirectoryOrCreate
+        name: socket-dir
+      - hostPath:
+          path: /var/lib/kubelet/plugins_registry/
+          type: Directory
+        name: registration-dir
+      - hostPath:
+          path: /dev
+          type: Directory
+        name: device-dir
+      - hostPath:
+          path: /etc/selinux
+          type: DirectoryOrCreate
+        name: etc-selinux
+      - hostPath:
+          path: /sys/fs
+          type: Directory
+        name: sys-fs
+      - name: metrics-serving-cert
+        secret:
+          secretName: manila-csi-driver-node-metrics-serving-cert
+      - hostPath:
+          path: /var/lib/kubelet/plugins/manila.csi.openstack.org
+          type: DirectoryOrCreate
+        name: plugin-dir
+      - hostPath:
+          path: /var/lib/kubelet/plugins/csi-nfsplugin
+          type: DirectoryOrCreate
+        name: fwd-plugin-dir
+      - configMap:
+          items:
+          - key: ca-bundle.pem
+            path: ca-bundle.pem
+          name: cloud-provider-config
+          optional: true
+        name: cacert
+  updateStrategy:
+    rollingUpdate:
+      maxUnavailable: 10%
+    type: RollingUpdate

--- a/assets/overlays/openstack-manila/generated/standalone/node_nfs.yaml
+++ b/assets/overlays/openstack-manila/generated/standalone/node_nfs.yaml
@@ -1,0 +1,82 @@
+# Generated file. Do not edit. Update using "make update".
+#
+# Loaded from overlays/openstack-manila/base/node_nfs.yaml
+#
+#
+
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: csi-nodeplugin-nfsplugin
+  namespace: ${NODE_NAMESPACE}
+spec:
+  selector:
+    matchLabels:
+      app: openstack-manila-csi
+      component: nfs-nodeplugin
+  template:
+    metadata:
+      annotations:
+        openshift.io/required-scc: privileged
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+      labels:
+        app: openstack-manila-csi
+        component: nfs-nodeplugin
+    spec:
+      containers:
+      - args:
+        - --v=${LOG_LEVEL}
+        - --nodeid=$(NODE_ID)
+        - --endpoint=unix://plugin/csi.sock
+        - --mount-permissions=0777
+        env:
+        - name: NODE_ID
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        image: ${NFS_DRIVER_IMAGE}
+        name: csi-driver
+        resources:
+          requests:
+            cpu: 10m
+            memory: 50Mi
+        securityContext:
+          privileged: true
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /plugin
+          name: plugin-dir
+        - mountPath: /var/lib/kubelet/pods
+          mountPropagation: Bidirectional
+          name: pods-mount-dir
+        - mountPath: /etc/selinux
+          name: etc-selinux
+        - mountPath: /sys/fs
+          name: sys-fs
+      dnsPolicy: ClusterFirstWithHostNet
+      hostNetwork: true
+      priorityClassName: system-node-critical
+      serviceAccount: manila-csi-driver-node-sa
+      tolerations:
+      - operator: Exists
+      volumes:
+      - hostPath:
+          path: /var/lib/kubelet/plugins/csi-nfsplugin
+          type: DirectoryOrCreate
+        name: plugin-dir
+      - hostPath:
+          path: /var/lib/kubelet/pods
+          type: DirectoryOrCreate
+        name: pods-mount-dir
+      - hostPath:
+          path: /etc/selinux
+          type: DirectoryOrCreate
+        name: etc-selinux
+      - hostPath:
+          path: /sys/fs
+          type: Directory
+        name: sys-fs
+  updateStrategy:
+    rollingUpdate:
+      maxUnavailable: 10%
+    type: RollingUpdate

--- a/assets/overlays/openstack-manila/generated/standalone/node_privileged_binding.yaml
+++ b/assets/overlays/openstack-manila/generated/standalone/node_privileged_binding.yaml
@@ -1,0 +1,18 @@
+# Generated file. Do not edit. Update using "make update".
+#
+# Loaded from base/rbac/node_privileged_binding.yaml
+#
+#
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: openstack-manila-node-privileged-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: openstack-manila-privileged-role
+subjects:
+- kind: ServiceAccount
+  name: manila-csi-driver-node-sa
+  namespace: ${NODE_NAMESPACE}

--- a/assets/overlays/openstack-manila/generated/standalone/node_sa.yaml
+++ b/assets/overlays/openstack-manila/generated/standalone/node_sa.yaml
@@ -1,0 +1,11 @@
+# Generated file. Do not edit. Update using "make update".
+#
+# Loaded from base/node_sa.yaml
+#
+#
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: manila-csi-driver-node-sa
+  namespace: ${NODE_NAMESPACE}

--- a/assets/overlays/openstack-manila/generated/standalone/privileged_role.yaml
+++ b/assets/overlays/openstack-manila/generated/standalone/privileged_role.yaml
@@ -1,0 +1,20 @@
+# Generated file. Do not edit. Update using "make update".
+#
+# Loaded from base/rbac/privileged_role.yaml
+#
+#
+# TODO: create custom SCC with things that the AWS CSI driver needs
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: openstack-manila-privileged-role
+rules:
+- apiGroups:
+  - security.openshift.io
+  resourceNames:
+  - privileged
+  resources:
+  - securitycontextconstraints
+  verbs:
+  - use

--- a/assets/overlays/openstack-manila/generated/standalone/prometheus_binding.yaml
+++ b/assets/overlays/openstack-manila/generated/standalone/prometheus_binding.yaml
@@ -1,0 +1,20 @@
+# Generated file. Do not edit. Update using "make update".
+#
+# Loaded from base/rbac/prometheus_binding.yaml
+#
+#
+# Grant cluster-monitoring access to the operator metrics service
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: manila-csi-driver-prometheus
+  namespace: ${NODE_NAMESPACE}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: manila-csi-driver-prometheus
+subjects:
+- kind: ServiceAccount
+  name: prometheus-k8s
+  namespace: openshift-monitoring

--- a/assets/overlays/openstack-manila/generated/standalone/prometheus_role.yaml
+++ b/assets/overlays/openstack-manila/generated/standalone/prometheus_role.yaml
@@ -1,0 +1,23 @@
+# Generated file. Do not edit. Update using "make update".
+#
+# Loaded from base/rbac/prometheus_role.yaml
+#
+#
+# Role for accessing metrics exposed by the operator
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: manila-csi-driver-prometheus
+  namespace: ${NODE_NAMESPACE}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - services
+  - endpoints
+  - pods
+  verbs:
+  - get
+  - list
+  - watch

--- a/assets/overlays/openstack-manila/generated/standalone/service.yaml
+++ b/assets/overlays/openstack-manila/generated/standalone/service.yaml
@@ -1,0 +1,41 @@
+# Generated file. Do not edit. Update using "make update".
+#
+# Loaded from base/controller_metrics_service.yaml
+# Applied strategic merge patch common/metrics/service_add_port.yaml
+# Applied strategic merge patch common/metrics/service_add_port.yaml
+# Applied strategic merge patch common/metrics/service_add_port.yaml
+# Applied strategic merge patch common/metrics/service_add_port.yaml
+#
+#
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    service.beta.openshift.io/serving-cert-secret-name: manila-csi-driver-controller-metrics-serving-cert
+  labels:
+    app: manila-csi-driver-controller-metrics
+  name: manila-csi-driver-controller-metrics
+  namespace: ${NAMESPACE}
+spec:
+  ports:
+  - name: provisioner-m
+    port: 9203
+    protocol: TCP
+    targetPort: provisioner-m
+  - name: resizer-m
+    port: 9204
+    protocol: TCP
+    targetPort: resizer-m
+  - name: snapshotter-m
+    port: 9205
+    protocol: TCP
+    targetPort: snapshotter-m
+  - name: driver-m
+    port: 9202
+    protocol: TCP
+    targetPort: driver-m
+  selector:
+    app: manila-csi-driver-controller
+  sessionAffinity: None
+  type: ClusterIP

--- a/assets/overlays/openstack-manila/generated/standalone/servicemonitor.yaml
+++ b/assets/overlays/openstack-manila/generated/standalone/servicemonitor.yaml
@@ -1,0 +1,53 @@
+# Generated file. Do not edit. Update using "make update".
+#
+# Loaded from base/controller_metrics_servicemonitor.yaml
+# Applied JSON patch common/metrics/service_monitor_add_port.yaml.patch
+# Applied JSON patch common/metrics/service_monitor_add_port.yaml.patch
+# Applied JSON patch common/metrics/service_monitor_add_port.yaml.patch
+# Applied JSON patch common/metrics/service_monitor_add_port.yaml.patch
+#
+#
+
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: manila-csi-driver-controller-monitor
+  namespace: ${NAMESPACE}
+spec:
+  endpoints:
+  - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+    interval: 30s
+    path: /metrics
+    port: provisioner-m
+    scheme: https
+    tlsConfig:
+      caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
+      serverName: manila-csi-driver-controller-metrics.${NAMESPACE}.svc
+  - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+    interval: 30s
+    path: /metrics
+    port: resizer-m
+    scheme: https
+    tlsConfig:
+      caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
+      serverName: manila-csi-driver-controller-metrics.${NAMESPACE}.svc
+  - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+    interval: 30s
+    path: /metrics
+    port: snapshotter-m
+    scheme: https
+    tlsConfig:
+      caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
+      serverName: manila-csi-driver-controller-metrics.${NAMESPACE}.svc
+  - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+    interval: 30s
+    path: /metrics
+    port: driver-m
+    scheme: https
+    tlsConfig:
+      caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
+      serverName: manila-csi-driver-controller-metrics.${NAMESPACE}.svc
+  jobLabel: component
+  selector:
+    matchLabels:
+      app: manila-csi-driver-controller-metrics

--- a/assets/overlays/openstack-manila/generated/standalone/storageclass_reader_resizer_binding.yaml
+++ b/assets/overlays/openstack-manila/generated/standalone/storageclass_reader_resizer_binding.yaml
@@ -1,0 +1,19 @@
+# Generated file. Do not edit. Update using "make update".
+#
+# Loaded from base/rbac/storageclass_reader_resizer_binding.yaml
+#   because it's needed by controller sidecar common/sidecars/resizer.yaml
+#
+#
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: openstack-manila-csi-storageclass-reader-resizer-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: openshift-csi-resizer-storageclass-reader-role
+subjects:
+- kind: ServiceAccount
+  name: manila-csi-driver-controller-sa
+  namespace: ${NODE_NAMESPACE}

--- a/assets/overlays/openstack-manila/generated/standalone/volumesnapshot_reader_provisioner_binding.yaml
+++ b/assets/overlays/openstack-manila/generated/standalone/volumesnapshot_reader_provisioner_binding.yaml
@@ -1,0 +1,19 @@
+# Generated file. Do not edit. Update using "make update".
+#
+# Loaded from base/rbac/volumesnapshot_reader_provisioner_binding.yaml
+#   because it's needed by controller sidecar common/sidecars/provisioner.yaml
+#
+#
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: openstack-manila-csi-volumesnapshot-reader-provisioner-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: openshift-csi-provisioner-volumesnapshot-reader-role
+subjects:
+- kind: ServiceAccount
+  name: manila-csi-driver-controller-sa
+  namespace: ${NODE_NAMESPACE}

--- a/assets/overlays/openstack-manila/generated/standalone/volumesnapshotclass.yaml
+++ b/assets/overlays/openstack-manila/generated/standalone/volumesnapshotclass.yaml
@@ -1,0 +1,16 @@
+# Generated file. Do not edit. Update using "make update".
+#
+# Loaded from overlays/openstack-manila/base/volumesnapshotclass.yaml
+#
+#
+
+apiVersion: snapshot.storage.k8s.io/v1
+deletionPolicy: Delete
+driver: manila.csi.openstack.org
+kind: VolumeSnapshotClass
+metadata:
+  name: csi-manila-standard
+parameters:
+  csi.storage.k8s.io/snapshotter-secret-name: csi-manila-secrets
+  csi.storage.k8s.io/snapshotter-secret-namespace: ${NODE_NAMESPACE}
+  force-create: "false"

--- a/assets/overlays/openstack-manila/patches/controller_add_driver.yaml
+++ b/assets/overlays/openstack-manila/patches/controller_add_driver.yaml
@@ -1,0 +1,129 @@
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  annotations:
+    config.openshift.io/inject-proxy: csi-driver
+    config.openshift.io/inject-proxy-cabundle: csi-driver
+  name: openstack-manila-csi-controllerplugin
+spec:
+  selector:
+    matchLabels:
+      app: openstack-manila-csi
+      component: controllerplugin
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+      maxSurge: 0
+  template:
+    metadata:
+      labels:
+        app: openstack-manila-csi
+        component: controllerplugin
+      annotations:
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        openshift.io/required-scc: restricted-v2
+    spec:
+      nodeSelector:
+        node-role.kubernetes.io/master: ""
+      priorityClassName: system-cluster-critical
+      tolerations:
+        - key: CriticalAddonsOnly
+          operator: Exists
+        - key: node-role.kubernetes.io/master
+          operator: Exists
+          effect: "NoSchedule"
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app: openstack-manila-csi
+                    component: controllerplugin
+                topologyKey: kubernetes.io/hostname
+      containers:
+        - name: csi-driver
+          image: ${DRIVER_IMAGE}
+          imagePullPolicy: IfNotPresent
+          args:
+            - --v=${LOG_LEVEL}
+            - --cluster-id=${CLUSTER_ID}
+            - --nodeid=$(NODE_ID)
+            - --endpoint=$(CSI_ENDPOINT)
+            - --drivername=$(DRIVER_NAME)
+            - --share-protocol-selector=$(MANILA_SHARE_PROTO)
+            - --fwdendpoint=$(FWD_CSI_ENDPOINT)
+          env:
+            - name: DRIVER_NAME
+              value: manila.csi.openstack.org
+            - name: NODE_ID
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: CSI_ENDPOINT
+              value: unix:///plugin/csi.sock
+            - name: MANILA_SHARE_PROTO
+              value: NFS
+            - name: FWD_CSI_ENDPOINT
+              value: unix:///plugin/csi-nfs.sock
+          ports:
+            - name: healthz
+              # Due to hostNetwork, this port is open on a node!
+              containerPort: 10306
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: healthz
+            initialDelaySeconds: 10
+            timeoutSeconds: 10
+            periodSeconds: 30
+            failureThreshold: 5
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /plugin
+            - name: cacert
+              mountPath: /etc/kubernetes/static-pod-resources/configmaps/cloud-config
+          resources:
+            requests:
+              cpu: 10m
+              memory: 50Mi
+          terminationMessagePolicy: FallbackToLogsOnError
+        # TODO: fix manila CSI driver not to require NFS driver socket!
+        - name: csi-driver-nfs
+          image: ${NFS_DRIVER_IMAGE}
+          imagePullPolicy: IfNotPresent
+          args:
+            - "--nodeid=$(NODE_ID)"
+            - "--endpoint=unix://plugin/csi-nfs.sock"
+            - "--mount-permissions=0777"
+          env:
+            - name: NODE_ID
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /plugin
+          resources:
+            requests:
+              cpu: 10m
+              memory: 50Mi
+          terminationMessagePolicy: FallbackToLogsOnError
+      volumes:
+        - name: socket-dir
+          emptyDir: {}
+        - name: cacert
+          # If present, extract ca-bundle.pem to
+          # /etc/kubernetes/static-pod-resources/configmaps/cloud-config
+          # Let the pod start when the ConfigMap does not exist or the certificate
+          # is not preset there. The certificate file will be created once the
+          # ConfigMap is created / the cerificate is added to it.
+          configMap:
+            name: cloud-provider-config
+            items:
+            - key: ca-bundle.pem
+              path: ca-bundle.pem
+            optional: true

--- a/assets/overlays/openstack-manila/patches/node_add_driver.yaml
+++ b/assets/overlays/openstack-manila/patches/node_add_driver.yaml
@@ -1,0 +1,119 @@
+kind: DaemonSet
+apiVersion: apps/v1
+metadata:
+  annotations:
+    config.openshift.io/inject-proxy: csi-driver
+    config.openshift.io/inject-proxy-cabundle: csi-driver
+  name: openstack-manila-csi-nodeplugin
+spec:
+  selector:
+    matchLabels:
+      app: openstack-manila-csi
+      component: nodeplugin
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 10%
+  template:
+    metadata:
+      labels:
+        app: openstack-manila-csi
+        component: nodeplugin
+      annotations:
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        # This annotation prevents eviction from the cluster-autoscaler
+        cluster-autoscaler.kubernetes.io/enable-ds-eviction: "false"
+        openshift.io/required-scc: privileged
+    spec:
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
+      priorityClassName: system-node-critical
+      tolerations:
+        - operator: Exists
+      containers:
+        - name: csi-driver
+          securityContext:
+            privileged: true
+          image: ${DRIVER_IMAGE}
+          imagePullPolicy: IfNotPresent
+          args:
+            - --v=${LOG_LEVEL}
+            - "--nodeid=$(NODE_ID)"
+            - "--endpoint=$(CSI_ENDPOINT)"
+            - "--drivername=$(DRIVER_NAME)"
+            - "--share-protocol-selector=$(MANILA_SHARE_PROTO)"
+            - "--fwdendpoint=$(FWD_CSI_ENDPOINT)"
+          env:
+            - name: DRIVER_NAME
+              value: manila.csi.openstack.org
+            - name: NODE_ID
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: CSI_ENDPOINT
+              value: unix:///var/lib/kubelet/plugins/manila.csi.openstack.org/csi.sock
+            - name: FWD_CSI_ENDPOINT
+              value: unix:///var/lib/kubelet/plugins/csi-nfsplugin/csi.sock
+            - name: MANILA_SHARE_PROTO
+              value: NFS
+          volumeMounts:
+            - name: plugin-dir
+              mountPath: /var/lib/kubelet/plugins/manila.csi.openstack.org
+            - name: fwd-plugin-dir
+              mountPath: /var/lib/kubelet/plugins/csi-nfsplugin
+            - name: cacert
+              mountPath: /etc/kubernetes/static-pod-resources/configmaps/cloud-config
+            - name: etc-selinux
+              mountPath: /etc/selinux
+            - name: sys-fs
+              mountPath: /sys/fs
+          ports:
+            - name: healthz
+              # Due to hostNetwork, this port is open on all nodes!
+              containerPort: 10305
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: healthz
+            initialDelaySeconds: 10
+            timeoutSeconds: 10
+            periodSeconds: 30
+            failureThreshold: 5
+          resources:
+            requests:
+              cpu: 10m
+              memory: 50Mi
+          terminationMessagePolicy: FallbackToLogsOnError
+      volumes:
+        - name: registration-dir
+          hostPath:
+            path: /var/lib/kubelet/plugins_registry/
+            type: Directory
+        - name: plugin-dir
+          hostPath:
+            path: /var/lib/kubelet/plugins/manila.csi.openstack.org
+            type: DirectoryOrCreate
+        - name: fwd-plugin-dir
+          hostPath:
+            path: /var/lib/kubelet/plugins/csi-nfsplugin
+            type: DirectoryOrCreate
+        - name: cacert
+          # Extract ca-bundle.pem to /etc/kubernetes/static-pod-resources/configmaps/cloud-config if present.
+          # Let the pod start when the ConfigMap does not exist or the certificate
+          # is not preset there. The certificate file will be created once the
+          # ConfigMap is created / the cerificate is added to it.
+          configMap:
+            name: cloud-provider-config
+            items:
+            - key: ca-bundle.pem
+              path: ca-bundle.pem
+            optional: true
+        - name: etc-selinux
+          hostPath:
+            path: /etc/selinux
+            type: DirectoryOrCreate
+        - name: sys-fs
+          hostPath:
+            path: /sys/fs
+            type: Directory

--- a/cmd/generator/main.go
+++ b/cmd/generator/main.go
@@ -11,6 +11,7 @@ import (
 	azure_disk "github.com/openshift/csi-operator/pkg/driver/azure-disk"
 	azure_file "github.com/openshift/csi-operator/pkg/driver/azure-file"
 	openstack_cinder "github.com/openshift/csi-operator/pkg/driver/openstack-cinder"
+	openstack_manila "github.com/openshift/csi-operator/pkg/driver/openstack-manila"
 	samba "github.com/openshift/csi-operator/pkg/driver/samba"
 	"github.com/openshift/csi-operator/pkg/generator"
 	"k8s.io/klog/v2"
@@ -63,6 +64,7 @@ func collectConfigs() []*generator.CSIDriverGeneratorConfig {
 		azure_disk.GetAzureDiskGeneratorConfig(),
 		azure_file.GetAzureFileGeneratorConfig(),
 		openstack_cinder.GetOpenStackCinderGeneratorConfig(),
+		openstack_manila.GetOpenStackManilaGeneratorConfig(),
 		samba.GetSambaGeneratorConfig(),
 	}
 }

--- a/cmd/openstack-manila-csi-driver-operator/main.go
+++ b/cmd/openstack-manila-csi-driver-operator/main.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"context"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"k8s.io/component-base/cli"
+
+	"github.com/openshift/library-go/pkg/controller/controllercmd"
+
+	openstack_manila "github.com/openshift/csi-operator/pkg/driver/openstack-manila"
+	"github.com/openshift/csi-operator/pkg/operator"
+	"github.com/openshift/csi-operator/pkg/version"
+)
+
+var guestKubeconfig *string
+
+func main() {
+	command := NewOperatorCommand()
+	code := cli.Run(command)
+	os.Exit(code)
+}
+
+func NewOperatorCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "openstack-manila-csi-driver-operator",
+		Short: "OpenShift Manila CSI Driver Operator",
+		Run: func(cmd *cobra.Command, args []string) {
+			cmd.Help()
+			os.Exit(1)
+		},
+	}
+
+	ctrlCmd := controllercmd.NewControllerCommandConfig(
+		"openstack-manila-csi-driver-operator",
+		version.Get(),
+		runCSIDriverOperator,
+	).NewCommand()
+
+	guestKubeconfig = ctrlCmd.Flags().String("guest-kubeconfig", "", "Path to the guest kubeconfig file. This flag enables hypershift integration.")
+
+	ctrlCmd.Use = "start"
+	ctrlCmd.Short = "Start the Manila CSI Driver Operator"
+
+	cmd.AddCommand(ctrlCmd)
+
+	return cmd
+}
+
+func runCSIDriverOperator(ctx context.Context, controllerConfig *controllercmd.ControllerContext) error {
+	opConfig := openstack_manila.GetOpenStackManilaOperatorConfig()
+	return operator.RunOperator(ctx, controllerConfig, *guestKubeconfig, opConfig)
+}

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/aws/aws-sdk-go v1.52.6
 	github.com/evanphx/json-patch v5.9.0+incompatible
 	github.com/google/go-cmp v0.6.0
-	github.com/gophercloud/gophercloud/v2 v2.1.0
+	github.com/gophercloud/gophercloud/v2 v2.1.1
 	github.com/gophercloud/utils/v2 v2.0.0-20240812072210-8ce1fc0f2894
 	github.com/kubernetes-csi/external-snapshotter/client/v6 v6.3.0
 	github.com/onsi/gomega v1.33.1

--- a/go.sum
+++ b/go.sum
@@ -95,8 +95,8 @@ github.com/google/pprof v0.0.0-20240711041743-f6c9dda6c6da h1:xRmpO92tb8y+Z85iUO
 github.com/google/pprof v0.0.0-20240711041743-f6c9dda6c6da/go.mod h1:K1liHPHnj73Fdn/EKuT8nrFqBihUSKXoLYU0BuatOYo=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-github.com/gophercloud/gophercloud/v2 v2.1.0 h1:91p6c+uMckXyx39nSIYjDirDBnPVFQq0q1njLNPX+NY=
-github.com/gophercloud/gophercloud/v2 v2.1.0/go.mod h1:f2hMRC7Kakbv5vM7wSGHrIPZh6JZR60GVHryJlF/K44=
+github.com/gophercloud/gophercloud/v2 v2.1.1 h1:KUeVTUoq6um/CijR+hl1JRZ35SXRY62LiYUbgp4qqKw=
+github.com/gophercloud/gophercloud/v2 v2.1.1/go.mod h1:f2hMRC7Kakbv5vM7wSGHrIPZh6JZR60GVHryJlF/K44=
 github.com/gophercloud/utils/v2 v2.0.0-20240812072210-8ce1fc0f2894 h1:KgYK/Mf71IdN7+sq2cVmY8Jtumi26GxahN7nlV0ETBQ=
 github.com/gophercloud/utils/v2 v2.0.0-20240812072210-8ce1fc0f2894/go.mod h1:IXS9MKM8YBsr9G2xhnMAuiCOaNxmghQFQGi1p68+No0=
 github.com/gorilla/websocket v1.5.1 h1:gmztn0JnHVt9JZquRuzLw3g4wouNVzKL15iLr/zn/QY=

--- a/pkg/clients/builder.go
+++ b/pkg/clients/builder.go
@@ -42,16 +42,14 @@ type Builder struct {
 }
 
 // NewBuilder creates a new Builder.
-func NewBuilder(userAgent string, csiDriverName, guestNamespace string, controllerConfig *controllercmd.ControllerContext, resync time.Duration) *Builder {
+func NewBuilder(userAgent string, csiDriverName, guestNamespace string, controlPlaneNamespaces []string, controllerConfig *controllercmd.ControllerContext, resync time.Duration) *Builder {
 	return &Builder{
-		userAgwent:       userAgent,
-		csiDriverName:    csiDriverName,
-		guestNamespace:   guestNamespace,
-		resync:           resync,
-		controllerConfig: controllerConfig,
-		controlPlaneNamespaces: []string{
-			controllerConfig.OperatorNamespace,
-		},
+		userAgwent:             userAgent,
+		csiDriverName:          csiDriverName,
+		guestNamespace:         guestNamespace,
+		resync:                 resync,
+		controllerConfig:       controllerConfig,
+		controlPlaneNamespaces: controlPlaneNamespaces,
 		guestNamespaces: []string{
 			"",
 			guestNamespace,

--- a/pkg/clients/clients.go
+++ b/pkg/clients/clients.go
@@ -18,6 +18,7 @@ import (
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/dynamic/dynamicinformer"
 	coreinformers "k8s.io/client-go/informers/core/v1"
+	v1 "k8s.io/client-go/informers/storage/v1"
 	"k8s.io/client-go/kubernetes"
 )
 
@@ -114,6 +115,16 @@ func (c *Clients) GetNodeInformer() coreinformers.NodeInformer {
 // GetInfraInformer returns an Infrastructure informer.
 func (c *Clients) GetInfraInformer() cfgv1informers.InfrastructureInformer {
 	return c.ConfigInformers.Config().V1().Infrastructures()
+}
+
+// GetStorageClassInformer returns a storage class informer.
+func (c *Clients) GetStorageClassInformer() v1.StorageClassInformer {
+	return c.KubeInformers.InformersFor("").Storage().V1().StorageClasses()
+}
+
+// GetCSIDriverInformer returns a CSI Driver informer.
+func (c *Clients) GetCSIDriverInformer() v1.CSIDriverInformer {
+	return c.KubeInformers.InformersFor("").Storage().V1().CSIDrivers()
 }
 
 // Start starts all informers.

--- a/pkg/driver/common/generator/port_registry.go
+++ b/pkg/driver/common/generator/port_registry.go
@@ -22,4 +22,7 @@ const (
 
 	OpenStackCinderLoopbackMetricsPortStart = 8202
 	OpenStackCinderExposedMetricsPortStart  = 9202
+
+	OpenStackManilaLoopbackMetricsPortStart = 8202
+	OpenStackManilaExposedMetricsPortStart  = 9202
 )

--- a/pkg/driver/common/operator/replacer.go
+++ b/pkg/driver/common/operator/replacer.go
@@ -64,6 +64,7 @@ func DefaultReplacements(controlPlaneNamespace, guestNamespace string) []string 
 	if csiDriver != "" {
 		pairs = append(pairs, []string{"${HYPERSHIFT_IMAGE}", hyperShiftImage}...)
 	}
+
 	pairs = append(pairs, []string{"${NAMESPACE}", controlPlaneNamespace}...)
 	pairs = append(pairs, []string{"${NODE_NAMESPACE}", guestNamespace}...)
 	return pairs

--- a/pkg/driver/openstack-manila/openstack_manila.go
+++ b/pkg/driver/openstack-manila/openstack_manila.go
@@ -145,6 +145,15 @@ func GetOpenStackManilaOperatorControllerConfig(ctx context.Context, flavour gen
 		return nil, err
 	}
 	cfg.ExtraControlPlaneControllers = append(cfg.ExtraControlPlaneControllers, configMapSyncer, secretSyncer, nfsCSIDriverController)
+
+	cfg.ExtraReplacementsFunc = func() []string {
+		pairs := []string{}
+		nfsImage := os.Getenv(nfsImageEnvName)
+		if nfsImage != "" {
+			pairs = append(pairs, []string{"${NFS_DRIVER_IMAGE}", nfsImage}...)
+		}
+		return pairs
+	}
 	return cfg, nil
 }
 

--- a/pkg/driver/openstack-manila/openstack_manila.go
+++ b/pkg/driver/openstack-manila/openstack_manila.go
@@ -1,0 +1,233 @@
+package openstack_manila
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	opv1 "github.com/openshift/api/operator/v1"
+	"github.com/openshift/csi-operator/assets"
+	"github.com/openshift/csi-operator/pkg/clients"
+	commongenerator "github.com/openshift/csi-operator/pkg/driver/common/generator"
+	"github.com/openshift/csi-operator/pkg/driver/common/operator"
+	"github.com/openshift/csi-operator/pkg/generator"
+	"github.com/openshift/csi-operator/pkg/openstack-manila/secret"
+	"github.com/openshift/csi-operator/pkg/openstack-manila/util"
+	"github.com/openshift/csi-operator/pkg/operator/config"
+	"github.com/openshift/library-go/pkg/controller/factory"
+	"github.com/openshift/library-go/pkg/operator/csi/csidrivercontrollerservicecontroller"
+	"github.com/openshift/library-go/pkg/operator/csi/csidrivernodeservicecontroller"
+	dc "github.com/openshift/library-go/pkg/operator/deploymentcontroller"
+	"github.com/openshift/library-go/pkg/operator/resourcesynccontroller"
+	"k8s.io/klog/v2"
+)
+
+const (
+	trustedCAConfigMap = "manila-csi-driver-trusted-ca-bundle"
+
+	generatedAssetBase                   = "overlays/openstack-manila/generated"
+	resyncInterval                       = 20 * time.Minute
+	openshiftDefaultCloudConfigNamespace = "openshift-config"
+	metricsCertSecretName                = "manila-csi-driver-controller-metrics-serving-cert"
+	nfsImageEnvName                      = "NFS_DRIVER_IMAGE"
+)
+
+// GetOpenStackCinderGeneratorConfig returns configuration for generating assets of Manila CSI driver operator.
+func GetOpenStackManilaGeneratorConfig() *generator.CSIDriverGeneratorConfig {
+	return &generator.CSIDriverGeneratorConfig{
+		AssetPrefix:      "manila-csi-driver",
+		AssetShortPrefix: "openstack-manila",
+		DriverName:       "manila.csi.openstack.org",
+		OutputDir:        generatedAssetBase,
+
+		ControllerConfig: &generator.ControlPlaneConfig{
+			DeploymentTemplateAssetName: "overlays/openstack-manila/patches/controller_add_driver.yaml",
+			LivenessProbePort:           10306,
+			MetricsPorts: []generator.MetricsPort{
+				{
+					LocalPort:           commongenerator.OpenStackManilaLoopbackMetricsPortStart,
+					InjectKubeRBACProxy: true,
+					ExposedPort:         commongenerator.OpenStackManilaExposedMetricsPortStart,
+					Name:                "driver-m",
+				},
+			},
+			SidecarLocalMetricsPortStart:   commongenerator.OpenStackManilaLoopbackMetricsPortStart + 1,
+			SidecarExposedMetricsPortStart: commongenerator.OpenStackManilaExposedMetricsPortStart + 1,
+			Sidecars: []generator.SidecarConfig{
+				commongenerator.DefaultProvisionerWithSnapshots.WithExtraArguments(
+					"--timeout=120s",
+					"--feature-gates=Topology=true",
+				),
+				commongenerator.DefaultResizer.WithExtraArguments(),
+				commongenerator.DefaultSnapshotter.WithExtraArguments(),
+				commongenerator.DefaultLivenessProbe.WithExtraArguments(
+					"--probe-timeout=10s",
+				),
+			},
+			Assets:       commongenerator.DefaultControllerAssets,
+			AssetPatches: commongenerator.DefaultAssetPatches,
+		},
+
+		GuestConfig: &generator.GuestConfig{
+			DaemonSetTemplateAssetName:   "overlays/openstack-manila/patches/node_add_driver.yaml",
+			LivenessProbePort:            10305,
+			NodeRegistrarHealthCheckPort: 10307,
+			Sidecars: []generator.SidecarConfig{
+				commongenerator.DefaultLivenessProbe.WithExtraArguments(
+					"--probe-timeout=10s",
+				),
+				commongenerator.DefaultNodeDriverRegistrar,
+			},
+			Assets: commongenerator.DefaultNodeAssets.WithAssets(generator.AllFlavours,
+				"overlays/openstack-manila/base/csidriver.yaml",
+				"overlays/openstack-manila/base/volumesnapshotclass.yaml",
+				"overlays/openstack-manila/base/node_nfs.yaml",
+			),
+		},
+		StandaloneOnly: true,
+	}
+}
+
+// GetOpenStackManilaOperatorConfig returns runtime configuration of the CSI driver operator.
+func GetOpenStackManilaOperatorConfig() *config.OperatorConfig {
+	return &config.OperatorConfig{
+		CSIDriverName:                   opv1.ManilaCSIDriver,
+		UserAgent:                       "openstack-manila-csi-driver-operator",
+		AssetReader:                     assets.ReadFile,
+		AssetDir:                        generatedAssetBase,
+		CloudConfigNamespace:            openshiftDefaultCloudConfigNamespace,
+		OperatorControllerConfigBuilder: GetOpenStackManilaOperatorControllerConfig,
+		Removable:                       false,
+	}
+}
+
+// GetOpenStackManilaOperatorControllerConfig returns second half of runtime configuration of the CSI driver operator,
+// after a client connection + cluster flavour are established.
+func GetOpenStackManilaOperatorControllerConfig(ctx context.Context, flavour generator.ClusterFlavour, c *clients.Clients) (*config.OperatorControllerConfig, error) {
+	if flavour != generator.FlavourStandalone {
+		klog.Error(nil, "Flavour HyperShift is not supported!")
+		return nil, fmt.Errorf("flavour HyperShift is not supported")
+	}
+	cfg := operator.NewDefaultOperatorControllerConfig(flavour, c, "OpenStackManila")
+
+	go c.ConfigInformers.Start(ctx.Done())
+
+	// Hooks to run on all clusters
+	cfg.AddDeploymentHookBuilders(c, withCABundleDeploymentHook)
+	cfg.AddDaemonSetHookBuilders(c, withCABundleDaemonSetHook, withClusterWideProxyDaemonSetHook)
+
+	cfg.DeploymentWatchedSecretNames = append(cfg.DeploymentWatchedSecretNames, metricsCertSecretName)
+
+	// Generate NFS driver asset with image and namespace populated
+	dsBytes, err := assetWithNFSDriver("overlays/openstack-manila/generated/standalone/node_nfs.yaml")
+	if err != nil {
+		return nil, err
+	}
+	nfsCSIDriverController := csidrivernodeservicecontroller.NewCSIDriverNodeServiceController(
+		"NFSDriverNodeServiceController",
+		dsBytes,
+		c.EventRecorder,
+		c.OperatorClient,
+		c.KubeClient,
+		c.ControlPlaneKubeInformers.InformersFor(c.ControlPlaneNamespace).Apps().V1().DaemonSets(),
+		[]factory.Informer{c.GetControlPlaneConfigMapInformer(c.ControlPlaneNamespace).Informer()},
+	)
+
+	configMapSyncer, err := createConfigMapSyncer(c)
+	if err != nil {
+		return nil, err
+	}
+
+	secretSyncer, err := createSecretSyncer(c)
+	if err != nil {
+		return nil, err
+	}
+	cfg.ExtraControlPlaneControllers = append(cfg.ExtraControlPlaneControllers, configMapSyncer, secretSyncer, nfsCSIDriverController)
+	return cfg, nil
+}
+
+// withClusterWideProxyHook adds the cluster-wide proxy config to the DaemonSet.
+func withClusterWideProxyDaemonSetHook(_ *clients.Clients) (csidrivernodeservicecontroller.DaemonSetHookFunc, []factory.Informer) {
+	hook := csidrivernodeservicecontroller.WithObservedProxyDaemonSetHook()
+	return hook, nil
+}
+
+// withCABundleDeploymentHook projects custom CA bundle ConfigMap into the CSI driver container
+func withCABundleDeploymentHook(c *clients.Clients) (dc.DeploymentHookFunc, []factory.Informer) {
+	hook := csidrivercontrollerservicecontroller.WithCABundleDeploymentHook(
+		c.ControlPlaneNamespace,
+		trustedCAConfigMap,
+		c.GetControlPlaneConfigMapInformer(c.ControlPlaneNamespace),
+	)
+	informers := []factory.Informer{
+		c.GetControlPlaneConfigMapInformer(c.ControlPlaneNamespace).Informer(),
+	}
+	return hook, informers
+}
+
+// withCABundleDaemonSetHook projects custom CA bundle ConfigMap into the CSI driver container
+func withCABundleDaemonSetHook(c *clients.Clients) (csidrivernodeservicecontroller.DaemonSetHookFunc, []factory.Informer) {
+	hook := csidrivernodeservicecontroller.WithCABundleDaemonSetHook(
+		clients.CSIDriverNamespace,
+		trustedCAConfigMap,
+		c.GetConfigMapInformer(clients.CSIDriverNamespace),
+	)
+	informers := []factory.Informer{
+		c.GetConfigMapInformer(clients.CSIDriverNamespace).Informer(),
+	}
+	return hook, informers
+}
+
+func createSecretSyncer(c *clients.Clients) (factory.Controller, error) {
+	secretSyncController := secret.NewSecretSyncController(
+		c.OperatorClient,
+		c.KubeClient,
+		c.KubeInformers,
+		resyncInterval,
+		c.EventRecorder)
+
+	return secretSyncController, nil
+}
+
+func createConfigMapSyncer(c *clients.Clients) (factory.Controller, error) {
+	// sync config map with OpenStack CA certificate to the operand namespace,
+	// so the driver can get it as a ConfigMap volume.
+	srcConfigMap := resourcesynccontroller.ResourceLocation{
+		Namespace: util.CloudConfigNamespace,
+		Name:      util.CloudConfigName,
+	}
+	dstConfigMap := resourcesynccontroller.ResourceLocation{
+		Namespace: util.OperatorNamespace,
+		Name:      util.CloudConfigName,
+	}
+	certController := resourcesynccontroller.NewResourceSyncController(
+		c.OperatorClient,
+		c.KubeInformers,
+		c.KubeClient.CoreV1(),
+		c.KubeClient.CoreV1(),
+		c.EventRecorder)
+	if err := certController.SyncConfigMap(dstConfigMap, srcConfigMap); err != nil {
+		return nil, err
+	}
+	return certController, nil
+}
+
+// CSIDriverController can replace only a single driver in driver manifests.
+// Manila needs to replace two of them: Manila driver and NFS driver image.
+// Let the Manila image be replaced by CSIDriverController and NFS in this
+// custom asset loading func.
+func assetWithNFSDriver(file string) ([]byte, error) {
+	asset, err := assets.ReadFile(file)
+	if err != nil {
+		return nil, err
+	}
+	nfsImage := os.Getenv(nfsImageEnvName)
+	if nfsImage == "" {
+		return asset, nil
+	}
+
+	asset = bytes.ReplaceAll(asset, []byte("${NFS_DRIVER_IMAGE}"), []byte(nfsImage))
+	return bytes.ReplaceAll(asset, []byte("${NAMESPACE}"), []byte(util.OperatorNamespace)), nil
+}

--- a/pkg/openstack-manila/client/openstack.go
+++ b/pkg/openstack-manila/client/openstack.go
@@ -1,0 +1,125 @@
+package client
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/gophercloud/gophercloud/v2"
+	"github.com/gophercloud/gophercloud/v2/openstack"
+	"github.com/gophercloud/gophercloud/v2/openstack/sharedfilesystems/v2/sharetypes"
+	"github.com/gophercloud/utils/v2/openstack/clientconfig"
+	"github.com/openshift/csi-operator/pkg/openstack-manila/util"
+	"github.com/openshift/csi-operator/pkg/version"
+	"sigs.k8s.io/yaml"
+)
+
+type openStackClient struct {
+	cloud *clientconfig.Cloud
+}
+
+func NewOpenStackClient(cloudConfigFilename string) (*openStackClient, error) {
+	cloud, err := getCloudFromFile(cloudConfigFilename)
+	if err != nil {
+		return nil, err
+	}
+	return &openStackClient{
+		cloud: cloud,
+	}, nil
+}
+
+func (o *openStackClient) GetShareTypes() ([]sharetypes.ShareType, error) {
+	clientOpts := new(clientconfig.ClientOpts)
+
+	if o.cloud.AuthInfo != nil {
+		clientOpts.AuthInfo = o.cloud.AuthInfo
+		clientOpts.AuthType = o.cloud.AuthType
+		clientOpts.Cloud = o.cloud.Cloud
+		clientOpts.RegionName = o.cloud.RegionName
+	}
+
+	opts, err := clientconfig.AuthOptions(clientOpts)
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate auth options: %w", err)
+	}
+
+	provider, err := openstack.NewClient(opts.IdentityEndpoint)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create a provider client: %w", err)
+	}
+
+	// we represent version using commits since we don't tag releases
+	ua := gophercloud.UserAgent{}
+	ua.Prepend(fmt.Sprintf("openstack-manila-csi-driver-operator/%s", version.Get().GitCommit))
+	provider.UserAgent = ua
+
+	cert, err := getCloudProviderCert()
+	if err != nil && !os.IsNotExist(err) {
+		return nil, fmt.Errorf("failed to get cloud provider CA certificate: %w", err)
+	}
+
+	if len(cert) > 0 {
+		certPool, err := x509.SystemCertPool()
+		if err != nil {
+			return nil, fmt.Errorf("create system cert pool failed: %w", err)
+		}
+		certPool.AppendCertsFromPEM(cert)
+		client := http.Client{
+			Transport: &http.Transport{
+				Proxy: http.ProxyFromEnvironment,
+				TLSClientConfig: &tls.Config{
+					RootCAs: certPool,
+				},
+			},
+		}
+		provider.HTTPClient = client
+	}
+
+	provider.HTTPClient.Timeout = 120 * time.Second
+
+	err = openstack.Authenticate(context.TODO(), provider, *opts)
+	if err != nil {
+		return nil, fmt.Errorf("cannot authenticate with given credentials: %w", err)
+	}
+
+	client, err := openstack.NewSharedFileSystemV2(provider, gophercloud.EndpointOpts{
+		Region: clientOpts.RegionName,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("cannot find an endpoint for Shared File Systems API v2: %w", err)
+	}
+
+	allPages, err := sharetypes.List(client, &sharetypes.ListOpts{}).AllPages(context.TODO())
+	if err != nil {
+		return nil, fmt.Errorf("cannot list available share types: %w", err)
+	}
+
+	return sharetypes.ExtractShareTypes(allPages)
+}
+
+func getCloudFromFile(filename string) (*clientconfig.Cloud, error) {
+	cloudConfig, err := ioutil.ReadFile(filename)
+	if err != nil {
+		return nil, err
+	}
+	var clouds clientconfig.Clouds
+	err = yaml.Unmarshal(cloudConfig, &clouds)
+	if err != nil {
+		return nil, fmt.Errorf("failed to unmarshal clouds credentials from %s: %w", filename, err)
+	}
+
+	cfg, ok := clouds.Clouds[util.CloudName]
+	if !ok {
+		return nil, fmt.Errorf("could not find cloud named %q in credential file %s", util.CloudName, filename)
+	}
+	return &cfg, nil
+}
+
+func getCloudProviderCert() ([]byte, error) {
+	return ioutil.ReadFile(util.CertFile)
+}

--- a/pkg/openstack-manila/secret/secretsync.go
+++ b/pkg/openstack-manila/secret/secretsync.go
@@ -1,0 +1,178 @@
+package secret
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/gophercloud/utils/v2/openstack/clientconfig"
+	operatorv1 "github.com/openshift/api/operator/v1"
+	"github.com/openshift/csi-operator/pkg/openstack-manila/util"
+	"github.com/openshift/library-go/pkg/controller/factory"
+	"github.com/openshift/library-go/pkg/operator/events"
+	"github.com/openshift/library-go/pkg/operator/resource/resourceapply"
+	"github.com/openshift/library-go/pkg/operator/v1helpers"
+	"gopkg.in/yaml.v2"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	corelisters "k8s.io/client-go/listers/core/v1"
+	"k8s.io/klog/v2"
+)
+
+// This SecretSyncController translates Secret provided by cloud-credential-operator into
+// format required by the CSI driver.
+type SecretSyncController struct {
+	operatorClient v1helpers.OperatorClient
+	kubeClient     kubernetes.Interface
+	secretLister   corelisters.SecretLister
+	eventRecorder  events.Recorder
+}
+
+const (
+	// Name of key with clouds.yaml in Secret provided by cloud-credentials-operator.
+	cloudSecretKey = "clouds.yaml"
+	// Name of OpenStack in clouds.yaml
+	// Canonical path for custom ca certificates
+	cacertPath = "/etc/kubernetes/static-pod-resources/configmaps/cloud-config/ca-bundle.pem"
+)
+
+func NewSecretSyncController(
+	operatorClient v1helpers.OperatorClient,
+	kubeClient kubernetes.Interface,
+	informers v1helpers.KubeInformersForNamespaces,
+	resync time.Duration,
+	eventRecorder events.Recorder) factory.Controller {
+
+	// Read secret from operator namespace and save the translated one to the operand namespace
+	secretInformer := informers.InformersFor(util.OperatorNamespace)
+	c := &SecretSyncController{
+		operatorClient: operatorClient,
+		kubeClient:     kubeClient,
+		secretLister:   secretInformer.Core().V1().Secrets().Lister(),
+		eventRecorder:  eventRecorder.WithComponentSuffix("SecretSync"),
+	}
+	return factory.New().WithSync(c.sync).ResyncEvery(resync).WithSyncDegradedOnError(operatorClient).WithInformers(
+		operatorClient.Informer(),
+		secretInformer.Core().V1().Secrets().Informer(),
+	).ToController("SecretSync", eventRecorder)
+}
+
+func (c *SecretSyncController) sync(ctx context.Context, syncCtx factory.SyncContext) error {
+	opSpec, _, _, err := c.operatorClient.GetOperatorState()
+	if err != nil {
+		return err
+	}
+	if opSpec.ManagementState != operatorv1.Managed {
+		return nil
+	}
+
+	cloudSecret, err := c.secretLister.Secrets(util.OperatorNamespace).Get(util.CloudCredentialSecretName)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			// TODO: report error after some while?
+			klog.V(2).Infof("Waiting for secret %s from cloud-credentials-operator", util.CloudCredentialSecretName)
+			return nil
+		}
+		return err
+	}
+
+	driverSecret, err := c.translateSecret(cloudSecret)
+	if err != nil {
+		return err
+	}
+
+	_, _, err = resourceapply.ApplySecret(ctx, c.kubeClient.CoreV1(), c.eventRecorder, driverSecret)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (c *SecretSyncController) translateSecret(cloudSecret *v1.Secret) (*v1.Secret, error) {
+	content, ok := cloudSecret.Data[cloudSecretKey]
+	if !ok {
+		return nil, fmt.Errorf("OpenStack credentials secret %s did not contain key %s", util.CloudCredentialSecretName, cloudSecretKey)
+	}
+
+	var clouds clientconfig.Clouds
+	err := yaml.Unmarshal(content, &clouds)
+	if err != nil {
+		return nil, fmt.Errorf("failed to unmarshal clouds credentials stored in secret %s: %s", util.CloudCredentialSecretName, err)
+	}
+
+	cloud, ok := clouds.Clouds[util.CloudName]
+	if !ok {
+		return nil, fmt.Errorf("failed to parse clouds credentials stored in secret %s: cloud %s not found", util.CloudCredentialSecretName, util.CloudName)
+	}
+
+	data := cloudToConf(cloud)
+
+	secret := v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      util.ManilaSecretName,
+			Namespace: util.OperandNamespace,
+		},
+		Type: v1.SecretTypeOpaque,
+		Data: data,
+	}
+
+	return &secret, nil
+}
+
+func cloudToConf(cloud clientconfig.Cloud) map[string][]byte {
+	data := make(map[string][]byte)
+
+	if cloud.AuthInfo.AuthURL != "" {
+		data["os-authURL"] = []byte(cloud.AuthInfo.AuthURL)
+	}
+	if cloud.RegionName != "" {
+		data["os-region"] = []byte(cloud.RegionName)
+	}
+	if cloud.AuthInfo.UserID != "" {
+		data["os-userID"] = []byte(cloud.AuthInfo.UserID)
+	} else if cloud.AuthInfo.Username != "" {
+		data["os-userName"] = []byte(cloud.AuthInfo.Username)
+	}
+	if cloud.AuthInfo.Password != "" {
+		data["os-password"] = []byte(cloud.AuthInfo.Password)
+	}
+	if cloud.AuthInfo.ApplicationCredentialID != "" {
+		data["os-applicationCredentialID"] = []byte(cloud.AuthInfo.ApplicationCredentialID)
+	}
+	if cloud.AuthInfo.ApplicationCredentialName != "" {
+		data["os-applicationCredentialName"] = []byte(cloud.AuthInfo.ApplicationCredentialName)
+	}
+	if cloud.AuthInfo.ApplicationCredentialSecret != "" {
+		data["os-applicationCredentialSecret"] = []byte(cloud.AuthInfo.ApplicationCredentialSecret)
+	}
+	if cloud.AuthInfo.ProjectID != "" {
+		data["os-projectID"] = []byte(cloud.AuthInfo.ProjectID)
+	} else if cloud.AuthInfo.ProjectName != "" {
+		data["os-projectName"] = []byte(cloud.AuthInfo.ProjectName)
+	}
+	if cloud.AuthInfo.DomainID != "" {
+		data["os-domainID"] = []byte(cloud.AuthInfo.DomainID)
+	} else if cloud.AuthInfo.DomainName != "" {
+		data["os-domainName"] = []byte(cloud.AuthInfo.DomainName)
+	}
+	if cloud.AuthInfo.ProjectDomainID != "" {
+		data["os-projectDomainID"] = []byte(cloud.AuthInfo.ProjectDomainID)
+	} else if cloud.AuthInfo.ProjectDomainName != "" {
+		data["os-projectDomainName"] = []byte(cloud.AuthInfo.ProjectDomainName)
+	}
+	if cloud.AuthInfo.UserDomainID != "" {
+		data["os-userDomainID"] = []byte(cloud.AuthInfo.UserDomainID)
+		data["os-domainID"] = []byte(cloud.AuthInfo.UserDomainID)
+	} else if cloud.AuthInfo.UserDomainName != "" {
+		data["os-userDomainName"] = []byte(cloud.AuthInfo.UserDomainName)
+		data["os-domainName"] = []byte(cloud.AuthInfo.UserDomainName)
+	}
+	if cloud.CACertFile != "" {
+		// Replace the original cert authority path from clouds.yaml with the canonical one
+		data["os-certAuthorityPath"] = []byte(cacertPath)
+	}
+
+	return data
+}

--- a/pkg/openstack-manila/util/const.go
+++ b/pkg/openstack-manila/util/const.go
@@ -1,0 +1,20 @@
+package util
+
+const (
+	OperatorNamespace         = "openshift-cluster-csi-drivers"
+	OperandNamespace          = "openshift-manila-csi-driver"
+	CloudCredentialSecretName = "manila-cloud-credentials"
+	ManilaSecretName          = "csi-manila-secrets"
+
+	CloudConfigNamespace = "openshift-config"
+	CloudConfigName      = "cloud-provider-config"
+
+	StorageClassNamePrefix = "csi-manila-"
+
+	// OpenStack config file name (as present in the operator Deployment)
+	CloudConfigFilename = "/etc/openstack/clouds.yaml"
+	CertFile            = "/etc/openstack-ca/ca-bundle.pem"
+
+	// Name of cloud in secret provided by cloud-credentials-operator
+	CloudName = "openstack"
+)

--- a/pkg/openstack-manila/util/const.go
+++ b/pkg/openstack-manila/util/const.go
@@ -1,8 +1,6 @@
 package util
 
 const (
-	OperatorNamespace         = "openshift-cluster-csi-drivers"
-	OperandNamespace          = "openshift-manila-csi-driver"
 	CloudCredentialSecretName = "manila-cloud-credentials"
 	ManilaSecretName          = "csi-manila-secrets"
 

--- a/pkg/operator/config/config.go
+++ b/pkg/operator/config/config.go
@@ -74,6 +74,12 @@ type OperatorControllerConfig struct {
 
 	// ExtraReplacements defines additional replacements that should be made to assets
 	ExtraReplacementsFunc func() []string
+
+	// Precondition to run operator
+	Precondition func() (bool, error)
+
+	// List of informers that should be added to the precondition controller
+	PreconditionInformers []factory.Informer
 }
 
 func (o *OperatorControllerConfig) AddCredentialsRequestHook(hook credentialsrequestcontroller.CredentialsRequestHook) {

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -40,13 +40,20 @@ func RunOperator(ctx context.Context, controllerConfig *controllercmd.Controller
 		flavour = generator.FlavourHyperShift
 	}
 
+	controlPlaneNamespaces := []string{controllerConfig.OperatorNamespace}
 	if opConfig.GuestNamespace == "" {
 		// If no guest namespace is defined, let's set the default value.
 		opConfig.GuestNamespace = "openshift-cluster-csi-drivers"
+	} else {
+		// Manila uses a different namespace than other operators for both control plane and guest in non-hypershift clusters.
+		if !isHypershift {
+			controlPlaneNamespace = opConfig.GuestNamespace
+			controlPlaneNamespaces = append(controlPlaneNamespaces, controlPlaneNamespace)
+		}
 	}
 
 	// Create Clients
-	builder := clients.NewBuilder(opConfig.UserAgent, string(opConfig.CSIDriverName), opConfig.GuestNamespace, controllerConfig, resync).
+	builder := clients.NewBuilder(opConfig.UserAgent, string(opConfig.CSIDriverName), opConfig.GuestNamespace, controlPlaneNamespaces, controllerConfig, resync).
 		WithHyperShiftGuest(guestKubeConfigString, opConfig.CloudConfigNamespace)
 
 	c := builder.BuildOrDie(ctx)

--- a/pkg/operator/starter_controller.go
+++ b/pkg/operator/starter_controller.go
@@ -1,0 +1,123 @@
+package operator
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	operatorv1 "github.com/openshift/api/operator/v1"
+	"github.com/openshift/csi-operator/pkg/operator/config"
+	"github.com/openshift/library-go/pkg/controller/factory"
+	"github.com/openshift/library-go/pkg/operator/csi/csicontrollerset"
+	"github.com/openshift/library-go/pkg/operator/events"
+	"github.com/openshift/library-go/pkg/operator/v1helpers"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/klog/v2"
+)
+
+type Controller struct {
+	operatorClient           v1helpers.OperatorClient
+	csiControllers           []*csicontrollerset.CSIControllerSet
+	factoryControllers       []factory.Controller
+	controllersRunning       bool
+	eventRecorder            events.Recorder
+	operatorControllerConfig *config.OperatorControllerConfig
+}
+
+type Runnable interface {
+	Run(ctx context.Context, workers int)
+}
+
+const (
+	// Minimal interval between controller resyncs.
+	resyncInterval = 20 * time.Minute
+
+	operatorConditionPrefix = "CSIController"
+)
+
+// Creates a controller that checks if a pre-condition, when defined,
+// is met every 20 minutes. If the pre-condition is met and the controllers
+// are not running yet, trigger the controllers run, if it's not, set the operator
+// condition to disabled.
+func StarterController(operatorClient v1helpers.OperatorClient,
+	csiControllers []*csicontrollerset.CSIControllerSet,
+	factoryControllers []factory.Controller,
+	eventRecorder events.Recorder, operatorControllerConfig *config.OperatorControllerConfig) factory.Controller {
+
+	c := &Controller{
+		operatorClient:           operatorClient,
+		csiControllers:           csiControllers,
+		factoryControllers:       factoryControllers,
+		eventRecorder:            eventRecorder.WithComponentSuffix(operatorConditionPrefix),
+		operatorControllerConfig: operatorControllerConfig,
+	}
+	informers := []factory.Informer{operatorClient.Informer()}
+	informers = append(informers, operatorControllerConfig.PreconditionInformers...)
+	return factory.New().WithSync(c.sync).WithSyncDegradedOnError(operatorClient).ResyncEvery(resyncInterval).WithInformers(
+		informers...,
+	).ToController("StarterController", eventRecorder)
+}
+
+func (c *Controller) sync(ctx context.Context, syncCtx factory.SyncContext) error {
+	opSpec, _, _, err := c.operatorClient.GetOperatorState()
+	if err != nil {
+		return err
+	}
+	if opSpec.ManagementState != operatorv1.Managed {
+		return nil
+	}
+
+	_, err = c.operatorControllerConfig.Precondition()
+	if err != nil {
+		return c.setDisabledCondition(ctx, fmt.Sprintf("Pre-condition not satisfied: %v", err))
+	}
+	if !c.controllersRunning {
+		// Start controllers
+		for _, controller := range c.factoryControllers {
+			klog.Infof("Starting controller %s", controller.Name())
+			go controller.Run(ctx, 1)
+		}
+
+		klog.V(4).Infof("Starting CSI driver controllers")
+		for _, ctrl := range c.csiControllers {
+			go func(ctrl Runnable) {
+				defer utilruntime.HandleCrash()
+				ctrl.Run(ctx, 1)
+			}(ctrl)
+		}
+		c.controllersRunning = true
+	}
+
+	return c.setEnabledCondition(ctx)
+}
+
+func (c *Controller) setEnabledCondition(ctx context.Context) error {
+	_, _, err := v1helpers.UpdateStatus(
+		ctx,
+		c.operatorClient,
+		removeConditionFn(operatorConditionPrefix+"Disabled"),
+	)
+	return err
+}
+
+func (c *Controller) setDisabledCondition(ctx context.Context, msg string) error {
+	disabledCnd := operatorv1.OperatorCondition{
+		Type:    operatorConditionPrefix + "Disabled",
+		Status:  operatorv1.ConditionTrue,
+		Reason:  "PreConditionNotSatisfied",
+		Message: msg,
+	}
+	_, _, err := v1helpers.UpdateStatus(
+		ctx,
+		c.operatorClient,
+		v1helpers.UpdateConditionFn(disabledCnd),
+	)
+	return err
+}
+
+func removeConditionFn(cnd string) v1helpers.UpdateStatusFunc {
+	return func(oldStatus *operatorv1.OperatorStatus) error {
+		v1helpers.RemoveOperatorCondition(&oldStatus.Conditions, cnd)
+		return nil
+	}
+}

--- a/pkg/operator/starter_test.go
+++ b/pkg/operator/starter_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/openshift/csi-operator/assets"
 	azure_disk "github.com/openshift/csi-operator/pkg/driver/azure-disk"
 	"github.com/openshift/csi-operator/pkg/driver/common/operator"
+	openstack_manila "github.com/openshift/csi-operator/pkg/driver/openstack-manila"
 	generated_assets "github.com/openshift/csi-operator/pkg/generated-assets"
 	"github.com/openshift/csi-operator/pkg/generator"
 	"github.com/openshift/csi-operator/pkg/operator/config"
@@ -124,6 +125,13 @@ func TestDefaultReplacements(t *testing.T) {
 			flavor:                generator.FlavourHyperShift,
 			controlPlaneNamespace: "clusters-foo",
 			GuestNamespace:        "openshift-cluster-csi-drivers",
+		},
+		{
+			name:                  "Testing replacement of OpenStack manila assets without Hypershift",
+			opConfig:              openstack_manila.GetOpenStackManilaOperatorConfig(),
+			flavor:                generator.FlavourStandalone,
+			controlPlaneNamespace: "openshift-manila-csi-driver",
+			GuestNamespace:        "openshift-manila-csi-driver",
 		},
 	}
 

--- a/vendor/github.com/gophercloud/gophercloud/v2/CHANGELOG.md
+++ b/vendor/github.com/gophercloud/gophercloud/v2/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v2.1.1 (2024-09-18)
+
+* [GH-3161](https://github.com/gophercloud/gophercloud/pull/3161) [v2] fix: create security group rule with any protocol
+
 ## v2.1.0 (2024-07-24)
 
 * [GH-3078](https://github.com/gophercloud/gophercloud/pull/3078) [networking]: add BGP VPNs support

--- a/vendor/github.com/gophercloud/gophercloud/v2/openstack/sharedfilesystems/v2/sharetypes/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/v2/openstack/sharedfilesystems/v2/sharetypes/requests.go
@@ -1,0 +1,221 @@
+package sharetypes
+
+import (
+	"context"
+
+	"github.com/gophercloud/gophercloud/v2"
+	"github.com/gophercloud/gophercloud/v2/pagination"
+)
+
+// CreateOptsBuilder allows extensions to add additional parameters to the
+// Create request.
+type CreateOptsBuilder interface {
+	ToShareTypeCreateMap() (map[string]any, error)
+}
+
+// CreateOpts contains options for creating a ShareType. This object is
+// passed to the sharetypes.Create function. For more information about
+// these parameters, see the ShareType object.
+type CreateOpts struct {
+	// The share type name
+	Name string `json:"name" required:"true"`
+	// Indicates whether a share type is publicly accessible
+	IsPublic bool `json:"os-share-type-access:is_public"`
+	// The extra specifications for the share type
+	ExtraSpecs ExtraSpecsOpts `json:"extra_specs" required:"true"`
+}
+
+// ExtraSpecsOpts represent the extra specifications that can be selected for a share type
+type ExtraSpecsOpts struct {
+	// An extra specification that defines the driver mode for share server, or storage, life cycle management
+	DriverHandlesShareServers bool `json:"driver_handles_share_servers" required:"true"`
+	// An extra specification that filters back ends by whether they do or do not support share snapshots
+	SnapshotSupport *bool `json:"snapshot_support,omitempty"`
+}
+
+// ToShareTypeCreateMap assembles a request body based on the contents of a
+// CreateOpts.
+func (opts CreateOpts) ToShareTypeCreateMap() (map[string]any, error) {
+	return gophercloud.BuildRequestBody(opts, "share_type")
+}
+
+// Create will create a new ShareType based on the values in CreateOpts. To
+// extract the ShareType object from the response, call the Extract method
+// on the CreateResult.
+func Create(ctx context.Context, client *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+	b, err := opts.ToShareTypeCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	resp, err := client.Post(ctx, createURL(client), b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200, 202},
+	})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+// Delete will delete the existing ShareType with the provided ID.
+func Delete(ctx context.Context, client *gophercloud.ServiceClient, id string) (r DeleteResult) {
+	resp, err := client.Delete(ctx, deleteURL(client, id), nil)
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+// ListOptsBuilder allows extensions to add additional parameters to the List
+// request.
+type ListOptsBuilder interface {
+	ToShareTypeListQuery() (string, error)
+}
+
+// ListOpts holds options for listing ShareTypes. It is passed to the
+// sharetypes.List function.
+type ListOpts struct {
+	// Select if public types, private types, or both should be listed
+	IsPublic string `q:"is_public"`
+}
+
+// ToShareTypeListQuery formats a ListOpts into a query string.
+func (opts ListOpts) ToShareTypeListQuery() (string, error) {
+	q, err := gophercloud.BuildQueryString(opts)
+	return q.String(), err
+}
+
+// List returns ShareTypes optionally limited by the conditions provided in ListOpts.
+func List(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+	url := listURL(client)
+	if opts != nil {
+		query, err := opts.ToShareTypeListQuery()
+		if err != nil {
+			return pagination.Pager{Err: err}
+		}
+		url += query
+	}
+
+	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
+		return ShareTypePage{pagination.SinglePageBase(r)}
+	})
+}
+
+// GetDefault will retrieve the default ShareType.
+func GetDefault(ctx context.Context, client *gophercloud.ServiceClient) (r GetDefaultResult) {
+	resp, err := client.Get(ctx, getDefaultURL(client), &r.Body, nil)
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+// GetExtraSpecs will retrieve the extra specifications for a given ShareType.
+func GetExtraSpecs(ctx context.Context, client *gophercloud.ServiceClient, id string) (r GetExtraSpecsResult) {
+	resp, err := client.Get(ctx, getExtraSpecsURL(client, id), &r.Body, nil)
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+// SetExtraSpecsOptsBuilder allows extensions to add additional parameters to the
+// SetExtraSpecs request.
+type SetExtraSpecsOptsBuilder interface {
+	ToShareTypeSetExtraSpecsMap() (map[string]any, error)
+}
+
+type SetExtraSpecsOpts struct {
+	// A list of all extra specifications to be added to a ShareType
+	ExtraSpecs map[string]any `json:"extra_specs" required:"true"`
+}
+
+// ToShareTypeSetExtraSpecsMap assembles a request body based on the contents of a
+// SetExtraSpecsOpts.
+func (opts SetExtraSpecsOpts) ToShareTypeSetExtraSpecsMap() (map[string]any, error) {
+	return gophercloud.BuildRequestBody(opts, "")
+}
+
+// SetExtraSpecs will set new specifications for a ShareType based on the values
+// in SetExtraSpecsOpts. To extract the extra specifications object from the response,
+// call the Extract method on the SetExtraSpecsResult.
+func SetExtraSpecs(ctx context.Context, client *gophercloud.ServiceClient, id string, opts SetExtraSpecsOptsBuilder) (r SetExtraSpecsResult) {
+	b, err := opts.ToShareTypeSetExtraSpecsMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+
+	resp, err := client.Post(ctx, setExtraSpecsURL(client, id), b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200, 202},
+	})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+// UnsetExtraSpecs will unset an extra specification for an existing ShareType.
+func UnsetExtraSpecs(ctx context.Context, client *gophercloud.ServiceClient, id string, key string) (r UnsetExtraSpecsResult) {
+	resp, err := client.Delete(ctx, unsetExtraSpecsURL(client, id, key), nil)
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+// ShowAccess will show access details for an existing ShareType.
+func ShowAccess(ctx context.Context, client *gophercloud.ServiceClient, id string) (r ShowAccessResult) {
+	resp, err := client.Get(ctx, showAccessURL(client, id), &r.Body, nil)
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+// AddAccessOptsBuilder allows extensions to add additional parameters to the
+// AddAccess
+type AddAccessOptsBuilder interface {
+	ToAddAccessMap() (map[string]any, error)
+}
+
+type AccessOpts struct {
+	// The UUID of the project to which access to the share type is granted.
+	Project string `json:"project"`
+}
+
+// ToAddAccessMap assembles a request body based on the contents of a
+// AccessOpts.
+func (opts AccessOpts) ToAddAccessMap() (map[string]any, error) {
+	return gophercloud.BuildRequestBody(opts, "addProjectAccess")
+}
+
+// AddAccess will add access to a ShareType based on the values
+// in AccessOpts.
+func AddAccess(ctx context.Context, client *gophercloud.ServiceClient, id string, opts AddAccessOptsBuilder) (r AddAccessResult) {
+	b, err := opts.ToAddAccessMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+
+	resp, err := client.Post(ctx, addAccessURL(client, id), b, nil, &gophercloud.RequestOpts{
+		OkCodes: []int{200, 202},
+	})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+// RemoveAccessOptsBuilder allows extensions to add additional parameters to the
+// RemoveAccess
+type RemoveAccessOptsBuilder interface {
+	ToRemoveAccessMap() (map[string]any, error)
+}
+
+// ToRemoveAccessMap assembles a request body based on the contents of a
+// AccessOpts.
+func (opts AccessOpts) ToRemoveAccessMap() (map[string]any, error) {
+	return gophercloud.BuildRequestBody(opts, "removeProjectAccess")
+}
+
+// RemoveAccess will remove access to a ShareType based on the values
+// in AccessOpts.
+func RemoveAccess(ctx context.Context, client *gophercloud.ServiceClient, id string, opts RemoveAccessOptsBuilder) (r RemoveAccessResult) {
+	b, err := opts.ToRemoveAccessMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+
+	resp, err := client.Post(ctx, removeAccessURL(client, id), b, nil, &gophercloud.RequestOpts{
+		OkCodes: []int{200, 202},
+	})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}

--- a/vendor/github.com/gophercloud/gophercloud/v2/openstack/sharedfilesystems/v2/sharetypes/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/v2/openstack/sharedfilesystems/v2/sharetypes/results.go
@@ -1,0 +1,143 @@
+package sharetypes
+
+import (
+	"github.com/gophercloud/gophercloud/v2"
+	"github.com/gophercloud/gophercloud/v2/pagination"
+)
+
+// ShareType contains all the information associated with an OpenStack
+// ShareType.
+type ShareType struct {
+	// The Share Type ID
+	ID string `json:"id"`
+	// The Share Type name
+	Name string `json:"name"`
+	// Indicates whether a share type is publicly accessible
+	IsPublic bool `json:"os-share-type-access:is_public"`
+	// The required extra specifications for the share type
+	RequiredExtraSpecs map[string]any `json:"required_extra_specs"`
+	// The extra specifications for the share type
+	ExtraSpecs map[string]any `json:"extra_specs"`
+}
+
+type commonResult struct {
+	gophercloud.Result
+}
+
+// Extract will get the ShareType object out of the commonResult object.
+func (r commonResult) Extract() (*ShareType, error) {
+	var s struct {
+		ShareType *ShareType `json:"share_type"`
+	}
+	err := r.ExtractInto(&s)
+	return s.ShareType, err
+}
+
+// CreateResult contains the response body and error from a Create request.
+type CreateResult struct {
+	commonResult
+}
+
+// DeleteResult contains the response body and error from a Delete request.
+type DeleteResult struct {
+	gophercloud.ErrResult
+}
+
+// ShareTypePage is a pagination.pager that is returned from a call to the List function.
+type ShareTypePage struct {
+	pagination.SinglePageBase
+}
+
+// IsEmpty returns true if a ListResult contains no ShareTypes.
+func (r ShareTypePage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
+	shareTypes, err := ExtractShareTypes(r)
+	return len(shareTypes) == 0, err
+}
+
+// ExtractShareTypes extracts and returns ShareTypes. It is used while
+// iterating over a sharetypes.List call.
+func ExtractShareTypes(r pagination.Page) ([]ShareType, error) {
+	var s struct {
+		ShareTypes []ShareType `json:"share_types"`
+	}
+	err := (r.(ShareTypePage)).ExtractInto(&s)
+	return s.ShareTypes, err
+}
+
+// GetDefaultResult contains the response body and error from a Get Default request.
+type GetDefaultResult struct {
+	commonResult
+}
+
+// ExtraSpecs contains all the information associated with extra specifications
+// for an Openstack ShareType.
+type ExtraSpecs map[string]any
+
+type extraSpecsResult struct {
+	gophercloud.Result
+}
+
+// Extract will get the ExtraSpecs object out of the commonResult object.
+func (r extraSpecsResult) Extract() (ExtraSpecs, error) {
+	var s struct {
+		Specs ExtraSpecs `json:"extra_specs"`
+	}
+	err := r.ExtractInto(&s)
+	return s.Specs, err
+}
+
+// GetExtraSpecsResult contains the response body and error from a Get Extra Specs request.
+type GetExtraSpecsResult struct {
+	extraSpecsResult
+}
+
+// SetExtraSpecsResult contains the response body and error from a Set Extra Specs request.
+type SetExtraSpecsResult struct {
+	extraSpecsResult
+}
+
+// UnsetExtraSpecsResult contains the response body and error from a Unset Extra Specs request.
+type UnsetExtraSpecsResult struct {
+	gophercloud.ErrResult
+}
+
+// ShareTypeAccess contains all the information associated with an OpenStack
+// ShareTypeAccess.
+type ShareTypeAccess struct {
+	// The share type ID of the member.
+	ShareTypeID string `json:"share_type_id"`
+	// The UUID of the project for which access to the share type is granted.
+	ProjectID string `json:"project_id"`
+}
+
+type shareTypeAccessResult struct {
+	gophercloud.Result
+}
+
+// ShowAccessResult contains the response body and error from a Show access request.
+type ShowAccessResult struct {
+	shareTypeAccessResult
+}
+
+// Extract will get the ShareTypeAccess objects out of the shareTypeAccessResult object.
+func (r ShowAccessResult) Extract() ([]ShareTypeAccess, error) {
+	var s struct {
+		ShareTypeAccess []ShareTypeAccess `json:"share_type_access"`
+	}
+	err := r.ExtractInto(&s)
+	return s.ShareTypeAccess, err
+}
+
+// AddAccessResult contains the response body and error from a Add Access request.
+type AddAccessResult struct {
+	gophercloud.ErrResult
+}
+
+// RemoveAccessResult contains the response body and error from a Remove Access request.
+type RemoveAccessResult struct {
+	gophercloud.ErrResult
+}

--- a/vendor/github.com/gophercloud/gophercloud/v2/openstack/sharedfilesystems/v2/sharetypes/urls.go
+++ b/vendor/github.com/gophercloud/gophercloud/v2/openstack/sharedfilesystems/v2/sharetypes/urls.go
@@ -1,0 +1,43 @@
+package sharetypes
+
+import "github.com/gophercloud/gophercloud/v2"
+
+func createURL(c *gophercloud.ServiceClient) string {
+	return c.ServiceURL("types")
+}
+
+func deleteURL(c *gophercloud.ServiceClient, id string) string {
+	return c.ServiceURL("types", id)
+}
+
+func listURL(c *gophercloud.ServiceClient) string {
+	return createURL(c)
+}
+
+func getDefaultURL(c *gophercloud.ServiceClient) string {
+	return c.ServiceURL("types", "default")
+}
+
+func getExtraSpecsURL(c *gophercloud.ServiceClient, id string) string {
+	return c.ServiceURL("types", id, "extra_specs")
+}
+
+func setExtraSpecsURL(c *gophercloud.ServiceClient, id string) string {
+	return getExtraSpecsURL(c, id)
+}
+
+func unsetExtraSpecsURL(c *gophercloud.ServiceClient, id string, key string) string {
+	return c.ServiceURL("types", id, "extra_specs", key)
+}
+
+func showAccessURL(c *gophercloud.ServiceClient, id string) string {
+	return c.ServiceURL("types", id, "share_type_access")
+}
+
+func addAccessURL(c *gophercloud.ServiceClient, id string) string {
+	return c.ServiceURL("types", id, "action")
+}
+
+func removeAccessURL(c *gophercloud.ServiceClient, id string) string {
+	return addAccessURL(c, id)
+}

--- a/vendor/github.com/gophercloud/gophercloud/v2/provider_client.go
+++ b/vendor/github.com/gophercloud/gophercloud/v2/provider_client.go
@@ -13,7 +13,7 @@ import (
 
 // DefaultUserAgent is the default User-Agent string set in the request header.
 const (
-	DefaultUserAgent         = "gophercloud/v2.1.0"
+	DefaultUserAgent         = "gophercloud/v2.1.1"
 	DefaultMaxBackoffRetries = 60
 )
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -179,7 +179,7 @@ github.com/google/pprof/profile
 # github.com/google/uuid v1.6.0
 ## explicit
 github.com/google/uuid
-# github.com/gophercloud/gophercloud/v2 v2.1.0
+# github.com/gophercloud/gophercloud/v2 v2.1.1
 ## explicit; go 1.22
 github.com/gophercloud/gophercloud/v2
 github.com/gophercloud/gophercloud/v2/openstack
@@ -190,6 +190,7 @@ github.com/gophercloud/gophercloud/v2/openstack/identity/v2/tokens
 github.com/gophercloud/gophercloud/v2/openstack/identity/v3/ec2tokens
 github.com/gophercloud/gophercloud/v2/openstack/identity/v3/oauth1
 github.com/gophercloud/gophercloud/v2/openstack/identity/v3/tokens
+github.com/gophercloud/gophercloud/v2/openstack/sharedfilesystems/v2/sharetypes
 github.com/gophercloud/gophercloud/v2/openstack/utils
 github.com/gophercloud/gophercloud/v2/pagination
 # github.com/gophercloud/utils/v2 v2.0.0-20240812072210-8ce1fc0f2894


### PR DESCRIPTION
This is the second part of the process to merge OpenStack Manila CSI operator into csi-operator.

This PR does the following:

- Adds Manila assets
- Adds the assets generator implementation
- Copy Manila Secret controller
- Use the control plane and guest namespaces
- Adds a new controller that manages the start of all controllers
- Adapt manila to use the precondition available with the new controller