### PR TITLE
OSASINFRA-3628: Make guest namespace configurable

### DIFF
--- a/assets/base/node.yaml
+++ b/assets/base/node.yaml
@@ -2,7 +2,7 @@ kind: DaemonSet
 apiVersion: apps/v1
 metadata:
   name: ${ASSET_PREFIX}-node
-  namespace: openshift-cluster-csi-drivers
+  namespace: ${NODE_NAMESPACE}
 spec:
   selector:
     matchLabels:

--- a/assets/base/node_metrics_service.yaml
+++ b/assets/base/node_metrics_service.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: ${ASSET_PREFIX}-node-metrics
   name: ${ASSET_PREFIX}-node-metrics
-  namespace: openshift-cluster-csi-drivers
+  namespace: ${NODE_NAMESPACE}
 spec:
   ports:
   selector:

--- a/assets/base/node_metrics_servicemonitor.yaml
+++ b/assets/base/node_metrics_servicemonitor.yaml
@@ -2,7 +2,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: ${ASSET_PREFIX}-node-monitor
-  namespace: openshift-cluster-csi-drivers
+  namespace: ${NODE_NAMESPACE}
 spec:
   # Empty list to make json-patch work
   endpoints: []

--- a/assets/base/node_sa.yaml
+++ b/assets/base/node_sa.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: ${ASSET_PREFIX}-node-sa
-  namespace: openshift-cluster-csi-drivers
+  namespace: ${NODE_NAMESPACE}

--- a/assets/base/rbac/lease_leader_election_binding.yaml
+++ b/assets/base/rbac/lease_leader_election_binding.yaml
@@ -3,7 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: ${ASSET_PREFIX}-lease-leader-election
-  namespace: openshift-cluster-csi-drivers
+  namespace: ${NODE_NAMESPACE}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -11,4 +11,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: ${ASSET_PREFIX}-controller-sa
-  namespace: openshift-cluster-csi-drivers
+  namespace: ${NODE_NAMESPACE}

--- a/assets/base/rbac/lease_leader_election_role.yaml
+++ b/assets/base/rbac/lease_leader_election_role.yaml
@@ -3,7 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: ${ASSET_PREFIX}-lease-leader-election
-  namespace: openshift-cluster-csi-drivers
+  namespace: ${NODE_NAMESPACE}
 rules:
 - apiGroups: ["coordination.k8s.io"]
   resources: ["leases"]

--- a/assets/base/rbac/main_attacher_binding.yaml
+++ b/assets/base/rbac/main_attacher_binding.yaml
@@ -5,7 +5,7 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: ${ASSET_PREFIX}-controller-sa
-    namespace: openshift-cluster-csi-drivers
+    namespace: ${NODE_NAMESPACE}
 roleRef:
   kind: ClusterRole
   name: openshift-csi-main-attacher-role

--- a/assets/base/rbac/main_provisioner_binding.yaml
+++ b/assets/base/rbac/main_provisioner_binding.yaml
@@ -5,7 +5,7 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: ${ASSET_PREFIX}-controller-sa
-    namespace: openshift-cluster-csi-drivers
+    namespace: ${NODE_NAMESPACE}
 roleRef:
   kind: ClusterRole
   name: openshift-csi-main-provisioner-role

--- a/assets/base/rbac/main_resizer_binding.yaml
+++ b/assets/base/rbac/main_resizer_binding.yaml
@@ -5,7 +5,7 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: ${ASSET_PREFIX}-controller-sa
-    namespace: openshift-cluster-csi-drivers
+    namespace: ${NODE_NAMESPACE}
 roleRef:
   kind: ClusterRole
   name: openshift-csi-main-resizer-role

--- a/assets/base/rbac/main_snapshotter_binding.yaml
+++ b/assets/base/rbac/main_snapshotter_binding.yaml
@@ -5,7 +5,7 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: ${ASSET_PREFIX}-controller-sa
-    namespace: openshift-cluster-csi-drivers
+    namespace: ${NODE_NAMESPACE}
 roleRef:
   kind: ClusterRole
   name: openshift-csi-main-snapshotter-role

--- a/assets/base/rbac/node_kube_rbac_proxy_binding.yaml
+++ b/assets/base/rbac/node_kube_rbac_proxy_binding.yaml
@@ -6,7 +6,7 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: ${ASSET_PREFIX}-node-sa
-    namespace: openshift-cluster-csi-drivers
+    namespace: ${NODE_NAMESPACE}
 roleRef:
   kind: ClusterRole
   name: ${ASSET_SHORT_PREFIX}-node-kube-rbac-proxy-role

--- a/assets/base/rbac/node_privileged_binding.yaml
+++ b/assets/base/rbac/node_privileged_binding.yaml
@@ -5,7 +5,7 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: ${ASSET_PREFIX}-node-sa
-    namespace: openshift-cluster-csi-drivers
+    namespace: ${NODE_NAMESPACE}
 roleRef:
   kind: ClusterRole
   name: ${ASSET_SHORT_PREFIX}-privileged-role

--- a/assets/base/rbac/prometheus_binding.yaml
+++ b/assets/base/rbac/prometheus_binding.yaml
@@ -3,7 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: ${ASSET_PREFIX}-prometheus
-  namespace: openshift-cluster-csi-drivers
+  namespace: ${NODE_NAMESPACE}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/assets/base/rbac/prometheus_role.yaml
+++ b/assets/base/rbac/prometheus_role.yaml
@@ -3,7 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: ${ASSET_PREFIX}-prometheus
-  namespace: openshift-cluster-csi-drivers
+  namespace: ${NODE_NAMESPACE}
 rules:
 - apiGroups:
   - ""

--- a/assets/base/rbac/storageclass_reader_resizer_binding.yaml
+++ b/assets/base/rbac/storageclass_reader_resizer_binding.yaml
@@ -5,7 +5,7 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: ${ASSET_PREFIX}-controller-sa
-    namespace: openshift-cluster-csi-drivers
+    namespace: ${NODE_NAMESPACE}
 roleRef:
   kind: ClusterRole
   name: openshift-csi-resizer-storageclass-reader-role

--- a/assets/base/rbac/volumesnapshot_reader_provisioner_binding.yaml
+++ b/assets/base/rbac/volumesnapshot_reader_provisioner_binding.yaml
@@ -5,7 +5,7 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: ${ASSET_PREFIX}-controller-sa
-    namespace: openshift-cluster-csi-drivers
+    namespace: ${NODE_NAMESPACE}
 roleRef:
   kind: ClusterRole
   name: openshift-csi-provisioner-volumesnapshot-reader-role

--- a/assets/common/sidecars/attacher.yaml
+++ b/assets/common/sidecars/attacher.yaml
@@ -14,7 +14,7 @@ spec:
             - --leader-election-lease-duration=${LEADER_ELECTION_LEASE_DURATION}
             - --leader-election-renew-deadline=${LEADER_ELECTION_RENEW_DEADLINE}
             - --leader-election-retry-period=${LEADER_ELECTION_RETRY_PERIOD}
-            - --leader-election-namespace=openshift-cluster-csi-drivers
+            - --leader-election-namespace=${NODE_NAMESPACE}
             - --v=${LOG_LEVEL}
           # Empty env. instead of nil for json patch to append new env. vars there
           env: []

--- a/assets/common/sidecars/provisioner.yaml
+++ b/assets/common/sidecars/provisioner.yaml
@@ -14,7 +14,7 @@ spec:
             - --leader-election-lease-duration=${LEADER_ELECTION_LEASE_DURATION}
             - --leader-election-renew-deadline=${LEADER_ELECTION_RENEW_DEADLINE}
             - --leader-election-retry-period=${LEADER_ELECTION_RETRY_PERIOD}
-            - --leader-election-namespace=openshift-cluster-csi-drivers
+            - --leader-election-namespace=${NODE_NAMESPACE}
             - --v=${LOG_LEVEL}
           # Empty env. instead of nil for json patch to append new env. vars there
           env: []

--- a/assets/common/sidecars/resizer.yaml
+++ b/assets/common/sidecars/resizer.yaml
@@ -14,7 +14,7 @@ spec:
             - --leader-election-lease-duration=${LEADER_ELECTION_LEASE_DURATION}
             - --leader-election-renew-deadline=${LEADER_ELECTION_RENEW_DEADLINE}
             - --leader-election-retry-period=${LEADER_ELECTION_RETRY_PERIOD}
-            - --leader-election-namespace=openshift-cluster-csi-drivers
+            - --leader-election-namespace=${NODE_NAMESPACE}
             - --v=${LOG_LEVEL}
           # Empty env. instead of nil for json patch to append new env. vars there
           env: []

--- a/assets/common/sidecars/snapshotter.yaml
+++ b/assets/common/sidecars/snapshotter.yaml
@@ -14,7 +14,7 @@ spec:
             - --leader-election-lease-duration=${LEADER_ELECTION_LEASE_DURATION}
             - --leader-election-renew-deadline=${LEADER_ELECTION_RENEW_DEADLINE}
             - --leader-election-retry-period=${LEADER_ELECTION_RETRY_PERIOD}
-            - --leader-election-namespace=openshift-cluster-csi-drivers
+            - --leader-election-namespace=${NODE_NAMESPACE}
             - --v=${LOG_LEVEL}
           # Empty env. instead of nil for json patch to append new env. vars there
           env: []

--- a/assets/overlays/aws-ebs/generated/hypershift/controller.yaml
+++ b/assets/overlays/aws-ebs/generated/hypershift/controller.yaml
@@ -165,7 +165,7 @@ spec:
         - --leader-election-lease-duration=${LEADER_ELECTION_LEASE_DURATION}
         - --leader-election-renew-deadline=${LEADER_ELECTION_RENEW_DEADLINE}
         - --leader-election-retry-period=${LEADER_ELECTION_RETRY_PERIOD}
-        - --leader-election-namespace=openshift-cluster-csi-drivers
+        - --leader-election-namespace=${NODE_NAMESPACE}
         - --v=${LOG_LEVEL}
         - --default-fstype=ext4
         - --feature-gates=Topology=true
@@ -222,7 +222,7 @@ spec:
         - --leader-election-lease-duration=${LEADER_ELECTION_LEASE_DURATION}
         - --leader-election-renew-deadline=${LEADER_ELECTION_RENEW_DEADLINE}
         - --leader-election-retry-period=${LEADER_ELECTION_RETRY_PERIOD}
-        - --leader-election-namespace=openshift-cluster-csi-drivers
+        - --leader-election-namespace=${NODE_NAMESPACE}
         - --v=${LOG_LEVEL}
         - --timeout=60s
         - --kube-api-qps=20
@@ -276,7 +276,7 @@ spec:
         - --leader-election-lease-duration=${LEADER_ELECTION_LEASE_DURATION}
         - --leader-election-renew-deadline=${LEADER_ELECTION_RENEW_DEADLINE}
         - --leader-election-retry-period=${LEADER_ELECTION_RETRY_PERIOD}
-        - --leader-election-namespace=openshift-cluster-csi-drivers
+        - --leader-election-namespace=${NODE_NAMESPACE}
         - --v=${LOG_LEVEL}
         - --timeout=60s
         - --kube-api-qps=20
@@ -330,7 +330,7 @@ spec:
         - --leader-election-lease-duration=${LEADER_ELECTION_LEASE_DURATION}
         - --leader-election-renew-deadline=${LEADER_ELECTION_RENEW_DEADLINE}
         - --leader-election-retry-period=${LEADER_ELECTION_RETRY_PERIOD}
