### PR TITLE
OCPBUGS-42939: Correct aws efs csi driver config as removable

### DIFF
--- a/pkg/driver/aws-efs/aws_efs.go
+++ b/pkg/driver/aws-efs/aws_efs.go
@@ -102,7 +102,7 @@ func GetAWSEFSOperatorConfig() *config.OperatorConfig {
 		AssetReader:                     assets.ReadFile,
 		AssetDir:                        generatedAssetBase,
 		OperatorControllerConfigBuilder: GetAWSEFSOperatorControllerConfig,
-		Removable:                       false,
+		Removable:                       true,
 	}
 }
 


### PR DESCRIPTION
### OCPBUGS-42939: Correct aws efs csi driver config as removable

- We introduce the [standard approach](https://github.com/openshift/csi-operator/pull/215) when moving other OLM operators to csi-operator just by setting Removable: true in the OperatorConfig.
- The aws efs csi driver is an OLM based operator which should be removable when we delete the clustercsidriver the static resources should be removed directly.

**Test on local build aws efs csi driver operator paased with the fix patch**
```console
wangpenghao@pewang-mac  ~  oc get po
NAME                                             READY   STATUS    RESTARTS     AGE
aws-ebs-csi-driver-controller-64bbcdc4c7-qw28z   11/11   Running   0            9h
aws-ebs-csi-driver-controller-64bbcdc4c7-zv2mt   11/11   Running   4 (9h ago)   9h
aws-ebs-csi-driver-node-657tx                    3/3     Running   0            9h
aws-ebs-csi-driver-node-bq9gk                    3/3     Running   0            9h
aws-ebs-csi-driver-node-cd8qw                    3/3     Running   0            8h
aws-ebs-csi-driver-node-df882                    3/3     Running   0            9h
aws-ebs-csi-driver-node-pckcf                    3/3     Running   0            8h
aws-ebs-csi-driver-node-vh66g                    3/3     Running   0            9h
aws-ebs-csi-driver-operator-7cfb4c8546-xktkv     1/1     Running   2 (9h ago)   9h
aws-efs-csi-driver-controller-76ccb465d5-llcz5   5/5     Running   0            4m7s
aws-efs-csi-driver-controller-76ccb465d5-wmk24   5/5     Running   0            86s
aws-efs-csi-driver-node-4ml4d                    3/3     Running   0            4m9s
aws-efs-csi-driver-node-56fzl                    3/3     Running   0            4m9s
aws-efs-csi-driver-node-8wg86                    3/3     Running   0            4m9s
aws-efs-csi-driver-node-j8w7j                    3/3     Running   0            4m9s
aws-efs-csi-driver-node-kp964                    3/3     Running   0            4m9s
aws-efs-csi-driver-node-mdgzk                    3/3     Running   0            4m9s
aws-efs-csi-driver-operator-5fbf65f487-v8zsb     1/1     Running   0            31s
 wangpenghao@pewang-mac  ~  oc delete clustercsidriver efs.csi.aws.com
clustercsidriver.operator.openshift.io "efs.csi.aws.com" deleted
 wangpenghao@pewang-mac  ~  oc get po
NAME                                             READY   STATUS    RESTARTS     AGE
aws-ebs-csi-driver-controller-64bbcdc4c7-qw28z   11/11   Running   0            9h
aws-ebs-csi-driver-controller-64bbcdc4c7-zv2mt   11/11   Running   4 (9h ago)   9h
aws-ebs-csi-driver-node-657tx                    3/3     Running   0            9h
aws-ebs-csi-driver-node-bq9gk                    3/3     Running   0            9h
aws-ebs-csi-driver-node-cd8qw                    3/3     Running   0            8h
aws-ebs-csi-driver-node-df882                    3/3     Running   0            9h
aws-ebs-csi-driver-node-pckcf                    3/3     Running   0            8h
aws-ebs-csi-driver-node-vh66g                    3/3     Running   0            9h
aws-ebs-csi-driver-operator-7cfb4c8546-xktkv     1/1     Running   2 (9h ago)   9h
aws-efs-csi-driver-operator-5fbf65f487-v8zsb     1/1     Running   0            41
```