### PR TITLE
OCPBUGS-42325: Set separate secrets for file and disk config on HyperShift

### DIFF
--- a/assets/overlays/azure-disk/generated/hypershift/controller.yaml
+++ b/assets/overlays/azure-disk/generated/hypershift/controller.yaml
@@ -409,4 +409,4 @@ spec:
           secretName: service-network-admin-kubeconfig
       - name: cloud-config
         secret:
-          secretName: azure-cloud-config
+          secretName: azure-disk-csi-config

--- a/assets/overlays/azure-disk/patches/controller_add_hypershift_controller.yaml
+++ b/assets/overlays/azure-disk/patches/controller_add_hypershift_controller.yaml
@@ -12,4 +12,4 @@ spec:
           secretName: service-network-admin-kubeconfig
       - name: cloud-config
         secret:
-          secretName: azure-cloud-config
+          secretName: azure-disk-csi-config

--- a/assets/overlays/azure-file/generated/hypershift/controller.yaml
+++ b/assets/overlays/azure-file/generated/hypershift/controller.yaml
@@ -415,4 +415,4 @@ spec:
           secretName: service-network-admin-kubeconfig
       - name: cloud-config
         secret:
-          secretName: azure-cloud-config
+          secretName: azure-file-csi-config

--- a/assets/overlays/azure-file/patches/controller_add_hypershift_controller.yaml
+++ b/assets/overlays/azure-file/patches/controller_add_hypershift_controller.yaml
@@ -12,4 +12,4 @@ spec:
           secretName: service-network-admin-kubeconfig
       - name: cloud-config
         secret:
-          secretName: azure-cloud-config
+          secretName: azure-file-csi-config


### PR DESCRIPTION
Set separate secrets for file and disk authentication config for Azure. Previously, these two components were reusing the same configuration as cloud provider.