-        - --leader-election-namespace=openshift-cluster-csi-drivers
+        - --leader-election-namespace=${NODE_NAMESPACE}
         - --v=${LOG_LEVEL}
         - --extra-create-metadata
         - --kube-api-qps=20

--- a/assets/overlays/aws-ebs/generated/hypershift/lease_leader_election_binding.yaml
+++ b/assets/overlays/aws-ebs/generated/hypershift/lease_leader_election_binding.yaml
@@ -9,7 +9,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: aws-ebs-csi-driver-lease-leader-election
-  namespace: openshift-cluster-csi-drivers
+  namespace: ${NODE_NAMESPACE}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -17,4 +17,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: aws-ebs-csi-driver-controller-sa
-  namespace: openshift-cluster-csi-drivers
+  namespace: ${NODE_NAMESPACE}

--- a/assets/overlays/aws-ebs/generated/hypershift/lease_leader_election_role.yaml
+++ b/assets/overlays/aws-ebs/generated/hypershift/lease_leader_election_role.yaml
@@ -9,7 +9,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: aws-ebs-csi-driver-lease-leader-election
-  namespace: openshift-cluster-csi-drivers
+  namespace: ${NODE_NAMESPACE}
 rules:
 - apiGroups:
   - coordination.k8s.io

--- a/assets/overlays/aws-ebs/generated/hypershift/main_attacher_binding.yaml
+++ b/assets/overlays/aws-ebs/generated/hypershift/main_attacher_binding.yaml
@@ -16,4 +16,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: aws-ebs-csi-driver-controller-sa
-  namespace: openshift-cluster-csi-drivers
+  namespace: ${NODE_NAMESPACE}

--- a/assets/overlays/aws-ebs/generated/hypershift/main_provisioner_binding.yaml
+++ b/assets/overlays/aws-ebs/generated/hypershift/main_provisioner_binding.yaml
@@ -16,4 +16,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: aws-ebs-csi-driver-controller-sa
-  namespace: openshift-cluster-csi-drivers
+  namespace: ${NODE_NAMESPACE}

--- a/assets/overlays/aws-ebs/generated/hypershift/main_resizer_binding.yaml
+++ b/assets/overlays/aws-ebs/generated/hypershift/main_resizer_binding.yaml
@@ -16,4 +16,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: aws-ebs-csi-driver-controller-sa
-  namespace: openshift-cluster-csi-drivers
+  namespace: ${NODE_NAMESPACE}

--- a/assets/overlays/aws-ebs/generated/hypershift/main_snapshotter_binding.yaml
+++ b/assets/overlays/aws-ebs/generated/hypershift/main_snapshotter_binding.yaml
@@ -16,4 +16,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: aws-ebs-csi-driver-controller-sa
-  namespace: openshift-cluster-csi-drivers
+  namespace: ${NODE_NAMESPACE}

--- a/assets/overlays/aws-ebs/generated/hypershift/node.yaml
+++ b/assets/overlays/aws-ebs/generated/hypershift/node.yaml
@@ -17,7 +17,7 @@ metadata:
     config.openshift.io/inject-proxy: csi-driver
     config.openshift.io/inject-proxy-cabundle: csi-driver
   name: aws-ebs-csi-driver-node
-  namespace: openshift-cluster-csi-drivers
+  namespace: ${NODE_NAMESPACE}
 spec:
   selector:
     matchLabels:

--- a/assets/overlays/aws-ebs/generated/hypershift/node_privileged_binding.yaml
+++ b/assets/overlays/aws-ebs/generated/hypershift/node_privileged_binding.yaml
@@ -15,4 +15,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: aws-ebs-csi-driver-node-sa
-  namespace: openshift-cluster-csi-drivers
+  namespace: ${NODE_NAMESPACE}

--- a/assets/overlays/aws-ebs/generated/hypershift/node_sa.yaml
+++ b/assets/overlays/aws-ebs/generated/hypershift/node_sa.yaml
@@ -8,4 +8,4 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: aws-ebs-csi-driver-node-sa
-  namespace: openshift-cluster-csi-drivers
+  namespace: ${NODE_NAMESPACE}

--- a/assets/overlays/aws-ebs/generated/hypershift/storageclass_reader_resizer_binding.yaml
+++ b/assets/overlays/aws-ebs/generated/hypershift/storageclass_reader_resizer_binding.yaml
@@ -16,4 +16,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: aws-ebs-csi-driver-controller-sa
-  namespace: openshift-cluster-csi-drivers
+  namespace: ${NODE_NAMESPACE}

--- a/assets/overlays/aws-ebs/generated/hypershift/volumesnapshot_reader_provisioner_binding.yaml
+++ b/assets/overlays/aws-ebs/generated/hypershift/volumesnapshot_reader_provisioner_binding.yaml
@@ -16,4 +16,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: aws-ebs-csi-driver-controller-sa
-  namespace: openshift-cluster-csi-drivers
+  namespace: ${NODE_NAMESPACE}

--- a/assets/overlays/aws-ebs/generated/standalone/controller.yaml
+++ b/assets/overlays/aws-ebs/generated/standalone/controller.yaml
@@ -135,7 +135,7 @@ spec:
         - --leader-election-lease-duration=${LEADER_ELECTION_LEASE_DURATION}
         - --leader-election-renew-deadline=${LEADER_ELECTION_RENEW_DEADLINE}
         - --leader-election-retry-period=${LEADER_ELECTION_RETRY_PERIOD}
-        - --leader-election-namespace=openshift-cluster-csi-drivers
+        - --leader-election-namespace=${NODE_NAMESPACE}
         - --v=${LOG_LEVEL}
         - --default-fstype=ext4
         - --feature-gates=Topology=true
@@ -186,7 +186,7 @@ spec:
         - --leader-election-lease-duration=${LEADER_ELECTION_LEASE_DURATION}
         - --leader-election-renew-deadline=${LEADER_ELECTION_RENEW_DEADLINE}
         - --leader-election-retry-period=${LEADER_ELECTION_RETRY_PERIOD}
-        - --leader-election-namespace=openshift-cluster-csi-drivers
+        - --leader-election-namespace=${NODE_NAMESPACE}
         - --v=${LOG_LEVEL}
         - --timeout=60s
         - --kube-api-qps=20
@@ -234,7 +234,7 @@ spec:
         - --leader-election-lease-duration=${LEADER_ELECTION_LEASE_DURATION}
         - --leader-election-renew-deadline=${LEADER_ELECTION_RENEW_DEADLINE}
         - --leader-election-retry-period=${LEADER_ELECTION_RETRY_PERIOD}
-        - --leader-election-namespace=openshift-cluster-csi-drivers
+        - --leader-election-namespace=${NODE_NAMESPACE}
         - --v=${LOG_LEVEL}
         - --timeout=60s
         - --kube-api-qps=20
@@ -282,7 +282,7 @@ spec:
         - --leader-election-lease-duration=${LEADER_ELECTION_LEASE_DURATION}
         - --leader-election-renew-deadline=${LEADER_ELECTION_RENEW_DEADLINE}
         - --leader-election-retry-period=${LEADER_ELECTION_RETRY_PERIOD}
-        - --leader-election-namespace=openshift-cluster-csi-drivers
+        - --leader-election-namespace=${NODE_NAMESPACE}
         - --v=${LOG_LEVEL}
         - --extra-create-metadata
         - --kube-api-qps=20

--- a/assets/overlays/aws-ebs/generated/standalone/lease_leader_election_binding.yaml
+++ b/assets/overlays/aws-ebs/generated/standalone/lease_leader_election_binding.yaml
@@ -9,7 +9,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: aws-ebs-csi-driver-lease-leader-election
-  namespace: openshift-cluster-csi-drivers
+  namespace: ${NODE_NAMESPACE}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -17,4 +17,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: aws-ebs-csi-driver-controller-sa
-  namespace: openshift-cluster-csi-drivers
+  namespace: ${NODE_NAMESPACE}

--- a/assets/overlays/aws-ebs/generated/standalone/lease_leader_election_role.yaml
+++ b/assets/overlays/aws-ebs/generated/standalone/lease_leader_election_role.yaml
@@ -9,7 +9,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: aws-ebs-csi-driver-lease-leader-election
-  namespace: openshift-cluster-csi-drivers
+  namespace: ${NODE_NAMESPACE}
 rules:
 - apiGroups:
   - coordination.k8s.io

--- a/assets/overlays/aws-ebs/generated/standalone/main_attacher_binding.yaml
+++ b/assets/overlays/aws-ebs/generated/standalone/main_attacher_binding.yaml
@@ -16,4 +16,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: aws-ebs-csi-driver-controller-sa
-  namespace: openshift-cluster-csi-drivers
+  namespace: ${NODE_NAMESPACE}

--- a/assets/overlays/aws-ebs/generated/standalone/main_provisioner_binding.yaml
+++ b/assets/overlays/aws-ebs/generated/standalone/main_provisioner_binding.yaml
@@ -16,4 +16,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: aws-ebs-csi-driver-controller-sa
-  namespace: openshift-cluster-csi-drivers
+  namespace: ${NODE_NAMESPACE}

--- a/assets/overlays/aws-ebs/generated/standalone/main_resizer_binding.yaml
+++ b/assets/overlays/aws-ebs/generated/standalone/main_resizer_binding.yaml
@@ -16,4 +16,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: aws-ebs-csi-driver-controller-sa
-  namespace: openshift-cluster-csi-drivers
+  namespace: ${NODE_NAMESPACE}

--- a/assets/overlays/aws-ebs/generated/standalone/main_snapshotter_binding.yaml
+++ b/assets/overlays/aws-ebs/generated/standalone/main_snapshotter_binding.yaml
@@ -16,4 +16,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: aws-ebs-csi-driver-controller-sa
-  namespace: openshift-cluster-csi-drivers
+  namespace: ${NODE_NAMESPACE}

--- a/assets/overlays/aws-ebs/generated/standalone/node.yaml
+++ b/assets/overlays/aws-ebs/generated/standalone/node.yaml
@@ -17,7 +17,7 @@ metadata:
     config.openshift.io/inject-proxy: csi-driver
     config.openshift.io/inject-proxy-cabundle: csi-driver
   name: aws-ebs-csi-driver-node
-  namespace: openshift-cluster-csi-drivers
+  namespace: ${NODE_NAMESPACE}
 spec:
   selector:
     matchLabels:

--- a/assets/overlays/aws-ebs/generated/standalone/node_privileged_binding.yaml
+++ b/assets/overlays/aws-ebs/generated/standalone/node_privileged_binding.yaml
@@ -15,4 +15,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: aws-ebs-csi-driver-node-sa
-  namespace: openshift-cluster-csi-drivers
+  namespace: ${NODE_NAMESPACE}

--- a/assets/overlays/aws-ebs/generated/standalone/node_sa.yaml
+++ b/assets/overlays/aws-ebs/generated/standalone/node_sa.yaml
@@ -8,4 +8,4 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: aws-ebs-csi-driver-node-sa
-  namespace: openshift-cluster-csi-drivers
+  namespace: ${NODE_NAMESPACE}

--- a/assets/overlays/aws-ebs/generated/standalone/prometheus_binding.yaml
+++ b/assets/overlays/aws-ebs/generated/standalone/prometheus_binding.yaml
@@ -9,7 +9,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: aws-ebs-csi-driver-prometheus
-  namespace: openshift-cluster-csi-drivers
+  namespace: ${NODE_NAMESPACE}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/assets/overlays/aws-ebs/generated/standalone/prometheus_role.yaml
+++ b/assets/overlays/aws-ebs/generated/standalone/prometheus_role.yaml
@@ -9,7 +9,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: aws-ebs-csi-driver-prometheus
-  namespace: openshift-cluster-csi-drivers
+  namespace: ${NODE_NAMESPACE}
 rules:
 - apiGroups:
   - ""

