### PR TITLE
NO-JIRA: ignore cmd/generator/main.go in .snyk

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -4,3 +4,4 @@
 exclude:
   global:
     - vendor/**
+    - cmd/generator/main.go


### PR DESCRIPTION
https://github.com/openshift/csi-operator/pull/287 introduced some new noise in the ci/prow/security job:

```
 ✗ [Medium] Path Traversal
   ID: d4eae1cf-1400-4b06-a906-bc189fed8faf 
   Path: cmd/generator/main.go, line 39 
   Info: Unsanitized input from a CLI argument flows into os.RemoveAll, where it is used as a path. This may result in a Path Traversal vulnerability and allow an attacker to delete arbitrary files.
```

cmd/generator/main.go is just a tool to generate static assets, not something an attacker could leverage to delete a file they couldn't otherwise delete.

/cc @openshift/storage
