### PR TITLE
OCPBUGS-41365: add ability to control kube rbac proxy container image…

### DIFF
--- a/pkg/driver/common/operator/hooks.go
+++ b/pkg/driver/common/operator/hooks.go
@@ -3,6 +3,7 @@ package operator
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	opv1 "github.com/openshift/api/operator/v1"
 	"github.com/openshift/csi-operator/pkg/clients"
@@ -127,6 +128,7 @@ func withHyperShiftControlPlaneImages(c *clients.Clients) (dc.DeploymentHookFunc
 	hook := func(_ *opv1.OperatorSpec, deployment *appsv1.Deployment) error {
 		driverControlPlaneImage := os.Getenv("DRIVER_CONTROL_PLANE_IMAGE")
 		livenessProbeControlPlaneImage := os.Getenv("LIVENESS_PROBE_CONTROL_PLANE_IMAGE")
+		kubeRBACProxyControlPlaneImage := os.Getenv("KUBE_RBAC_PROXY_CONTROL_PLANE_IMAGE")
 		for i := range deployment.Spec.Template.Spec.Containers {
 			container := &deployment.Spec.Template.Spec.Containers[i]
 			if container.Name == "csi-driver" && driverControlPlaneImage != "" {
@@ -134,6 +136,9 @@ func withHyperShiftControlPlaneImages(c *clients.Clients) (dc.DeploymentHookFunc
 			}
 			if container.Name == "csi-liveness-probe" && livenessProbeControlPlaneImage != "" {
 				container.Image = livenessProbeControlPlaneImage
+			}
+			if strings.Contains(container.Name, "kube-rbac-proxy") && kubeRBACProxyControlPlaneImage != "" {
+				container.Image = kubeRBACProxyControlPlaneImage
 			}
 		}
 		return nil

--- a/pkg/driver/common/operator/hooks_test.go
+++ b/pkg/driver/common/operator/hooks_test.go
@@ -174,12 +174,18 @@ func Test_WithHyperShiftControlPlaneImages(t *testing.T) {
 		{
 			name: "env set",
 			env: map[string]string{
-				"DRIVER_CONTROL_PLANE_IMAGE":         "control_plane_driver_image:1",
-				"LIVENESS_PROBE_CONTROL_PLANE_IMAGE": "control_plane_livenessprobe_image:1",
+				"DRIVER_CONTROL_PLANE_IMAGE":          "control_plane_driver_image:1",
+				"LIVENESS_PROBE_CONTROL_PLANE_IMAGE":  "control_plane_livenessprobe_image:1",
+				"KUBE_RBAC_PROXY_CONTROL_PLANE_IMAGE": "control_plane_kube_rbac_proxy_image:1",
 			},
 			expectedContainerImages: map[string]string{
-				"csi-driver":         "control_plane_driver_image:1",
-				"csi-liveness-probe": "control_plane_livenessprobe_image:1",
+				"csi-driver":                  "control_plane_driver_image:1",
+				"csi-liveness-probe":          "control_plane_livenessprobe_image:1",
+				"kube-rbac-proxy-8201":        "control_plane_kube_rbac_proxy_image:1",
+				"provisioner-kube-rbac-proxy": "control_plane_kube_rbac_proxy_image:1",
+				"attacher-kube-rbac-proxy":    "control_plane_kube_rbac_proxy_image:1",
+				"resizer-kube-rbac-proxy":     "control_plane_kube_rbac_proxy_image:1",
+				"snapshotter-kube-rbac-proxy": "control_plane_kube_rbac_proxy_image:1",
 			},
 		},
 	}


### PR DESCRIPTION
OCPBUGS-41365: add ability to control kube rbac proxy container image on controlplane