--- a/assets/overlays/aws-ebs/generated/standalone/storageclass_reader_resizer_binding.yaml
+++ b/assets/overlays/aws-ebs/generated/standalone/storageclass_reader_resizer_binding.yaml
@@ -16,4 +16,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: aws-ebs-csi-driver-controller-sa
-  namespace: openshift-cluster-csi-drivers
+  namespace: ${NODE_NAMESPACE}

--- a/assets/overlays/aws-ebs/generated/standalone/volumesnapshot_reader_provisioner_binding.yaml
+++ b/assets/overlays/aws-ebs/generated/standalone/volumesnapshot_reader_provisioner_binding.yaml
@@ -16,4 +16,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: aws-ebs-csi-driver-controller-sa
-  namespace: openshift-cluster-csi-drivers
+  namespace: ${NODE_NAMESPACE}

--- a/assets/overlays/aws-efs/generated/standalone/controller.yaml
+++ b/assets/overlays/aws-efs/generated/standalone/controller.yaml
@@ -100,7 +100,7 @@ spec:
         - --leader-election-lease-duration=${LEADER_ELECTION_LEASE_DURATION}
         - --leader-election-renew-deadline=${LEADER_ELECTION_RENEW_DEADLINE}
         - --leader-election-retry-period=${LEADER_ELECTION_RETRY_PERIOD}
-        - --leader-election-namespace=openshift-cluster-csi-drivers
+        - --leader-election-namespace=${NODE_NAMESPACE}
         - --v=${LOG_LEVEL}
         - --feature-gates=Topology=true
         - --extra-create-metadata=true

--- a/assets/overlays/aws-efs/generated/standalone/lease_leader_election_binding.yaml
+++ b/assets/overlays/aws-efs/generated/standalone/lease_leader_election_binding.yaml
@@ -10,7 +10,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: aws-efs-csi-driver-lease-leader-election
-  namespace: openshift-cluster-csi-drivers
+  namespace: ${NODE_NAMESPACE}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/assets/overlays/aws-efs/generated/standalone/lease_leader_election_role.yaml
+++ b/assets/overlays/aws-efs/generated/standalone/lease_leader_election_role.yaml
@@ -9,7 +9,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: aws-efs-csi-driver-lease-leader-election
-  namespace: openshift-cluster-csi-drivers
+  namespace: ${NODE_NAMESPACE}
 rules:
 - apiGroups:
   - coordination.k8s.io

--- a/assets/overlays/aws-efs/generated/standalone/node_privileged_binding.yaml
+++ b/assets/overlays/aws-efs/generated/standalone/node_privileged_binding.yaml
@@ -15,4 +15,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: aws-efs-csi-driver-node-sa
-  namespace: openshift-cluster-csi-drivers
+  namespace: ${NODE_NAMESPACE}

--- a/assets/overlays/aws-efs/generated/standalone/node_sa.yaml
+++ b/assets/overlays/aws-efs/generated/standalone/node_sa.yaml
@@ -8,4 +8,4 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: aws-efs-csi-driver-node-sa
-  namespace: openshift-cluster-csi-drivers
+  namespace: ${NODE_NAMESPACE}

--- a/assets/overlays/aws-efs/generated/standalone/prometheus_binding.yaml
+++ b/assets/overlays/aws-efs/generated/standalone/prometheus_binding.yaml
@@ -9,7 +9,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: aws-efs-csi-driver-prometheus
-  namespace: openshift-cluster-csi-drivers
+  namespace: ${NODE_NAMESPACE}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/assets/overlays/aws-efs/generated/standalone/prometheus_role.yaml
+++ b/assets/overlays/aws-efs/generated/standalone/prometheus_role.yaml
@@ -9,7 +9,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: aws-efs-csi-driver-prometheus
-  namespace: openshift-cluster-csi-drivers
+  namespace: ${NODE_NAMESPACE}
 rules:
 - apiGroups:
   - ""

--- a/assets/overlays/azure-disk/generated/hypershift/controller.yaml
+++ b/assets/overlays/azure-disk/generated/hypershift/controller.yaml
@@ -158,7 +158,7 @@ spec:
         - --leader-election-lease-duration=${LEADER_ELECTION_LEASE_DURATION}
         - --leader-election-renew-deadline=${LEADER_ELECTION_RENEW_DEADLINE}
         - --leader-election-retry-period=${LEADER_ELECTION_RETRY_PERIOD}
-        - --leader-election-namespace=openshift-cluster-csi-drivers
+        - --leader-election-namespace=${NODE_NAMESPACE}
         - --v=${LOG_LEVEL}
         - --default-fstype=ext4
         - --feature-gates=Topology=true
@@ -216,7 +216,7 @@ spec:
         - --leader-election-lease-duration=${LEADER_ELECTION_LEASE_DURATION}
         - --leader-election-renew-deadline=${LEADER_ELECTION_RENEW_DEADLINE}
         - --leader-election-retry-period=${LEADER_ELECTION_RETRY_PERIOD}
-        - --leader-election-namespace=openshift-cluster-csi-drivers
+        - --leader-election-namespace=${NODE_NAMESPACE}
         - --v=${LOG_LEVEL}
         - --timeout=1200s
         - --worker-threads=1000
@@ -270,7 +270,7 @@ spec:
         - --leader-election-lease-duration=${LEADER_ELECTION_LEASE_DURATION}
         - --leader-election-renew-deadline=${LEADER_ELECTION_RENEW_DEADLINE}
         - --leader-election-retry-period=${LEADER_ELECTION_RETRY_PERIOD}
-        - --leader-election-namespace=openshift-cluster-csi-drivers
+        - --leader-election-namespace=${NODE_NAMESPACE}
         - --v=${LOG_LEVEL}
         - --timeout=240s
         - -handle-volume-inuse-error=false
@@ -322,7 +322,7 @@ spec:
         - --leader-election-lease-duration=${LEADER_ELECTION_LEASE_DURATION}
         - --leader-election-renew-deadline=${LEADER_ELECTION_RENEW_DEADLINE}
         - --leader-election-retry-period=${LEADER_ELECTION_RETRY_PERIOD}
-        - --leader-election-namespace=openshift-cluster-csi-drivers
+        - --leader-election-namespace=${NODE_NAMESPACE}
         - --v=${LOG_LEVEL}
         - --timeout=600s
         - --kubeconfig=$(KUBECONFIG)

--- a/assets/overlays/azure-disk/generated/hypershift/lease_leader_election_binding.yaml
+++ b/assets/overlays/azure-disk/generated/hypershift/lease_leader_election_binding.yaml
@@ -9,7 +9,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: azure-disk-csi-driver-lease-leader-election
-  namespace: openshift-cluster-csi-drivers
+  namespace: ${NODE_NAMESPACE}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -17,4 +17,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: azure-disk-csi-driver-controller-sa
-  namespace: openshift-cluster-csi-drivers
+  namespace: ${NODE_NAMESPACE}

--- a/assets/overlays/azure-disk/generated/hypershift/lease_leader_election_role.yaml
+++ b/assets/overlays/azure-disk/generated/hypershift/lease_leader_election_role.yaml
@@ -9,7 +9,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: azure-disk-csi-driver-lease-leader-election
-  namespace: openshift-cluster-csi-drivers
+  namespace: ${NODE_NAMESPACE}
 rules:
 - apiGroups:
   - coordination.k8s.io

--- a/assets/overlays/azure-disk/generated/hypershift/main_attacher_binding.yaml
+++ b/assets/overlays/azure-disk/generated/hypershift/main_attacher_binding.yaml
@@ -16,4 +16,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: azure-disk-csi-driver-controller-sa
-  namespace: openshift-cluster-csi-drivers
+  namespace: ${NODE_NAMESPACE}

--- a/assets/overlays/azure-disk/generated/hypershift/main_provisioner_binding.yaml
+++ b/assets/overlays/azure-disk/generated/hypershift/main_provisioner_binding.yaml
@@ -16,4 +16,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: azure-disk-csi-driver-controller-sa
-  namespace: openshift-cluster-csi-drivers
+  namespace: ${NODE_NAMESPACE}

--- a/assets/overlays/azure-disk/generated/hypershift/main_resizer_binding.yaml
+++ b/assets/overlays/azure-disk/generated/hypershift/main_resizer_binding.yaml
@@ -16,4 +16,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: azure-disk-csi-driver-controller-sa
-  namespace: openshift-cluster-csi-drivers
+  namespace: ${NODE_NAMESPACE}

--- a/assets/overlays/azure-disk/generated/hypershift/main_snapshotter_binding.yaml
+++ b/assets/overlays/azure-disk/generated/hypershift/main_snapshotter_binding.yaml
@@ -16,4 +16,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: azure-disk-csi-driver-controller-sa
-  namespace: openshift-cluster-csi-drivers
+  namespace: ${NODE_NAMESPACE}

--- a/assets/overlays/azure-disk/generated/hypershift/node.yaml
+++ b/assets/overlays/azure-disk/generated/hypershift/node.yaml
@@ -18,7 +18,7 @@ metadata:
     config.openshift.io/inject-proxy: csi-driver
     config.openshift.io/inject-proxy-cabundle: csi-driver
   name: azure-disk-csi-driver-node
-  namespace: openshift-cluster-csi-drivers
+  namespace: ${NODE_NAMESPACE}
 spec:
   selector:
     matchLabels:

--- a/assets/overlays/azure-disk/generated/hypershift/node_kube_rbac_proxy_binding.yaml
+++ b/assets/overlays/azure-disk/generated/hypershift/node_kube_rbac_proxy_binding.yaml
@@ -16,4 +16,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: azure-disk-csi-driver-node-sa
-  namespace: openshift-cluster-csi-drivers
+  namespace: ${NODE_NAMESPACE}

--- a/assets/overlays/azure-disk/generated/hypershift/node_privileged_binding.yaml
+++ b/assets/overlays/azure-disk/generated/hypershift/node_privileged_binding.yaml
@@ -15,4 +15,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: azure-disk-csi-driver-node-sa
-  namespace: openshift-cluster-csi-drivers
+  namespace: ${NODE_NAMESPACE}

--- a/assets/overlays/azure-disk/generated/hypershift/node_sa.yaml
+++ b/assets/overlays/azure-disk/generated/hypershift/node_sa.yaml
@@ -8,4 +8,4 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: azure-disk-csi-driver-node-sa
-  namespace: openshift-cluster-csi-drivers
+  namespace: ${NODE_NAMESPACE}

--- a/assets/overlays/azure-disk/generated/hypershift/node_service.yaml
+++ b/assets/overlays/azure-disk/generated/hypershift/node_service.yaml
@@ -13,7 +13,7 @@ metadata:
   labels:
     app: azure-disk-csi-driver-node-metrics
   name: azure-disk-csi-driver-node-metrics
-  namespace: openshift-cluster-csi-drivers
+  namespace: ${NODE_NAMESPACE}
 spec:
   ports:
   - name: driver-m

--- a/assets/overlays/azure-disk/generated/hypershift/node_servicemonitor.yaml
+++ b/assets/overlays/azure-disk/generated/hypershift/node_servicemonitor.yaml
@@ -9,7 +9,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: azure-disk-csi-driver-node-monitor
-  namespace: openshift-cluster-csi-drivers
+  namespace: ${NODE_NAMESPACE}
 spec:
   endpoints:
   - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token

--- a/assets/overlays/azure-disk/generated/hypershift/storageclass_reader_resizer_binding.yaml
+++ b/assets/overlays/azure-disk/generated/hypershift/storageclass_reader_resizer_binding.yaml
@@ -16,4 +16,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: azure-disk-csi-driver-controller-sa
-  namespace: openshift-cluster-csi-drivers
+  namespace: ${NODE_NAMESPACE}

--- a/assets/overlays/azure-disk/generated/hypershift/volumesnapshot_reader_provisioner_binding.yaml
+++ b/assets/overlays/azure-disk/generated/hypershift/volumesnapshot_reader_provisioner_binding.yaml
@@ -16,4 +16,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: azure-disk-csi-driver-controller-sa
-  namespace: openshift-cluster-csi-drivers
+  namespace: ${NODE_NAMESPACE}

--- a/assets/overlays/azure-disk/generated/standalone/controller.yaml
+++ b/assets/overlays/azure-disk/generated/standalone/controller.yaml
@@ -129,7 +129,7 @@ spec:
         - --leader-election-lease-duration=${LEADER_ELECTION_LEASE_DURATION}
         - --leader-election-renew-deadline=${LEADER_ELECTION_RENEW_DEADLINE}
         - --leader-election-retry-period=${LEADER_ELECTION_RETRY_PERIOD}
-        - --leader-election-namespace=openshift-cluster-csi-drivers
+        - --leader-election-namespace=${NODE_NAMESPACE}
         - --v=${LOG_LEVEL}
         - --default-fstype=ext4
         - --feature-gates=Topology=true
@@ -181,7 +181,7 @@ spec:
         - --leader-election-lease-duration=${LEADER_ELECTION_LEASE_DURATION}
         - --leader-election-renew-deadline=${LEADER_ELECTION_RENEW_DEADLINE}
         - --leader-election-retry-period=${LEADER_ELECTION_RETRY_PERIOD}
-        - --leader-election-namespace=openshift-cluster-csi-drivers
+        - --leader-election-namespace=${NODE_NAMESPACE}
         - --v=${LOG_LEVEL}
         - --timeout=1200s
         - --worker-threads=1000
@@ -229,7 +229,7 @@ spec:
         - --leader-election-lease-duration=${LEADER_ELECTION_LEASE_DURATION}
         - --leader-election-renew-deadline=${LEADER_ELECTION_RENEW_DEADLINE}
         - --leader-election-retry-period=${LEADER_ELECTION_RETRY_PERIOD}
-        - --leader-election-namespace=openshift-cluster-csi-drivers
+        - --leader-election-namespace=${NODE_NAMESPACE}
         - --v=${LOG_LEVEL}
         - --timeout=240s
         - -handle-volume-inuse-error=false
@@ -275,7 +275,7 @@ spec:
         - --leader-election-lease-duration=${LEADER_ELECTION_LEASE_DURATION}
         - --leader-election-renew-deadline=${LEADER_ELECTION_RENEW_DEADLINE}
         - --leader-election-retry-period=${LEADER_ELECTION_RETRY_PERIOD}
-        - --leader-election-namespace=openshift-cluster-csi-drivers
+        - --leader-election-namespace=${NODE_NAMESPACE}
         - --v=${LOG_LEVEL}
         - --timeout=600s
         env: []

--- a/assets/overlays/azure-disk/generated/standalone/lease_leader_election_binding.yaml
+++ b/assets/overlays/azure-disk/generated/standalone/lease_leader_election_binding.yaml
@@ -9,7 +9,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: azure-disk-csi-driver-lease-leader-election
-  namespace: openshift-cluster-csi-drivers
+  namespace: ${NODE_NAMESPACE}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -17,4 +17,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: azure-disk-csi-driver-controller-sa
-  namespace: openshift-cluster-csi-drivers
+  namespace: ${NODE_NAMESPACE}

--- a/assets/overlays/azure-disk/generated/standalone/lease_leader_election_role.yaml
+++ b/assets/overlays/azure-disk/generated/standalone/lease_leader_election_role.yaml
@@ -9,7 +9,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: azure-disk-csi-driver-lease-leader-election
-  namespace: openshift-cluster-csi-drivers
+  namespace: ${NODE_NAMESPACE}
 rules:
 - apiGroups:
   - coordination.k8s.io

--- a/assets/overlays/azure-disk/generated/standalone/main_attacher_binding.yaml
+++ b/assets/overlays/azure-disk/generated/standalone/main_attacher_binding.yaml
@@ -16,4 +16,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: azure-disk-csi-driver-controller-sa
-  namespace: openshift-cluster-csi-drivers
+  namespace: ${NODE_NAMESPACE}

--- a/assets/overlays/azure-disk/generated/standalone/main_provisioner_binding.yaml
+++ b/assets/overlays/azure-disk/generated/standalone/main_provisioner_binding.yaml
@@ -16,4 +16,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: azure-disk-csi-driver-controller-sa
-  namespace: openshift-cluster-csi-drivers
+  namespace: ${NODE_NAMESPACE}

--- a/assets/overlays/azure-disk/generated/standalone/main_resizer_binding.yaml
+++ b/assets/overlays/azure-disk/generated/standalone/main_resizer_binding.yaml
@@ -16,4 +16,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: azure-disk-csi-driver-controller-sa
-  namespace: openshift-cluster-csi-drivers
+  namespace: ${NODE_NAMESPACE}

--- a/assets/overlays/azure-disk/generated/standalone/main_snapshotter_binding.yaml
+++ b/assets/overlays/azure-disk/generated/standalone/main_snapshotter_binding.yaml
@@ -16,4 +16,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: azure-disk-csi-driver-controller-sa
-  namespace: openshift-cluster-csi-drivers
+  namespace: ${NODE_NAMESPACE}

--- a/assets/overlays/azure-disk/generated/standalone/node.yaml
+++ b/assets/overlays/azure-disk/generated/standalone/node.yaml
@@ -18,7 +18,7 @@ metadata:
     config.openshift.io/inject-proxy: csi-driver
     config.openshift.io/inject-proxy-cabundle: csi-driver
   name: azure-disk-csi-driver-node
-  namespace: openshift-cluster-csi-drivers
+  namespace: ${NODE_NAMESPACE}
 spec:
   selector:
     matchLabels:

--- a/assets/overlays/azure-disk/generated/standalone/node_kube_rbac_proxy_binding.yaml
+++ b/assets/overlays/azure-disk/generated/standalone/node_kube_rbac_proxy_binding.yaml
@@ -16,4 +16,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: azure-disk-csi-driver-node-sa
-  namespace: openshift-cluster-csi-drivers
+  namespace: ${NODE_NAMESPACE}

--- a/assets/overlays/azure-disk/generated/standalone/node_privileged_binding.yaml
+++ b/assets/overlays/azure-disk/generated/standalone/node_privileged_binding.yaml
@@ -15,4 +15,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: azure-disk-csi-driver-node-sa
-  namespace: openshift-cluster-csi-drivers
+  namespace: ${NODE_NAMESPACE}

--- a/assets/overlays/azure-disk/generated/standalone/node_sa.yaml
+++ b/assets/overlays/azure-disk/generated/standalone/node_sa.yaml
@@ -8,4 +8,4 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: azure-disk-csi-driver-node-sa
-  namespace: openshift-cluster-csi-drivers
+  namespace: ${NODE_NAMESPACE}

--- a/assets/overlays/azure-disk/generated/standalone/node_service.yaml
+++ b/assets/overlays/azure-disk/generated/standalone/node_service.yaml
@@ -13,7 +13,7 @@ metadata:
   labels:
     app: azure-disk-csi-driver-node-metrics
   name: azure-disk-csi-driver-node-metrics
-  namespace: openshift-cluster-csi-drivers
+  namespace: ${NODE_NAMESPACE}
 spec:
   ports:
   - name: driver-m

--- a/assets/overlays/azure-disk/generated/standalone/node_servicemonitor.yaml
+++ b/assets/overlays/azure-disk/generated/standalone/node_servicemonitor.yaml
@@ -9,7 +9,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: azure-disk-csi-driver-node-monitor
-  namespace: openshift-cluster-csi-drivers
+  namespace: ${NODE_NAMESPACE}
 spec:
   endpoints:
   - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token

--- a/assets/overlays/azure-disk/generated/standalone/prometheus_binding.yaml
+++ b/assets/overlays/azure-disk/generated/standalone/prometheus_binding.yaml
@@ -9,7 +9,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: azure-disk-csi-driver-prometheus
-  namespace: openshift-cluster-csi-drivers
+  namespace: ${NODE_NAMESPACE}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/assets/overlays/azure-disk/generated/standalone/prometheus_role.yaml
+++ b/assets/overlays/azure-disk/generated/standalone/prometheus_role.yaml
@@ -9,7 +9,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: azure-disk-csi-driver-prometheus
-  namespace: openshift-cluster-csi-drivers
+  namespace: ${NODE_NAMESPACE}
 rules:
 - apiGroups:
   - ""

--- a/assets/overlays/azure-disk/generated/standalone/storageclass_reader_resizer_binding.yaml
+++ b/assets/overlays/azure-disk/generated/standalone/storageclass_reader_resizer_binding.yaml
@@ -16,4 +16,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: azure-disk-csi-driver-controller-sa
-  namespace: openshift-cluster-csi-drivers
+  namespace: ${NODE_NAMESPACE}

--- a/assets/overlays/azure-disk/generated/standalone/volumesnapshot_reader_provisioner_binding.yaml
+++ b/assets/overlays/azure-disk/generated/standalone/volumesnapshot_reader_provisioner_binding.yaml
@@ -16,4 +16,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: azure-disk-csi-driver-controller-sa
-  namespace: openshift-cluster-csi-drivers
+  namespace: ${NODE_NAMESPACE}

--- a/assets/overlays/azure-file/base/csi-driver-cluster-role-binding.yaml
+++ b/assets/overlays/azure-file/base/csi-driver-cluster-role-binding.yaml
@@ -5,7 +5,7 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: azure-file-csi-driver-controller-sa
-    namespace: openshift-cluster-csi-drivers
+    namespace: ${NODE_NAMESPACE}
 roleRef:
   kind: ClusterRole
   name: azure-file-csi-driver-role

--- a/assets/overlays/azure-file/generated/hypershift/controller.yaml
+++ b/assets/overlays/azure-file/generated/hypershift/controller.yaml
@@ -171,7 +171,7 @@ spec:
         - --leader-election-lease-duration=${LEADER_ELECTION_LEASE_DURATION}
         - --leader-election-renew-deadline=${LEADER_ELECTION_RENEW_DEADLINE}
         - --leader-election-retry-period=${LEADER_ELECTION_RETRY_PERIOD}
-        - --leader-election-namespace=openshift-cluster-csi-drivers
+        - --leader-election-namespace=${NODE_NAMESPACE}
         - --v=${LOG_LEVEL}
         - --extra-create-metadata=true
         - --timeout=300s
@@ -225,7 +225,7 @@ spec:
         - --leader-election-lease-duration=${LEADER_ELECTION_LEASE_DURATION}
         - --leader-election-renew-deadline=${LEADER_ELECTION_RENEW_DEADLINE}
         - --leader-election-retry-period=${LEADER_ELECTION_RETRY_PERIOD}
-        - --leader-election-namespace=openshift-cluster-csi-drivers
+        - --leader-election-namespace=${NODE_NAMESPACE}
         - --v=${LOG_LEVEL}
         - --timeout=120s
         - --kubeconfig=$(KUBECONFIG)
@@ -276,7 +276,7 @@ spec:
         - --leader-election-lease-duration=${LEADER_ELECTION_LEASE_DURATION}
         - --leader-election-renew-deadline=${LEADER_ELECTION_RENEW_DEADLINE}
         - --leader-election-retry-period=${LEADER_ELECTION_RETRY_PERIOD}
-        - --leader-election-namespace=openshift-cluster-csi-drivers
+        - --leader-election-namespace=${NODE_NAMESPACE}
         - --v=${LOG_LEVEL}
         - --timeout=120s
         - -handle-volume-inuse-error=false
@@ -328,7 +328,7 @@ spec:
         - --leader-election-lease-duration=${LEADER_ELECTION_LEASE_DURATION}
         - --leader-election-renew-deadline=${LEADER_ELECTION_RENEW_DEADLINE}
         - --leader-election-retry-period=${LEADER_ELECTION_RETRY_PERIOD}
-        - --leader-election-namespace=openshift-cluster-csi-drivers
+        - --leader-election-namespace=${NODE_NAMESPACE}
         - --v=${LOG_LEVEL}
         - --timeout=600s
         - --kubeconfig=$(KUBECONFIG)

--- a/assets/overlays/azure-file/generated/hypershift/csi-driver-cluster-role-binding.yaml
+++ b/assets/overlays/azure-file/generated/hypershift/csi-driver-cluster-role-binding.yaml
@@ -15,4 +15,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: azure-file-csi-driver-controller-sa
-  namespace: openshift-cluster-csi-drivers
+  namespace: ${NODE_NAMESPACE}

--- a/assets/overlays/azure-file/generated/hypershift/lease_leader_election_binding.yaml
+++ b/assets/overlays/azure-file/generated/hypershift/lease_leader_election_binding.yaml
@@ -9,7 +9,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: azure-file-csi-driver-lease-leader-election
-  namespace: openshift-cluster-csi-drivers
+  namespace: ${NODE_NAMESPACE}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -17,4 +17,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: azure-file-csi-driver-controller-sa
-  namespace: openshift-cluster-csi-drivers
+  namespace: ${NODE_NAMESPACE}

--- a/assets/overlays/azure-file/generated/hypershift/lease_leader_election_role.yaml
+++ b/assets/overlays/azure-file/generated/hypershift/lease_leader_election_role.yaml
@@ -9,7 +9,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: azure-file-csi-driver-lease-leader-election
-  namespace: openshift-cluster-csi-drivers
+  namespace: ${NODE_NAMESPACE}
 rules:
 - apiGroups:
   - coordination.k8s.io

--- a/assets/overlays/azure-file/generated/hypershift/main_attacher_binding.yaml
+++ b/assets/overlays/azure-file/generated/hypershift/main_attacher_binding.yaml
@@ -16,4 +16,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: azure-file-csi-driver-controller-sa
-  namespace: openshift-cluster-csi-drivers
+  namespace: ${NODE_NAMESPACE}

--- a/assets/overlays/azure-file/generated/hypershift/main_provisioner_binding.yaml
+++ b/assets/overlays/azure-file/generated/hypershift/main_provisioner_binding.yaml
@@ -16,4 +16,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: azure-file-csi-driver-controller-sa
-  namespace: openshift-cluster-csi-drivers
+  namespace: ${NODE_NAMESPACE}

--- a/assets/overlays/azure-file/generated/hypershift/main_resizer_binding.yaml
+++ b/assets/overlays/azure-file/generated/hypershift/main_resizer_binding.yaml
@@ -16,4 +16,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: azure-file-csi-driver-controller-sa
-  namespace: openshift-cluster-csi-drivers
+  namespace: ${NODE_NAMESPACE}

--- a/assets/overlays/azure-file/generated/hypershift/main_snapshotter_binding.yaml
+++ b/assets/overlays/azure-file/generated/hypershift/main_snapshotter_binding.yaml
@@ -16,4 +16,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: azure-file-csi-driver-controller-sa
-  namespace: openshift-cluster-csi-drivers
+  namespace: ${NODE_NAMESPACE}

--- a/assets/overlays/azure-file/generated/hypershift/node.yaml
+++ b/assets/overlays/azure-file/generated/hypershift/node.yaml
@@ -17,7 +17,7 @@ metadata:
     config.openshift.io/inject-proxy: csi-driver
     config.openshift.io/inject-proxy-cabundle: csi-driver
   name: azure-file-csi-driver-node
-  namespace: openshift-cluster-csi-drivers
+  namespace: ${NODE_NAMESPACE}
 spec:
   selector:
     matchLabels:

--- a/assets/overlays/azure-file/generated/hypershift/node_privileged_binding.yaml
+++ b/assets/overlays/azure-file/generated/hypershift/node_privileged_binding.yaml
@@ -15,4 +15,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: azure-file-csi-driver-node-sa
-  namespace: openshift-cluster-csi-drivers
+  namespace: ${NODE_NAMESPACE}

--- a/assets/overlays/azure-file/generated/hypershift/node_sa.yaml
+++ b/assets/overlays/azure-file/generated/hypershift/node_sa.yaml
@@ -8,4 +8,4 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: azure-file-csi-driver-node-sa
-  namespace: openshift-cluster-csi-drivers
+  namespace: ${NODE_NAMESPACE}

--- a/assets/overlays/azure-file/generated/hypershift/storageclass_reader_resizer_binding.yaml
+++ b/assets/overlays/azure-file/generated/hypershift/storageclass_reader_resizer_binding.yaml
@@ -16,4 +16,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: azure-file-csi-driver-controller-sa
-  namespace: openshift-cluster-csi-drivers
+  namespace: ${NODE_NAMESPACE}

--- a/assets/overlays/azure-file/generated/hypershift/volumesnapshot_reader_provisioner_binding.yaml
+++ b/assets/overlays/azure-file/generated/hypershift/volumesnapshot_reader_provisioner_binding.yaml
@@ -16,4 +16,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: azure-file-csi-driver-controller-sa
-  namespace: openshift-cluster-csi-drivers
+  namespace: ${NODE_NAMESPACE}

--- a/assets/overlays/azure-file/generated/standalone/controller.yaml
+++ b/assets/overlays/azure-file/generated/standalone/controller.yaml
@@ -135,7 +135,7 @@ spec:
         - --leader-election-lease-duration=${LEADER_ELECTION_LEASE_DURATION}
         - --leader-election-renew-deadline=${LEADER_ELECTION_RENEW_DEADLINE}
         - --leader-election-retry-period=${LEADER_ELECTION_RETRY_PERIOD}
-        - --leader-election-namespace=openshift-cluster-csi-drivers
+        - --leader-election-namespace=${NODE_NAMESPACE}
         - --v=${LOG_LEVEL}
         - --extra-create-metadata=true
         - --timeout=300s
@@ -183,7 +183,7 @@ spec:
         - --leader-election-lease-duration=${LEADER_ELECTION_LEASE_DURATION}
         - --leader-election-renew-deadline=${LEADER_ELECTION_RENEW_DEADLINE}
         - --leader-election-retry-period=${LEADER_ELECTION_RETRY_PERIOD}
-        - --leader-election-namespace=openshift-cluster-csi-drivers
+        - --leader-election-namespace=${NODE_NAMESPACE}
         - --v=${LOG_LEVEL}
         - --timeout=120s
         env: []
@@ -228,7 +228,7 @@ spec:
         - --leader-election-lease-duration=${LEADER_ELECTION_LEASE_DURATION}
         - --leader-election-renew-deadline=${LEADER_ELECTION_RENEW_DEADLINE}
         - --leader-election-retry-period=${LEADER_ELECTION_RETRY_PERIOD}
-        - --leader-election-namespace=openshift-cluster-csi-drivers
+        - --leader-election-namespace=${NODE_NAMESPACE}
         - --v=${LOG_LEVEL}
         - --timeout=120s
         - -handle-volume-inuse-error=false
@@ -274,7 +274,7 @@ spec:
         - --leader-election-lease-duration=${LEADER_ELECTION_LEASE_DURATION}
         - --leader-election-renew-deadline=${LEADER_ELECTION_RENEW_DEADLINE}
         - --leader-election-retry-period=${LEADER_ELECTION_RETRY_PERIOD}
-        - --leader-election-namespace=openshift-cluster-csi-drivers
+        - --leader-election-namespace=${NODE_NAMESPACE}
         - --v=${LOG_LEVEL}
         - --timeout=600s
         env: []

--- a/assets/overlays/azure-file/generated/standalone/csi-driver-cluster-role-binding.yaml
+++ b/assets/overlays/azure-file/generated/standalone/csi-driver-cluster-role-binding.yaml
@@ -15,4 +15,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: azure-file-csi-driver-controller-sa
-  namespace: openshift-cluster-csi-drivers
+  namespace: ${NODE_NAMESPACE}

--- a/assets/overlays/azure-file/generated/standalone/lease_leader_election_binding.yaml
+++ b/assets/overlays/azure-file/generated/standalone/lease_leader_election_binding.yaml
@@ -9,7 +9,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: azure-file-csi-driver-lease-leader-election
-  namespace: openshift-cluster-csi-drivers
+  namespace: ${NODE_NAMESPACE}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -17,4 +17,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: azure-file-csi-driver-controller-sa
-  namespace: openshift-cluster-csi-drivers
+  namespace: ${NODE_NAMESPACE}

--- a/assets/overlays/azure-file/generated/standalone/lease_leader_election_role.yaml
+++ b/assets/overlays/azure-file/generated/standalone/lease_leader_election_role.yaml
@@ -9,7 +9,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: azure-file-csi-driver-lease-leader-election
-  namespace: openshift-cluster-csi-drivers
+  namespace: ${NODE_NAMESPACE}
 rules:
 - apiGroups:
   - coordination.k8s.io

--- a/assets/overlays/azure-file/generated/standalone/main_attacher_binding.yaml
+++ b/assets/overlays/azure-file/generated/standalone/main_attacher_binding.yaml
@@ -16,4 +16,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: azure-file-csi-driver-controller-sa
-  namespace: openshift-cluster-csi-drivers
+  namespace: ${NODE_NAMESPACE}

--- a/assets/overlays/azure-file/generated/standalone/main_provisioner_binding.yaml
+++ b/assets/overlays/azure-file/generated/standalone/main_provisioner_binding.yaml
@@ -16,4 +16,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: azure-file-csi-driver-controller-sa
-  namespace: openshift-cluster-csi-drivers
+  namespace: ${NODE_NAMESPACE}

--- a/assets/overlays/azure-file/generated/standalone/main_resizer_binding.yaml
+++ b/assets/overlays/azure-file/generated/standalone/main_resizer_binding.yaml
@@ -16,4 +16,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: azure-file-csi-driver-controller-sa
-  namespace: openshift-cluster-csi-drivers
+  namespace: ${NODE_NAMESPACE}

--- a/assets/overlays/azure-file/generated/standalone/main_snapshotter_binding.yaml
+++ b/assets/overlays/azure-file/generated/standalone/main_snapshotter_binding.yaml
@@ -16,4 +16,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: azure-file-csi-driver-controller-sa
-  namespace: openshift-cluster-csi-drivers
+  namespace: ${NODE_NAMESPACE}

--- a/assets/overlays/azure-file/generated/standalone/node.yaml
+++ b/assets/overlays/azure-file/generated/standalone/node.yaml
@@ -17,7 +17,7 @@ metadata:
     config.openshift.io/inject-proxy: csi-driver
     config.openshift.io/inject-proxy-cabundle: csi-driver
   name: azure-file-csi-driver-node
-  namespace: openshift-cluster-csi-drivers
+  namespace: ${NODE_NAMESPACE}
 spec:
   selector:
     matchLabels:

--- a/assets/overlays/azure-file/generated/standalone/node_privileged_binding.yaml
+++ b/assets/overlays/azure-file/generated/standalone/node_privileged_binding.yaml
@@ -15,4 +15,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: azure-file-csi-driver-node-sa
-  namespace: openshift-cluster-csi-drivers
+  namespace: ${NODE_NAMESPACE}

--- a/assets/overlays/azure-file/generated/standalone/node_sa.yaml
+++ b/assets/overlays/azure-file/generated/standalone/node_sa.yaml
@@ -8,4 +8,4 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: azure-file-csi-driver-node-sa
-  namespace: openshift-cluster-csi-drivers
+  namespace: ${NODE_NAMESPACE}

--- a/assets/overlays/azure-file/generated/standalone/prometheus_binding.yaml
+++ b/assets/overlays/azure-file/generated/standalone/prometheus_binding.yaml
@@ -9,7 +9,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: azure-file-csi-driver-prometheus
-  namespace: openshift-cluster-csi-drivers
+  namespace: ${NODE_NAMESPACE}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/assets/overlays/azure-file/generated/standalone/prometheus_role.yaml
+++ b/assets/overlays/azure-file/generated/standalone/prometheus_role.yaml
@@ -9,7 +9,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: azure-file-csi-driver-prometheus
-  namespace: openshift-cluster-csi-drivers
+  namespace: ${NODE_NAMESPACE}
 rules:
 - apiGroups:
   - ""

--- a/assets/overlays/azure-file/generated/standalone/storageclass_reader_resizer_binding.yaml
+++ b/assets/overlays/azure-file/generated/standalone/storageclass_reader_resizer_binding.yaml
@@ -16,4 +16,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: azure-file-csi-driver-controller-sa
-  namespace: openshift-cluster-csi-drivers
+  namespace: ${NODE_NAMESPACE}

--- a/assets/overlays/azure-file/generated/standalone/volumesnapshot_reader_provisioner_binding.yaml
+++ b/assets/overlays/azure-file/generated/standalone/volumesnapshot_reader_provisioner_binding.yaml
@@ -16,4 +16,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: azure-file-csi-driver-controller-sa
-  namespace: openshift-cluster-csi-drivers
+  namespace: ${NODE_NAMESPACE}

--- a/assets/overlays/openstack-cinder/generated/standalone/controller.yaml
+++ b/assets/overlays/openstack-cinder/generated/standalone/controller.yaml
@@ -134,7 +134,7 @@ spec:
         - --leader-election-lease-duration=${LEADER_ELECTION_LEASE_DURATION}
         - --leader-election-renew-deadline=${LEADER_ELECTION_RENEW_DEADLINE}
         - --leader-election-retry-period=${LEADER_ELECTION_RETRY_PERIOD}
-        - --leader-election-namespace=openshift-cluster-csi-drivers
+        - --leader-election-namespace=${NODE_NAMESPACE}
         - --v=${LOG_LEVEL}
         - --timeout=3m
         - --feature-gates=Topology=$(ENABLE_TOPOLOGY)
@@ -186,7 +186,7 @@ spec:
         - --leader-election-lease-duration=${LEADER_ELECTION_LEASE_DURATION}
         - --leader-election-renew-deadline=${LEADER_ELECTION_RENEW_DEADLINE}
         - --leader-election-retry-period=${LEADER_ELECTION_RETRY_PERIOD}
-        - --leader-election-namespace=openshift-cluster-csi-drivers
+        - --leader-election-namespace=${NODE_NAMESPACE}
         - --v=${LOG_LEVEL}
         - --timeout=3m
         env: []
@@ -231,7 +231,7 @@ spec:
         - --leader-election-lease-duration=${LEADER_ELECTION_LEASE_DURATION}
         - --leader-election-renew-deadline=${LEADER_ELECTION_RENEW_DEADLINE}
         - --leader-election-retry-period=${LEADER_ELECTION_RETRY_PERIOD}
-        - --leader-election-namespace=openshift-cluster-csi-drivers
+        - --leader-election-namespace=${NODE_NAMESPACE}
         - --v=${LOG_LEVEL}
         env: []
         image: ${RESIZER_IMAGE}
@@ -275,7 +275,7 @@ spec:
         - --leader-election-lease-duration=${LEADER_ELECTION_LEASE_DURATION}
         - --leader-election-renew-deadline=${LEADER_ELECTION_RENEW_DEADLINE}
         - --leader-election-retry-period=${LEADER_ELECTION_RETRY_PERIOD}
-        - --leader-election-namespace=openshift-cluster-csi-drivers
+        - --leader-election-namespace=${NODE_NAMESPACE}
         - --v=${LOG_LEVEL}
         env: []
         image: ${SNAPSHOTTER_IMAGE}

--- a/assets/overlays/openstack-cinder/generated/standalone/lease_leader_election_binding.yaml
+++ b/assets/overlays/openstack-cinder/generated/standalone/lease_leader_election_binding.yaml
@@ -9,7 +9,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: openstack-cinder-csi-driver-lease-leader-election
-  namespace: openshift-cluster-csi-drivers
+  namespace: ${NODE_NAMESPACE}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -17,4 +17,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: openstack-cinder-csi-driver-controller-sa
-  namespace: openshift-cluster-csi-drivers
+  namespace: ${NODE_NAMESPACE}

--- a/assets/overlays/openstack-cinder/generated/standalone/lease_leader_election_role.yaml
+++ b/assets/overlays/openstack-cinder/generated/standalone/lease_leader_election_role.yaml
@@ -9,7 +9,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: openstack-cinder-csi-driver-lease-leader-election
-  namespace: openshift-cluster-csi-drivers
+  namespace: ${NODE_NAMESPACE}
 rules:
 - apiGroups:
   - coordination.k8s.io

--- a/assets/overlays/openstack-cinder/generated/standalone/main_attacher_binding.yaml
+++ b/assets/overlays/openstack-cinder/generated/standalone/main_attacher_binding.yaml
@@ -16,4 +16,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: openstack-cinder-csi-driver-controller-sa
-  namespace: openshift-cluster-csi-drivers
+  namespace: ${NODE_NAMESPACE}

--- a/assets/overlays/openstack-cinder/generated/standalone/main_provisioner_binding.yaml
+++ b/assets/overlays/openstack-cinder/generated/standalone/main_provisioner_binding.yaml
@@ -16,4 +16,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: openstack-cinder-csi-driver-controller-sa
-  namespace: openshift-cluster-csi-drivers
+  namespace: ${NODE_NAMESPACE}

--- a/assets/overlays/openstack-cinder/generated/standalone/main_resizer_binding.yaml
+++ b/assets/overlays/openstack-cinder/generated/standalone/main_resizer_binding.yaml
@@ -16,4 +16,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: openstack-cinder-csi-driver-controller-sa
-  namespace: openshift-cluster-csi-drivers
+  namespace: ${NODE_NAMESPACE}

--- a/assets/overlays/openstack-cinder/generated/standalone/main_snapshotter_binding.yaml
+++ b/assets/overlays/openstack-cinder/generated/standalone/main_snapshotter_binding.yaml
@@ -16,4 +16,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: openstack-cinder-csi-driver-controller-sa
-  namespace: openshift-cluster-csi-drivers
+  namespace: ${NODE_NAMESPACE}

--- a/assets/overlays/openstack-cinder/generated/standalone/node.yaml
+++ b/assets/overlays/openstack-cinder/generated/standalone/node.yaml
@@ -17,7 +17,7 @@ metadata:
     config.openshift.io/inject-proxy: csi-driver
     config.openshift.io/inject-proxy-cabundle: csi-driver
   name: openstack-cinder-csi-driver-node
-  namespace: openshift-cluster-csi-drivers
+  namespace: ${NODE_NAMESPACE}
 spec:
   selector:
     matchLabels:

--- a/assets/overlays/openstack-cinder/generated/standalone/node_privileged_binding.yaml
+++ b/assets/overlays/openstack-cinder/generated/standalone/node_privileged_binding.yaml
@@ -15,4 +15,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: openstack-cinder-csi-driver-node-sa
-  namespace: openshift-cluster-csi-drivers
+  namespace: ${NODE_NAMESPACE}

--- a/assets/overlays/openstack-cinder/generated/standalone/node_sa.yaml
+++ b/assets/overlays/openstack-cinder/generated/standalone/node_sa.yaml
@@ -8,4 +8,4 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: openstack-cinder-csi-driver-node-sa
-  namespace: openshift-cluster-csi-drivers
+  namespace: ${NODE_NAMESPACE}

--- a/assets/overlays/openstack-cinder/generated/standalone/prometheus_binding.yaml
+++ b/assets/overlays/openstack-cinder/generated/standalone/prometheus_binding.yaml
@@ -9,7 +9,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: openstack-cinder-csi-driver-prometheus
-  namespace: openshift-cluster-csi-drivers
+  namespace: ${NODE_NAMESPACE}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/assets/overlays/openstack-cinder/generated/standalone/prometheus_role.yaml
+++ b/assets/overlays/openstack-cinder/generated/standalone/prometheus_role.yaml
@@ -9,7 +9,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: openstack-cinder-csi-driver-prometheus
-  namespace: openshift-cluster-csi-drivers
+  namespace: ${NODE_NAMESPACE}
 rules:
 - apiGroups:
   - ""

--- a/assets/overlays/openstack-cinder/generated/standalone/storageclass_reader_resizer_binding.yaml
+++ b/assets/overlays/openstack-cinder/generated/standalone/storageclass_reader_resizer_binding.yaml
@@ -16,4 +16,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: openstack-cinder-csi-driver-controller-sa
-  namespace: openshift-cluster-csi-drivers
+  namespace: ${NODE_NAMESPACE}

--- a/assets/overlays/openstack-cinder/generated/standalone/volumesnapshot_reader_provisioner_binding.yaml
+++ b/assets/overlays/openstack-cinder/generated/standalone/volumesnapshot_reader_provisioner_binding.yaml
@@ -16,4 +16,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: openstack-cinder-csi-driver-controller-sa
-  namespace: openshift-cluster-csi-drivers
+  namespace: ${NODE_NAMESPACE}

--- a/assets/overlays/samba/base/configmap_and_secret_reader_provisioner_binding.yaml
+++ b/assets/overlays/samba/base/configmap_and_secret_reader_provisioner_binding.yaml
@@ -11,4 +11,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: smb-csi-driver-controller-sa
-  namespace: openshift-cluster-csi-drivers
+  namespace: ${NODE_NAMESPACE}

--- a/assets/overlays/samba/base/controller_privileged_binding.yaml
+++ b/assets/overlays/samba/base/controller_privileged_binding.yaml
@@ -11,4 +11,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: smb-csi-driver-controller-sa
-  namespace: openshift-cluster-csi-drivers
+  namespace:  ${NODE_NAMESPACE}

--- a/assets/overlays/samba/generated/standalone/controller.yaml
+++ b/assets/overlays/samba/generated/standalone/controller.yaml
@@ -109,7 +109,7 @@ spec:
         - --leader-election-lease-duration=${LEADER_ELECTION_LEASE_DURATION}
         - --leader-election-renew-deadline=${LEADER_ELECTION_RENEW_DEADLINE}
         - --leader-election-retry-period=${LEADER_ELECTION_RETRY_PERIOD}
-        - --leader-election-namespace=openshift-cluster-csi-drivers
+        - --leader-election-namespace=${NODE_NAMESPACE}
         - --v=${LOG_LEVEL}
         - --extra-create-metadata=true
         env: []

--- a/assets/overlays/samba/generated/standalone/lease_leader_election_binding.yaml
+++ b/assets/overlays/samba/generated/standalone/lease_leader_election_binding.yaml
@@ -10,7 +10,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: smb-csi-driver-lease-leader-election
-  namespace: openshift-cluster-csi-drivers
+  namespace: ${NODE_NAMESPACE}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/assets/overlays/samba/generated/standalone/lease_leader_election_role.yaml
+++ b/assets/overlays/samba/generated/standalone/lease_leader_election_role.yaml
@@ -9,7 +9,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: smb-csi-driver-lease-leader-election
-  namespace: openshift-cluster-csi-drivers
+  namespace: ${NODE_NAMESPACE}
 rules:
 - apiGroups:
   - coordination.k8s.io

--- a/assets/overlays/samba/generated/standalone/node.yaml
+++ b/assets/overlays/samba/generated/standalone/node.yaml
@@ -14,7 +14,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: smb-csi-driver-node
-  namespace: openshift-cluster-csi-drivers
+  namespace: ${NODE_NAMESPACE}
 spec:
   selector:
     matchLabels:

--- a/assets/overlays/samba/generated/standalone/node_sa.yaml
+++ b/assets/overlays/samba/generated/standalone/node_sa.yaml
@@ -8,4 +8,4 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: smb-csi-driver-node-sa
-  namespace: openshift-cluster-csi-drivers
+  namespace: ${NODE_NAMESPACE}

--- a/assets/overlays/samba/generated/standalone/prometheus_binding.yaml
+++ b/assets/overlays/samba/generated/standalone/prometheus_binding.yaml
@@ -9,7 +9,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: smb-csi-driver-prometheus
-  namespace: openshift-cluster-csi-drivers
+  namespace: ${NODE_NAMESPACE}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/assets/overlays/samba/generated/standalone/prometheus_role.yaml
+++ b/assets/overlays/samba/generated/standalone/prometheus_role.yaml
@@ -9,7 +9,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: smb-csi-driver-prometheus
-  namespace: openshift-cluster-csi-drivers
+  namespace: ${NODE_NAMESPACE}
 rules:
 - apiGroups:
   - ""

--- a/pkg/clients/builder.go
+++ b/pkg/clients/builder.go
@@ -30,6 +30,7 @@ import (
 type Builder struct {
 	userAgwent             string
 	csiDriverName          string
+	guestNamespace         string
 	resync                 time.Duration
 	controllerConfig       *controllercmd.ControllerContext
 	guestKubeConfig        *rest.Config
@@ -41,10 +42,11 @@ type Builder struct {
 }
 
 // NewBuilder creates a new Builder.
-func NewBuilder(userAgent string, csiDriverName string, controllerConfig *controllercmd.ControllerContext, resync time.Duration) *Builder {
+func NewBuilder(userAgent string, csiDriverName, guestNamespace string, controllerConfig *controllercmd.ControllerContext, resync time.Duration) *Builder {
 	return &Builder{
 		userAgwent:       userAgent,
 		csiDriverName:    csiDriverName,
+		guestNamespace:   guestNamespace,
 		resync:           resync,
 		controllerConfig: controllerConfig,
 		controlPlaneNamespaces: []string{
@@ -52,7 +54,7 @@ func NewBuilder(userAgent string, csiDriverName string, controllerConfig *contro
 		},
 		guestNamespaces: []string{
 			"",
-			CSIDriverNamespace,
+			guestNamespace,
 		},
 	}
 }
@@ -86,6 +88,7 @@ func (b *Builder) BuildOrDie(ctx context.Context) *Clients {
 
 		ControlPlaneDynamicClient:   controlPlaneDynamicClient,
 		ControlPlaneDynamicInformer: controlPlaneDynamicInformers,
+		GuestNamespace:              b.guestNamespace,
 	}
 
 	guestKubeClient := controlPlaneKubeClient

--- a/pkg/clients/builder.go
+++ b/pkg/clients/builder.go
@@ -106,11 +106,11 @@ func (b *Builder) BuildOrDie(ctx context.Context) *Clients {
 		// Use name of the operator Deployment in the management cluster + namespace
 		// in the guest cluster as the closest approximation of the real involvedObject.
 		controllerRef, err := events.GetControllerReferenceForCurrentPod(ctx, controlPlaneKubeClient, b.controllerConfig.OperatorNamespace, nil)
-		controllerRef.Namespace = CSIDriverNamespace
+		controllerRef.Namespace = b.guestNamespace
 		if err != nil {
 			klog.Warningf("unable to get owner reference (falling back to namespace): %v", err)
 		}
-		b.client.EventRecorder = events.NewKubeRecorder(guestKubeClient.CoreV1().Events(CSIDriverNamespace), b.userAgwent, controllerRef)
+		b.client.EventRecorder = events.NewKubeRecorder(guestKubeClient.CoreV1().Events(b.guestNamespace), b.userAgwent, controllerRef)
 
 		b.client.ControlPlaneHypeClient = hypextclient.NewForConfigOrDie(controlPlaneRestConfig)
 		b.client.ControlPlaneHypeInformer = hypextinformers.NewFilteredSharedInformerFactory(b.client.ControlPlaneHypeClient, b.resync, b.controllerConfig.OperatorNamespace, nil)
@@ -142,7 +142,7 @@ func (b *Builder) BuildOrDie(ctx context.Context) *Clients {
 	b.client.DynamicClient = guestDynamicClient
 
 	// TODO: non-filtered one for VolumeSnapshots?
-	b.client.DynamicInformer = dynamicinformer.NewFilteredDynamicSharedInformerFactory(guestDynamicClient, b.resync, CSIDriverNamespace, nil)
+	b.client.DynamicInformer = dynamicinformer.NewFilteredDynamicSharedInformerFactory(guestDynamicClient, b.resync, b.guestNamespace, nil)
 
 	b.client.OperatorClientSet = opclient.NewForConfigOrDie(guestKubeConfig)
 	b.client.OperatorInformers = opinformers.NewSharedInformerFactory(b.client.OperatorClientSet, b.resync)

--- a/pkg/clients/clients.go
+++ b/pkg/clients/clients.go
@@ -32,6 +32,9 @@ type Clients struct {
 	// i.e. openshift-cluster-csi-drivers.
 	ControlPlaneNamespace string
 
+	// Namespace where to install CSI driver guest.
+	GuestNamespace string
+
 	// Client for operator's ClusterCSIDriver CR. Always in the guest or standalone cluster.
 	OperatorClient v1helpers.OperatorClientWithFinalizers
 	// Informer for the ClusterCSIDriver CR. Always in the guest or standalone cluster.

--- a/pkg/clients/clients.go
+++ b/pkg/clients/clients.go
@@ -22,7 +22,6 @@ import (
 )
 
 const (
-	CSIDriverNamespace     = "openshift-cluster-csi-drivers"
 	ManagedConfigNamespace = "openshift-config-managed" // For kube-cloud-config config map. TODO: should be namespace list configurable?
 )
 

--- a/pkg/clients/fake.go
+++ b/pkg/clients/fake.go
@@ -23,12 +23,14 @@ import (
 	fakecore "k8s.io/client-go/kubernetes/fake"
 )
 
+const csiDriverNamespace = "openshift-cluster-csi-drivers"
+
 // NewFakeClients creates a new Clients full of fake interfaces for testing.
 // To add existing objects to the fake clients, use this pattern: c.controlPlaneKubeClient.(*fake.Clientset).Tracer().Add(obj1, obj2).
 // Each fake client interface has its own Tracer.
 func NewFakeClients(controllerNamespace string, cr *opv1.ClusterCSIDriver) *Clients {
 	controlPlaneKubeClient := fakecore.NewSimpleClientset()
-	controlPlaneKubeInformers := v1helpers.NewKubeInformersForNamespaces(controlPlaneKubeClient, controllerNamespace, "", CSIDriverNamespace)
+	controlPlaneKubeInformers := v1helpers.NewKubeInformersForNamespaces(controlPlaneKubeClient, controllerNamespace, "", csiDriverNamespace)
 
 	// Manually register HyperShift's CRDs used by the operator. We cannot import their schema,
 	// https://issues.redhat.com/browse/HOSTEDCP-336, This is necessary to enable List() support in the fake dynamic
@@ -44,7 +46,7 @@ func NewFakeClients(controllerNamespace string, cr *opv1.ClusterCSIDriver) *Clie
 	controlPlaneHypeInformers := hypextinformers.NewSharedInformerFactory(controlPlaneHypeClient, 0)
 
 	guestKubeClient := fakecore.NewSimpleClientset()
-	guestKubeInformers := v1helpers.NewKubeInformersForNamespaces(guestKubeClient, controllerNamespace, "", CSIDriverNamespace)
+	guestKubeInformers := v1helpers.NewKubeInformersForNamespaces(guestKubeClient, controllerNamespace, "", csiDriverNamespace)
 
 	guestAPIExtClient := fakeextapi.NewSimpleClientset()
 	guestAPIExtInformerFactory := apiextinformers.NewSharedInformerFactory(guestAPIExtClient, 0 /*no resync */)
@@ -62,7 +64,7 @@ func NewFakeClients(controllerNamespace string, cr *opv1.ClusterCSIDriver) *Clie
 
 	fakeObjectRef := corev1.ObjectReference{
 		Kind:       "Pod",
-		Namespace:  CSIDriverNamespace,
+		Namespace:  csiDriverNamespace,
 		Name:       "fake",
 		APIVersion: "v1",
 	}
@@ -74,7 +76,7 @@ func NewFakeClients(controllerNamespace string, cr *opv1.ClusterCSIDriver) *Clie
 		// OperatorClient.Informer().
 		operatorDynamicInformers: nil,
 
-		EventRecorder: events.NewKubeRecorder(guestKubeClient.CoreV1().Events(CSIDriverNamespace), "fake", &fakeObjectRef),
+		EventRecorder: events.NewKubeRecorder(guestKubeClient.CoreV1().Events(csiDriverNamespace), "fake", &fakeObjectRef),
 
 		ControlPlaneKubeClient:      controlPlaneKubeClient,
 		ControlPlaneKubeInformers:   controlPlaneKubeInformers,

--- a/pkg/driver/aws-ebs/aws_ebs.go
+++ b/pkg/driver/aws-ebs/aws_ebs.go
@@ -266,7 +266,7 @@ func newCustomAWSBundleSyncer(c *clients.Clients) (factory.Controller, error) {
 		Name:      cloudConfigName,
 	}
 	dstConfigMap := resourcesynccontroller.ResourceLocation{
-		Namespace: clients.CSIDriverNamespace,
+		Namespace: c.GuestNamespace,
 		Name:      cloudConfigName,
 	}
 	certController := resourcesynccontroller.NewResourceSyncController(
@@ -314,12 +314,12 @@ func withCABundleDeploymentHook(c *clients.Clients) (dc.DeploymentHookFunc, []fa
 // withCABundleDaemonSetHook projects custom CA bundle ConfigMap into the CSI driver container
 func withCABundleDaemonSetHook(c *clients.Clients) (csidrivernodeservicecontroller.DaemonSetHookFunc, []factory.Informer) {
 	hook := csidrivernodeservicecontroller.WithCABundleDaemonSetHook(
-		clients.CSIDriverNamespace,
+		c.GuestNamespace,
 		trustedCAConfigMap,
-		c.GetConfigMapInformer(clients.CSIDriverNamespace),
+		c.GetConfigMapInformer(c.GuestNamespace),
 	)
 	informers := []factory.Informer{
-		c.GetConfigMapInformer(clients.CSIDriverNamespace).Informer(),
+		c.GetConfigMapInformer(c.GuestNamespace).Informer(),
 	}
 	return hook, informers
 }

--- a/pkg/driver/azure-disk/azure_disk.go
+++ b/pkg/driver/azure-disk/azure_disk.go
@@ -288,7 +288,7 @@ func syncCloudConfigGuest(c *clients.Clients) (factory.Controller, error) {
 		Name:      configMapName,
 	}
 	dstConfigMap := resourcesynccontroller.ResourceLocation{
-		Namespace: clients.CSIDriverNamespace,
+		Namespace: c.GuestNamespace,
 		Name:      localCloudConfigName,
 	}
 	cloudConfigSyncController := resourcesynccontroller.NewResourceSyncController(
@@ -399,12 +399,12 @@ func getVolumeSnapshotHook() volume_snapshot_class.VolumeSnapshotClassHookFunc {
 // withCABundleDaemonSetHook projects custom CA bundle ConfigMap into the CSI driver container
 func withCABundleDaemonSetHook(c *clients.Clients) (csidrivernodeservicecontroller.DaemonSetHookFunc, []factory.Informer) {
 	hook := csidrivernodeservicecontroller.WithCABundleDaemonSetHook(
-		clients.CSIDriverNamespace,
+		c.GuestNamespace,
 		trustedCAConfigMap,
-		c.GetConfigMapInformer(clients.CSIDriverNamespace),
+		c.GetConfigMapInformer(c.GuestNamespace),
 	)
 	informers := []factory.Informer{
-		c.GetConfigMapInformer(clients.CSIDriverNamespace).Informer(),
+		c.GetConfigMapInformer(c.GuestNamespace).Informer(),
 	}
 	return hook, informers
 }

--- a/pkg/driver/azure-file/azure_file.go
+++ b/pkg/driver/azure-file/azure_file.go
@@ -211,7 +211,7 @@ func syncCloudConfigGuest(c *clients.Clients) (factory.Controller, error) {
 		Name:      configMapName,
 	}
 	dstConfigMap := resourcesynccontroller.ResourceLocation{
-		Namespace: clients.CSIDriverNamespace,
+		Namespace: c.GuestNamespace,
 		Name:      localCloudConfigName,
 	}
 	cloudConfigSyncController := resourcesynccontroller.NewResourceSyncController(
@@ -260,12 +260,12 @@ func syncCloudConfigStandAlone(c *clients.Clients) (factory.Controller, error) {
 // withCABundleDaemonSetHook projects custom CA bundle ConfigMap into the CSI driver container
 func withCABundleDaemonSetHook(c *clients.Clients) (csidrivernodeservicecontroller.DaemonSetHookFunc, []factory.Informer) {
 	hook := csidrivernodeservicecontroller.WithCABundleDaemonSetHook(
-		clients.CSIDriverNamespace,
+		c.GuestNamespace,
 		trustedCAConfigMap,
-		c.GetConfigMapInformer(clients.CSIDriverNamespace),
+		c.GetConfigMapInformer(c.GuestNamespace),
 	)
 	informers := []factory.Informer{
-		c.GetConfigMapInformer(clients.CSIDriverNamespace).Informer(),
+		c.GetConfigMapInformer(c.GuestNamespace).Informer(),
 	}
 	return hook, informers
 }

--- a/pkg/driver/common/operator/replacer.go
+++ b/pkg/driver/common/operator/replacer.go
@@ -16,7 +16,7 @@ const (
 	hyperShiftImageEnvName    = "HYPERSHIFT_IMAGE"
 )
 
-func DefaultReplacements(controlPlaneNamespace string) []string {
+func DefaultReplacements(controlPlaneNamespace, guestNamespace string) []string {
 	pairs := []string{}
 
 	// Replace container images by env vars if they are set
@@ -65,5 +65,6 @@ func DefaultReplacements(controlPlaneNamespace string) []string {
 		pairs = append(pairs, []string{"${HYPERSHIFT_IMAGE}", hyperShiftImage}...)
 	}
 	pairs = append(pairs, []string{"${NAMESPACE}", controlPlaneNamespace}...)
+	pairs = append(pairs, []string{"${NODE_NAMESPACE}", guestNamespace}...)
 	return pairs
 }

--- a/pkg/driver/openstack-cinder/openstack_cinder.go
+++ b/pkg/driver/openstack-cinder/openstack_cinder.go
@@ -158,12 +158,12 @@ func withCABundleDeploymentHook(c *clients.Clients) (dc.DeploymentHookFunc, []fa
 // withCABundleDaemonSetHook projects custom CA bundle ConfigMap into the CSI driver container
 func withCABundleDaemonSetHook(c *clients.Clients) (csidrivernodeservicecontroller.DaemonSetHookFunc, []factory.Informer) {
 	hook := csidrivernodeservicecontroller.WithCABundleDaemonSetHook(
-		clients.CSIDriverNamespace,
+		c.GuestNamespace,
 		trustedCAConfigMap,
-		c.GetConfigMapInformer(clients.CSIDriverNamespace),
+		c.GetConfigMapInformer(c.GuestNamespace),
 	)
 	informers := []factory.Informer{
-		c.GetConfigMapInformer(clients.CSIDriverNamespace).Informer(),
+		c.GetConfigMapInformer(c.GuestNamespace).Informer(),
 	}
 	return hook, informers
 }
@@ -201,6 +201,7 @@ func createConfigMapSyncer(c *clients.Clients) (factory.Controller, error) {
 		c.KubeClient,
 		c.KubeInformers,
 		c.ConfigInformers,
+		c.GuestNamespace,
 		resyncInterval,
 		c.EventRecorder)
 

--- a/pkg/openstack-cinder/config/configsync_test.go
+++ b/pkg/openstack-cinder/config/configsync_test.go
@@ -141,7 +141,7 @@ cloud       = openstack`,
 					"enable_topology": tc.expectedTopologyValue,
 				},
 			}
-			actualConfigMap, err := translateConfigMap(&sourceConfigMap, tc.generatedTopologyValue)
+			actualConfigMap, err := translateConfigMap(&sourceConfigMap, tc.generatedTopologyValue, expectedConfigMap.Namespace)
 			if tc.errMsg != "" {
 				g.Expect(err).Should(MatchError(tc.errMsg))
 				return

--- a/pkg/operator/config/config.go
+++ b/pkg/operator/config/config.go
@@ -18,6 +18,9 @@ import (
 type OperatorConfig struct {
 	// CSI driver name. ClusterCSIDriver with this name will be used as CR of this operator.
 	CSIDriverName opv1.CSIDriverName
+	// Guest namespace. This is the namespace that non-control plane resources
+	// will be placed in. This defaults to "openshift-cluster-csi-drivers" if unset.
+	GuestNamespace string
 	// HTTP User-agent for connection to the API server
 	UserAgent string
 	// Reader for generated assets.

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -66,7 +66,7 @@ func RunOperator(ctx context.Context, controllerConfig *controllercmd.Controller
 	if err != nil {
 		return err
 	}
-	defaultReplacements := operator.DefaultReplacements(controlPlaneNamespace)
+	defaultReplacements := operator.DefaultReplacements(controlPlaneNamespace, opConfig.GuestNamespace)
 	if csiOperatorControllerConfig.ExtraReplacementsFunc != nil {
 		defaultReplacements = append(defaultReplacements, csiOperatorControllerConfig.ExtraReplacementsFunc()...)
 	}

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -40,8 +40,13 @@ func RunOperator(ctx context.Context, controllerConfig *controllercmd.Controller
 		flavour = generator.FlavourHyperShift
 	}
 
+	if opConfig.GuestNamespace == "" {
+		// If no guest namespace is defined, let's set the default value.
+		opConfig.GuestNamespace = "openshift-cluster-csi-drivers"
+	}
+
 	// Create Clients
-	builder := clients.NewBuilder(opConfig.UserAgent, string(opConfig.CSIDriverName), controllerConfig, resync).
+	builder := clients.NewBuilder(opConfig.UserAgent, string(opConfig.CSIDriverName), opConfig.GuestNamespace, controllerConfig, resync).
 		WithHyperShiftGuest(guestKubeConfigString, opConfig.CloudConfigNamespace)
 
 	c := builder.BuildOrDie(ctx)

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -136,9 +136,9 @@ func RunOperator(ctx context.Context, controllerConfig *controllercmd.Controller
 	guestDaemonInformers := csiOperatorControllerConfig.GuestDaemonSetInformers
 
 	if len(csiOperatorControllerConfig.DaemonSetWatchedSecretNames) > 0 {
-		nodeSecretInformer := c.GetNodeSecretInformer(clients.CSIDriverNamespace)
+		nodeSecretInformer := c.GetNodeSecretInformer(c.GuestNamespace)
 		for _, secretName := range csiOperatorControllerConfig.DaemonSetWatchedSecretNames {
-			guestDaemonSetHooks = append(guestDaemonSetHooks, csidrivernodeservicecontroller.WithSecretHashAnnotationHook(clients.CSIDriverNamespace, secretName, nodeSecretInformer))
+			guestDaemonSetHooks = append(guestDaemonSetHooks, csidrivernodeservicecontroller.WithSecretHashAnnotationHook(c.GuestNamespace, secretName, nodeSecretInformer))
 			guestDaemonInformers = append(guestDaemonInformers, nodeSecretInformer.Informer())
 		}
 	}
@@ -147,7 +147,7 @@ func RunOperator(ctx context.Context, controllerConfig *controllercmd.Controller
 	if credentialsRequestAssetNames := a.GetCredentialsRequestAssetNames(); len(credentialsRequestAssetNames) > 0 {
 		controlPlaneCSIControllerSet.WithCredentialsRequestController(
 			csiOperatorControllerConfig.GetControllerName("CredentialsRequestController"),
-			clients.CSIDriverNamespace,
+			c.GuestNamespace,
 			a.GetAsset,
 			generated_assets.CredentialRequestControllerAssetName,
 			c.ControlPlaneDynamicClient,
@@ -174,7 +174,7 @@ func RunOperator(ctx context.Context, controllerConfig *controllercmd.Controller
 		a.GetAsset,
 		generated_assets.NodeDaemonSetAssetName,
 		c.KubeClient,
-		c.KubeInformers.InformersFor(clients.CSIDriverNamespace),
+		c.KubeInformers.InformersFor(c.GuestNamespace),
 		guestDaemonInformers,
 		guestDaemonSetHooks...,
 	)


### PR DESCRIPTION
All manila assets runs on the `openshift-manila-csi-driver` on standalone cluster and all the assets generated by csi-operator runs on the `openshift-cluster-csi-drivers`. In preparation for the integration of manila CSI into csi-operator, we need to ensure manila keeps running the same namespace it always did to avoid complications during upgrades. To achieve that let's make the guest namespace configurable, right now the control plane namespace already is.