### PR TITLE
OSASINFRA-3535: Add support for Hypershift to Cinder CSI

### DIFF
--- a/assets/overlays/openstack-cinder/generated/hypershift/cabundle_cm.yaml
+++ b/assets/overlays/openstack-cinder/generated/hypershift/cabundle_cm.yaml
@@ -1,0 +1,13 @@
+# Generated file. Do not edit. Update using "make update".
+#
+# Loaded from base/cabundle_cm.yaml
+#
+#
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    config.openshift.io/inject-trusted-cabundle: "true"
+  name: openstack-cinder-csi-driver-trusted-ca-bundle
+  namespace: ${NAMESPACE}

--- a/assets/overlays/openstack-cinder/generated/hypershift/controller.yaml
+++ b/assets/overlays/openstack-cinder/generated/hypershift/controller.yaml
@@ -415,7 +415,7 @@ spec:
           items:
           - key: ca-bundle.pem
             path: ca-bundle.pem
-          name: cloud-provider-config
+          name: cloud-conf
           optional: true
         name: cacert
       - name: hosted-kubeconfig

--- a/assets/overlays/openstack-cinder/generated/hypershift/controller.yaml
+++ b/assets/overlays/openstack-cinder/generated/hypershift/controller.yaml
@@ -1,0 +1,424 @@
+# Generated file. Do not edit. Update using "make update".
+#
+# Loaded from base/controller.yaml
+# Applied strategic merge patch overlays/openstack-cinder/patches/controller_add_driver.yaml
+# Applied strategic merge patch common/sidecars/controller_driver_kube_rbac_proxy.yaml
+# provisioner.yaml: Loaded from common/sidecars/provisioner.yaml
+# provisioner.yaml: Added arguments [--timeout=3m --feature-gates=Topology=$(ENABLE_TOPOLOGY) --default-fstype=ext4]
+# provisioner.yaml: Applied JSON patch common/hypershift/sidecar_add_kubeconfig.yaml.patch
+# provisioner.yaml: Applied strategic merge patch overlays/openstack-cinder/patches/provisioner_add_envvars.yaml
+# Applied strategic merge patch provisioner.yaml
+# attacher.yaml: Loaded from common/sidecars/attacher.yaml
+# attacher.yaml: Added arguments [--timeout=3m]
+# attacher.yaml: Applied JSON patch common/hypershift/sidecar_add_kubeconfig.yaml.patch
+# Applied strategic merge patch attacher.yaml
+# resizer.yaml: Loaded from common/sidecars/resizer.yaml
+# resizer.yaml: Applied JSON patch common/hypershift/sidecar_add_kubeconfig.yaml.patch
+# Applied strategic merge patch resizer.yaml
+# snapshotter.yaml: Loaded from common/sidecars/snapshotter.yaml
+# snapshotter.yaml: Applied JSON patch common/hypershift/sidecar_add_kubeconfig.yaml.patch
+# Applied strategic merge patch snapshotter.yaml
+# livenessprobe.yaml: Loaded from common/sidecars/livenessprobe.yaml
+# livenessprobe.yaml: Added arguments [--probe-timeout=10s]
+# Applied strategic merge patch livenessprobe.yaml
+# Applied strategic merge patch common/hypershift/controller_add_affinity_tolerations.yaml
+# Applied strategic merge patch overlays/openstack-cinder/patches/controller_add_hypershift_volumes.yaml
+#
+#
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    config.openshift.io/inject-proxy: csi-driver
+    config.openshift.io/inject-proxy-cabundle: csi-driver
+  name: openstack-cinder-csi-driver-controller
+  namespace: ${NAMESPACE}
+spec:
+  selector:
+    matchLabels:
+      app: openstack-cinder-csi-driver-controller
+  strategy:
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: cacert,config-cinderplugin,secret-cinderplugin,socket-dir
+        openshift.io/required-scc: restricted-v2
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+      labels:
+        app: openstack-cinder-csi-driver-controller
+        hypershift.openshift.io/hosted-control-plane: ${NAMESPACE}
+    spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: hypershift.openshift.io/control-plane
+                operator: In
+                values:
+                - "true"
+            weight: 50
+          - preference:
+              matchExpressions:
+              - key: hypershift.openshift.io/cluster
+                operator: In
+                values:
+                - ${NAMESPACE}
+            weight: 100
+        podAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  hypershift.openshift.io/hosted-control-plane: ${NAMESPACE}
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: openstack-cinder-csi-driver-controller
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+      containers:
+      - args:
+        - /bin/cinder-csi-plugin
+        - --provide-controller-service=true
+        - --provide-node-service=false
+        - --endpoint=$(CSI_ENDPOINT)
+        - --cloud-config=$(CLOUD_CONFIG)
+        - --cluster=${CLUSTER_ID}
+        - --v=${LOG_LEVEL}
+        env:
+        - name: CSI_ENDPOINT
+          value: unix://csi/csi.sock
+        - name: CLOUD_CONFIG
+          value: /etc/kubernetes/config/cloud.conf
+        image: ${DRIVER_IMAGE}
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          failureThreshold: 5
+          httpGet:
+            path: /healthz
+            port: healthz
+          initialDelaySeconds: 10
+          periodSeconds: 30
+          timeoutSeconds: 10
+        name: csi-driver
+        ports:
+        - containerPort: 10301
+          name: healthz
+          protocol: TCP
+        resources:
+          requests:
+            cpu: 10m
+            memory: 50Mi
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /etc/kubernetes/static-pod-resources/configmaps/cloud-config
+          name: cacert
+        - mountPath: /etc/kubernetes/config
+          name: config-cinderplugin
+          readOnly: true
+        - mountPath: /etc/kubernetes/secret
+          name: secret-cinderplugin
+          readOnly: true
+        - mountPath: /csi
+          name: socket-dir
+      - args:
+        - --secure-listen-address=0.0.0.0:9202
+        - --upstream=http://127.0.0.1:8202/
+        - --tls-cert-file=/etc/tls/private/tls.crt
+        - --tls-private-key-file=/etc/tls/private/tls.key
+        - --tls-cipher-suites=${TLS_CIPHER_SUITES}
+        - --tls-min-version=${TLS_MIN_VERSION}
+        - --logtostderr=true
+        image: ${KUBE_RBAC_PROXY_IMAGE}
+        imagePullPolicy: IfNotPresent
+        name: kube-rbac-proxy-8202
+        ports:
+        - containerPort: 9202
+          name: driver-m
+          protocol: TCP
+        resources:
+          requests:
+            cpu: 10m
+            memory: 20Mi
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /etc/tls/private
+          name: metrics-serving-cert
+      - args:
+        - --csi-address=/var/lib/csi/sockets/pluginproxy/csi.sock
+        - --http-endpoint=localhost:8203
+        - --leader-election
+        - --leader-election-lease-duration=${LEADER_ELECTION_LEASE_DURATION}
+        - --leader-election-renew-deadline=${LEADER_ELECTION_RENEW_DEADLINE}
+        - --leader-election-retry-period=${LEADER_ELECTION_RETRY_PERIOD}
+        - --leader-election-namespace=${NODE_NAMESPACE}
+        - --v=${LOG_LEVEL}
+        - --timeout=3m
+        - --feature-gates=Topology=$(ENABLE_TOPOLOGY)
+        - --default-fstype=ext4
+        - --kubeconfig=$(KUBECONFIG)
+        env:
+        - name: KUBECONFIG
+          value: /etc/hosted-kubernetes/kubeconfig
+        - name: ENABLE_TOPOLOGY
+          valueFrom:
+            configMapKeyRef:
+              key: enable_topology
+              name: cloud-conf
+        image: ${PROVISIONER_IMAGE}
+        imagePullPolicy: IfNotPresent
+        name: csi-provisioner
+        resources:
+          requests:
+            cpu: 10m
+            memory: 50Mi
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /var/lib/csi/sockets/pluginproxy/
+          name: socket-dir
+        - mountPath: /etc/hosted-kubernetes
+          name: hosted-kubeconfig
+          readOnly: true
+      - args:
+        - --secure-listen-address=0.0.0.0:9203
+        - --upstream=http://127.0.0.1:8203/
+        - --tls-cert-file=/etc/tls/private/tls.crt
+        - --tls-private-key-file=/etc/tls/private/tls.key
+        - --tls-cipher-suites=${TLS_CIPHER_SUITES}
+        - --tls-min-version=${TLS_MIN_VERSION}
+        - --logtostderr=true
+        image: ${KUBE_RBAC_PROXY_IMAGE}
+        imagePullPolicy: IfNotPresent
+        name: provisioner-kube-rbac-proxy
+        ports:
+        - containerPort: 9203
+          name: provisioner-m
+          protocol: TCP
+        resources:
+          requests:
+            cpu: 10m
+            memory: 20Mi
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /etc/tls/private
+          name: metrics-serving-cert
+      - args:
+        - --csi-address=/var/lib/csi/sockets/pluginproxy/csi.sock
+        - --http-endpoint=localhost:8204
+        - --leader-election
+        - --leader-election-lease-duration=${LEADER_ELECTION_LEASE_DURATION}
+        - --leader-election-renew-deadline=${LEADER_ELECTION_RENEW_DEADLINE}
+        - --leader-election-retry-period=${LEADER_ELECTION_RETRY_PERIOD}
+        - --leader-election-namespace=${NODE_NAMESPACE}
+        - --v=${LOG_LEVEL}
+        - --timeout=3m
+        - --kubeconfig=$(KUBECONFIG)
+        env:
+        - name: KUBECONFIG
+          value: /etc/hosted-kubernetes/kubeconfig
+        image: ${ATTACHER_IMAGE}
+        imagePullPolicy: IfNotPresent
+        name: csi-attacher
+        resources:
+          requests:
+            cpu: 10m
+            memory: 50Mi
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /var/lib/csi/sockets/pluginproxy/
+          name: socket-dir
+        - mountPath: /etc/hosted-kubernetes
+          name: hosted-kubeconfig
+          readOnly: true
+      - args:
+        - --secure-listen-address=0.0.0.0:9204
+        - --upstream=http://127.0.0.1:8204/
+        - --tls-cert-file=/etc/tls/private/tls.crt
+        - --tls-private-key-file=/etc/tls/private/tls.key
+        - --tls-cipher-suites=${TLS_CIPHER_SUITES}
+        - --tls-min-version=${TLS_MIN_VERSION}
+        - --logtostderr=true
+        image: ${KUBE_RBAC_PROXY_IMAGE}
+        imagePullPolicy: IfNotPresent
+        name: attacher-kube-rbac-proxy
+        ports:
+        - containerPort: 9204
+          name: attacher-m
+          protocol: TCP
+        resources:
+          requests:
+            cpu: 10m
+            memory: 20Mi
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /etc/tls/private
+          name: metrics-serving-cert
+      - args:
+        - --csi-address=/var/lib/csi/sockets/pluginproxy/csi.sock
+        - --http-endpoint=localhost:8205
+        - --leader-election
+        - --leader-election-lease-duration=${LEADER_ELECTION_LEASE_DURATION}
+        - --leader-election-renew-deadline=${LEADER_ELECTION_RENEW_DEADLINE}
+        - --leader-election-retry-period=${LEADER_ELECTION_RETRY_PERIOD}
+        - --leader-election-namespace=${NODE_NAMESPACE}
+        - --v=${LOG_LEVEL}
+        - --kubeconfig=$(KUBECONFIG)
+        env:
+        - name: KUBECONFIG
+          value: /etc/hosted-kubernetes/kubeconfig
+        image: ${RESIZER_IMAGE}
+        imagePullPolicy: IfNotPresent
+        name: csi-resizer
+        resources:
+          requests:
+            cpu: 10m
+            memory: 50Mi
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /var/lib/csi/sockets/pluginproxy/
+          name: socket-dir
+        - mountPath: /etc/hosted-kubernetes
+          name: hosted-kubeconfig
+          readOnly: true
+      - args:
+        - --secure-listen-address=0.0.0.0:9205
+        - --upstream=http://127.0.0.1:8205/
+        - --tls-cert-file=/etc/tls/private/tls.crt
+        - --tls-private-key-file=/etc/tls/private/tls.key
+        - --tls-cipher-suites=${TLS_CIPHER_SUITES}
+        - --tls-min-version=${TLS_MIN_VERSION}
+        - --logtostderr=true
+        image: ${KUBE_RBAC_PROXY_IMAGE}
+        imagePullPolicy: IfNotPresent
+        name: resizer-kube-rbac-proxy
+        ports:
+        - containerPort: 9205
+          name: resizer-m
+          protocol: TCP
+        resources:
+          requests:
+            cpu: 10m
+            memory: 20Mi
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /etc/tls/private
+          name: metrics-serving-cert
+      - args:
+        - --csi-address=/var/lib/csi/sockets/pluginproxy/csi.sock
+        - --metrics-address=localhost:8206
+        - --leader-election
+        - --leader-election-lease-duration=${LEADER_ELECTION_LEASE_DURATION}
+        - --leader-election-renew-deadline=${LEADER_ELECTION_RENEW_DEADLINE}
+        - --leader-election-retry-period=${LEADER_ELECTION_RETRY_PERIOD}
+        - --leader-election-namespace=${NODE_NAMESPACE}
+        - --v=${LOG_LEVEL}
+        - --kubeconfig=$(KUBECONFIG)
+        env:
+        - name: KUBECONFIG
+          value: /etc/hosted-kubernetes/kubeconfig
+        image: ${SNAPSHOTTER_IMAGE}
+        imagePullPolicy: IfNotPresent
+        name: csi-snapshotter
+        resources:
+          requests:
+            cpu: 10m
+            memory: 50Mi
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /var/lib/csi/sockets/pluginproxy/
+          name: socket-dir
+        - mountPath: /etc/hosted-kubernetes
+          name: hosted-kubeconfig
+          readOnly: true
+      - args:
+        - --secure-listen-address=0.0.0.0:9206
+        - --upstream=http://127.0.0.1:8206/
+        - --tls-cert-file=/etc/tls/private/tls.crt
+        - --tls-private-key-file=/etc/tls/private/tls.key
+        - --tls-cipher-suites=${TLS_CIPHER_SUITES}
+        - --tls-min-version=${TLS_MIN_VERSION}
+        - --logtostderr=true
+        image: ${KUBE_RBAC_PROXY_IMAGE}
+        imagePullPolicy: IfNotPresent
+        name: snapshotter-kube-rbac-proxy
+        ports:
+        - containerPort: 9206
+          name: snapshotter-m
+          protocol: TCP
+        resources:
+          requests:
+            cpu: 10m
+            memory: 20Mi
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /etc/tls/private
+          name: metrics-serving-cert
+      - args:
+        - --csi-address=/csi/csi.sock
+        - --health-port=10301
+        - --v=${LOG_LEVEL}
+        - --probe-timeout=10s
+        env: []
+        image: ${LIVENESS_PROBE_IMAGE}
+        imagePullPolicy: IfNotPresent
+        name: csi-liveness-probe
+        resources:
+          requests:
+            cpu: 10m
+            memory: 50Mi
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /csi
+          name: socket-dir
+      nodeSelector:
+        node-role.kubernetes.io/master: ""
+      priorityClassName: hypershift-control-plane
+      serviceAccount: openstack-cinder-csi-driver-controller-sa
+      tolerations:
+      - effect: NoSchedule
+        key: hypershift.openshift.io/control-plane
+        operator: Equal
+        value: "true"
+      - effect: NoSchedule
+        key: hypershift.openshift.io/cluster
+        operator: Equal
+        value: ${NAMESPACE}
+      volumes:
+      - emptyDir: {}
+        name: socket-dir
+      - name: metrics-serving-cert
+        secret:
+          secretName: openstack-cinder-csi-driver-controller-metrics-serving-cert
+      - name: secret-cinderplugin
+        secret:
+          items:
+          - key: clouds.yaml
+            path: clouds.yaml
+          secretName: openstack-cloud-credentials
+      - configMap:
+          items:
+          - key: cloud.conf
+            path: cloud.conf
+          name: cloud-conf
+        name: config-cinderplugin
+      - configMap:
+          items:
+          - key: ca-bundle.pem
+            path: ca-bundle.pem
+          name: cloud-provider-config
+          optional: true
+        name: cacert
+      - name: hosted-kubeconfig
+        secret:
+          defaultMode: 420
+          secretName: service-network-admin-kubeconfig

--- a/assets/overlays/openstack-cinder/generated/hypershift/controller_pdb.yaml
+++ b/assets/overlays/openstack-cinder/generated/hypershift/controller_pdb.yaml
@@ -1,0 +1,16 @@
+# Generated file. Do not edit. Update using "make update".
+#
+# Loaded from base/controller_pdb.yaml
+#
+#
+
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: openstack-cinder-csi-driver-controller-pdb
+  namespace: ${NAMESPACE}
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: openstack-cinder-csi-driver-controller

--- a/assets/overlays/openstack-cinder/generated/hypershift/controller_sa.yaml
+++ b/assets/overlays/openstack-cinder/generated/hypershift/controller_sa.yaml
@@ -1,0 +1,14 @@
+# Generated file. Do not edit. Update using "make update".
+#
+# Loaded from base/controller_sa.yaml
+# Applied strategic merge patch common/hypershift/controller_sa_pull_secret.yaml
+#
+#
+
+apiVersion: v1
+imagePullSecrets:
+- name: pull-secret
+kind: ServiceAccount
+metadata:
+  name: openstack-cinder-csi-driver-controller-sa
+  namespace: ${NAMESPACE}

--- a/assets/overlays/openstack-cinder/generated/hypershift/csidriver.yaml
+++ b/assets/overlays/openstack-cinder/generated/hypershift/csidriver.yaml
@@ -1,0 +1,21 @@
+# Generated file. Do not edit. Update using "make update".
+#
+# Loaded from overlays/openstack-cinder/base/csidriver.yaml
+#
+#
+
+apiVersion: storage.k8s.io/v1
+kind: CSIDriver
+metadata:
+  annotations:
+    csi.openshift.io/managed: "true"
+  name: cinder.csi.openstack.org
+spec:
+  attachRequired: true
+  fsGroupPolicy: File
+  podInfoOnMount: true
+  requiresRepublish: false
+  seLinuxMount: true
+  storageCapacity: false
+  volumeLifecycleModes:
+  - Persistent

--- a/assets/overlays/openstack-cinder/generated/hypershift/lease_leader_election_binding.yaml
+++ b/assets/overlays/openstack-cinder/generated/hypershift/lease_leader_election_binding.yaml
@@ -1,0 +1,20 @@
+# Generated file. Do not edit. Update using "make update".
+#
+# Loaded from base/rbac/lease_leader_election_binding.yaml
+#
+#
+# Grant controller access to leases
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: openstack-cinder-csi-driver-lease-leader-election
+  namespace: ${NODE_NAMESPACE}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: openstack-cinder-csi-driver-lease-leader-election
+subjects:
+- kind: ServiceAccount
+  name: openstack-cinder-csi-driver-controller-sa
+  namespace: ${NODE_NAMESPACE}

--- a/assets/overlays/openstack-cinder/generated/hypershift/lease_leader_election_role.yaml
+++ b/assets/overlays/openstack-cinder/generated/hypershift/lease_leader_election_role.yaml
@@ -1,0 +1,24 @@
+# Generated file. Do not edit. Update using "make update".
+#
+# Loaded from base/rbac/lease_leader_election_role.yaml
+#
+#
+# Role for electing leader by the operator
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: openstack-cinder-csi-driver-lease-leader-election
+  namespace: ${NODE_NAMESPACE}
+rules:
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - watch
+  - list
+  - delete
+  - update
+  - create

--- a/assets/overlays/openstack-cinder/generated/hypershift/main_attacher_binding.yaml
+++ b/assets/overlays/openstack-cinder/generated/hypershift/main_attacher_binding.yaml
@@ -1,0 +1,19 @@
+# Generated file. Do not edit. Update using "make update".
+#
+# Loaded from base/rbac/main_attacher_binding.yaml
+#   because it's needed by controller sidecar common/sidecars/attacher.yaml
+#
+#
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: openstack-cinder-csi-main-attacher-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: openshift-csi-main-attacher-role
+subjects:
+- kind: ServiceAccount
+  name: openstack-cinder-csi-driver-controller-sa
+  namespace: ${NODE_NAMESPACE}

--- a/assets/overlays/openstack-cinder/generated/hypershift/main_provisioner_binding.yaml
+++ b/assets/overlays/openstack-cinder/generated/hypershift/main_provisioner_binding.yaml
@@ -1,0 +1,19 @@
+# Generated file. Do not edit. Update using "make update".
+#
+# Loaded from base/rbac/main_provisioner_binding.yaml
+#   because it's needed by controller sidecar common/sidecars/provisioner.yaml
+#
+#
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: openstack-cinder-csi-main-provisioner-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: openshift-csi-main-provisioner-role
+subjects:
+- kind: ServiceAccount
+  name: openstack-cinder-csi-driver-controller-sa
+  namespace: ${NODE_NAMESPACE}

--- a/assets/overlays/openstack-cinder/generated/hypershift/main_resizer_binding.yaml
+++ b/assets/overlays/openstack-cinder/generated/hypershift/main_resizer_binding.yaml
@@ -1,0 +1,19 @@
+# Generated file. Do not edit. Update using "make update".
+#
+# Loaded from base/rbac/main_resizer_binding.yaml
+#   because it's needed by controller sidecar common/sidecars/resizer.yaml
+#
+#
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: openstack-cinder-csi-main-resizer-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: openshift-csi-main-resizer-role
+subjects:
+- kind: ServiceAccount
+  name: openstack-cinder-csi-driver-controller-sa
+  namespace: ${NODE_NAMESPACE}

--- a/assets/overlays/openstack-cinder/generated/hypershift/main_snapshotter_binding.yaml
+++ b/assets/overlays/openstack-cinder/generated/hypershift/main_snapshotter_binding.yaml
@@ -1,0 +1,19 @@
+# Generated file. Do not edit. Update using "make update".
+#
+# Loaded from base/rbac/main_snapshotter_binding.yaml
+#   because it's needed by controller sidecar common/sidecars/snapshotter.yaml
+#
+#
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: openstack-cinder-csi-main-snapshotter-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: openshift-csi-main-snapshotter-role
+subjects:
+- kind: ServiceAccount
+  name: openstack-cinder-csi-driver-controller-sa
+  namespace: ${NODE_NAMESPACE}

--- a/assets/overlays/openstack-cinder/generated/hypershift/manifests.yaml
+++ b/assets/overlays/openstack-cinder/generated/hypershift/manifests.yaml
@@ -1,0 +1,22 @@
+controllerStaticAssetNames:
+- cabundle_cm.yaml
+- controller.yaml
+- controller_pdb.yaml
+- controller_sa.yaml
+- service.yaml
+guestStaticAssetNames:
+- csidriver.yaml
+- lease_leader_election_binding.yaml
+- lease_leader_election_role.yaml
+- main_attacher_binding.yaml
+- main_provisioner_binding.yaml
+- main_resizer_binding.yaml
+- main_snapshotter_binding.yaml
+- node.yaml
+- node_privileged_binding.yaml
+- node_sa.yaml
+- privileged_role.yaml
+- storageclass.yaml
+- storageclass_reader_resizer_binding.yaml
+- volumesnapshot_reader_provisioner_binding.yaml
+- volumesnapshotclass.yaml

--- a/assets/overlays/openstack-cinder/generated/hypershift/node.yaml
+++ b/assets/overlays/openstack-cinder/generated/hypershift/node.yaml
@@ -1,0 +1,208 @@
+# Generated file. Do not edit. Update using "make update".
+#
+# Loaded from base/node.yaml
+# Applied strategic merge patch overlays/openstack-cinder/patches/node_add_driver.yaml
+# livenessprobe.yaml: Loaded from common/sidecars/livenessprobe.yaml
+# livenessprobe.yaml: Added arguments [--probe-timeout=10s]
+# Applied strategic merge patch livenessprobe.yaml
+# node_driver_registrar.yaml: Loaded from common/sidecars/node_driver_registrar.yaml
+# Applied strategic merge patch node_driver_registrar.yaml
+#
+#
+
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  annotations:
+    config.openshift.io/inject-proxy: csi-driver
+    config.openshift.io/inject-proxy-cabundle: csi-driver
+  name: openstack-cinder-csi-driver-node
+  namespace: ${NODE_NAMESPACE}
+spec:
+  selector:
+    matchLabels:
+      app: openstack-cinder-csi-driver-node
+  template:
+    metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/enable-ds-eviction: "false"
+        openshift.io/required-scc: privileged
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+      labels:
+        app: openstack-cinder-csi-driver-node
+    spec:
+      containers:
+      - args:
+        - /bin/cinder-csi-plugin
+        - --provide-controller-service=false
+        - --provide-node-service=true
+        - --endpoint=$(CSI_ENDPOINT)
+        - --cloud-config=$(CLOUD_CONFIG)
+        - --v=${LOG_LEVEL}
+        env:
+        - name: CSI_ENDPOINT
+          value: unix://csi/csi.sock
+        - name: CLOUD_CONFIG
+          value: /etc/kubernetes/config/cloud.conf
+        image: ${DRIVER_IMAGE}
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          failureThreshold: 5
+          httpGet:
+            path: /healthz
+            port: healthz
+          initialDelaySeconds: 10
+          periodSeconds: 30
+          timeoutSeconds: 10
+        name: csi-driver
+        ports:
+        - containerPort: 10300
+          name: healthz
+          protocol: TCP
+        resources:
+          requests:
+            cpu: 10m
+            memory: 50Mi
+        securityContext:
+          allowPrivilegeEscalation: true
+          capabilities:
+            add:
+            - SYS_ADMIN
+          privileged: true
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /var/lib/kubelet
+          mountPropagation: Bidirectional
+          name: kubelet-dir
+        - mountPath: /csi
+          name: socket-dir
+        - mountPath: /dev
+          mountPropagation: HostToContainer
+          name: device-dir
+        - mountPath: /etc/selinux
+          name: etc-selinux
+        - mountPath: /sys/fs
+          name: sys-fs
+        - mountPath: /etc/kubernetes/static-pod-resources/configmaps/cloud-config
+          name: cacert
+        - mountPath: /etc/kubernetes/config
+          name: config-cinderplugin
+          readOnly: true
+        - mountPath: /etc/kubernetes/secret
+          name: secret-cinderplugin
+          readOnly: true
+      - args:
+        - --csi-address=/csi/csi.sock
+        - --health-port=10300
+        - --v=${LOG_LEVEL}
+        - --probe-timeout=10s
+        env: []
+        image: ${LIVENESS_PROBE_IMAGE}
+        imagePullPolicy: IfNotPresent
+        name: csi-liveness-probe
+        resources:
+          requests:
+            cpu: 10m
+            memory: 50Mi
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /csi
+          name: socket-dir
+      - args:
+        - --csi-address=/csi/csi.sock
+        - --kubelet-registration-path=/var/lib/kubelet/plugins/cinder.csi.openstack.org/csi.sock
+        - --http-endpoint=:10304
+        - --v=${LOG_LEVEL}
+        env: []
+        image: ${NODE_DRIVER_REGISTRAR_IMAGE}
+        imagePullPolicy: IfNotPresent
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - /bin/sh
+              - -c
+              - rm -rf /registration/cinder.csi.openstack.org-reg.sock /csi/csi.sock
+        livenessProbe:
+          failureThreshold: 5
+          httpGet:
+            path: /healthz
+            port: rhealthz
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          timeoutSeconds: 3
+        name: csi-node-driver-registrar
+        ports:
+        - containerPort: 10304
+          name: rhealthz
+          protocol: TCP
+        resources:
+          requests:
+            cpu: 10m
+            memory: 50Mi
+        securityContext:
+          privileged: true
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /csi
+          name: socket-dir
+        - mountPath: /registration
+          name: registration-dir
+      hostNetwork: true
+      nodeSelector:
+        kubernetes.io/os: linux
+      priorityClassName: system-node-critical
+      serviceAccount: openstack-cinder-csi-driver-node-sa
+      tolerations:
+      - operator: Exists
+      volumes:
+      - hostPath:
+          path: /var/lib/kubelet
+          type: Directory
+        name: kubelet-dir
+      - hostPath:
+          path: /var/lib/kubelet/plugins/cinder.csi.openstack.org/
+          type: DirectoryOrCreate
+        name: socket-dir
+      - hostPath:
+          path: /var/lib/kubelet/plugins_registry/
+          type: Directory
+        name: registration-dir
+      - hostPath:
+          path: /dev
+          type: Directory
+        name: device-dir
+      - hostPath:
+          path: /etc/selinux
+          type: DirectoryOrCreate
+        name: etc-selinux
+      - hostPath:
+          path: /sys/fs
+          type: Directory
+        name: sys-fs
+      - name: metrics-serving-cert
+        secret:
+          secretName: openstack-cinder-csi-driver-node-metrics-serving-cert
+      - configMap:
+          items:
+          - key: ca-bundle.pem
+            path: ca-bundle.pem
+          name: cloud-provider-config
+          optional: true
+        name: cacert
+      - configMap:
+          items:
+          - key: cloud.conf
+            path: cloud.conf
+          name: cloud-conf
+        name: config-cinderplugin
+      - name: secret-cinderplugin
+        secret:
+          items:
+          - key: clouds.yaml
+            path: clouds.yaml
+          secretName: openstack-cloud-credentials
+  updateStrategy:
+    rollingUpdate:
+      maxUnavailable: 10%
+    type: RollingUpdate

--- a/assets/overlays/openstack-cinder/generated/hypershift/node.yaml
+++ b/assets/overlays/openstack-cinder/generated/hypershift/node.yaml
@@ -187,7 +187,7 @@ spec:
           items:
           - key: ca-bundle.pem
             path: ca-bundle.pem
-          name: cloud-provider-config
+          name: cloud-conf
           optional: true
         name: cacert
       - configMap:

--- a/assets/overlays/openstack-cinder/generated/hypershift/node_privileged_binding.yaml
+++ b/assets/overlays/openstack-cinder/generated/hypershift/node_privileged_binding.yaml
@@ -1,0 +1,18 @@
+# Generated file. Do not edit. Update using "make update".
+#
+# Loaded from base/rbac/node_privileged_binding.yaml
+#
+#
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: openstack-cinder-node-privileged-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: openstack-cinder-privileged-role
+subjects:
+- kind: ServiceAccount
+  name: openstack-cinder-csi-driver-node-sa
+  namespace: ${NODE_NAMESPACE}

--- a/assets/overlays/openstack-cinder/generated/hypershift/node_sa.yaml
+++ b/assets/overlays/openstack-cinder/generated/hypershift/node_sa.yaml
@@ -1,0 +1,11 @@
+# Generated file. Do not edit. Update using "make update".
+#
+# Loaded from base/node_sa.yaml
+#
+#
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: openstack-cinder-csi-driver-node-sa
+  namespace: ${NODE_NAMESPACE}

--- a/assets/overlays/openstack-cinder/generated/hypershift/privileged_role.yaml
+++ b/assets/overlays/openstack-cinder/generated/hypershift/privileged_role.yaml
@@ -1,0 +1,20 @@
+# Generated file. Do not edit. Update using "make update".
+#
+# Loaded from base/rbac/privileged_role.yaml
+#
+#
+# TODO: create custom SCC with things that the AWS CSI driver needs
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: openstack-cinder-privileged-role
+rules:
+- apiGroups:
+  - security.openshift.io
+  resourceNames:
+  - privileged
+  resources:
+  - securitycontextconstraints
+  verbs:
+  - use

--- a/assets/overlays/openstack-cinder/generated/hypershift/service.yaml
+++ b/assets/overlays/openstack-cinder/generated/hypershift/service.yaml
@@ -1,0 +1,46 @@
+# Generated file. Do not edit. Update using "make update".
+#
+# Loaded from base/controller_metrics_service.yaml
+# Applied strategic merge patch common/metrics/service_add_port.yaml
+# Applied strategic merge patch common/metrics/service_add_port.yaml
+# Applied strategic merge patch common/metrics/service_add_port.yaml
+# Applied strategic merge patch common/metrics/service_add_port.yaml
+# Applied strategic merge patch common/metrics/service_add_port.yaml
+#
+#
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    service.beta.openshift.io/serving-cert-secret-name: openstack-cinder-csi-driver-controller-metrics-serving-cert
+  labels:
+    app: openstack-cinder-csi-driver-controller-metrics
+  name: openstack-cinder-csi-driver-controller-metrics
+  namespace: ${NAMESPACE}
+spec:
+  ports:
+  - name: provisioner-m
+    port: 9203
+    protocol: TCP
+    targetPort: provisioner-m
+  - name: attacher-m
+    port: 9204
+    protocol: TCP
+    targetPort: attacher-m
+  - name: resizer-m
+    port: 9205
+    protocol: TCP
+    targetPort: resizer-m
+  - name: snapshotter-m
+    port: 9206
+    protocol: TCP
+    targetPort: snapshotter-m
+  - name: driver-m
+    port: 9202
+    protocol: TCP
+    targetPort: driver-m
+  selector:
+    app: openstack-cinder-csi-driver-controller
+  sessionAffinity: None
+  type: ClusterIP

--- a/assets/overlays/openstack-cinder/generated/hypershift/storageclass.yaml
+++ b/assets/overlays/openstack-cinder/generated/hypershift/storageclass.yaml
@@ -1,0 +1,16 @@
+# Generated file. Do not edit. Update using "make update".
+#
+# Loaded from overlays/openstack-cinder/base/storageclass.yaml
+#
+#
+
+allowVolumeExpansion: true
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "true"
+  name: standard-csi
+provisioner: cinder.csi.openstack.org
+reclaimPolicy: Delete
+volumeBindingMode: WaitForFirstConsumer

--- a/assets/overlays/openstack-cinder/generated/hypershift/storageclass_reader_resizer_binding.yaml
+++ b/assets/overlays/openstack-cinder/generated/hypershift/storageclass_reader_resizer_binding.yaml
@@ -1,0 +1,19 @@
+# Generated file. Do not edit. Update using "make update".
+#
+# Loaded from base/rbac/storageclass_reader_resizer_binding.yaml
+#   because it's needed by controller sidecar common/sidecars/resizer.yaml
+#
+#
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: openstack-cinder-csi-storageclass-reader-resizer-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: openshift-csi-resizer-storageclass-reader-role
+subjects:
+- kind: ServiceAccount
+  name: openstack-cinder-csi-driver-controller-sa
+  namespace: ${NODE_NAMESPACE}

--- a/assets/overlays/openstack-cinder/generated/hypershift/volumesnapshot_reader_provisioner_binding.yaml
+++ b/assets/overlays/openstack-cinder/generated/hypershift/volumesnapshot_reader_provisioner_binding.yaml
@@ -1,0 +1,19 @@
+# Generated file. Do not edit. Update using "make update".
+#
+# Loaded from base/rbac/volumesnapshot_reader_provisioner_binding.yaml
+#   because it's needed by controller sidecar common/sidecars/provisioner.yaml
+#
+#
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: openstack-cinder-csi-volumesnapshot-reader-provisioner-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: openshift-csi-provisioner-volumesnapshot-reader-role
+subjects:
+- kind: ServiceAccount
+  name: openstack-cinder-csi-driver-controller-sa
+  namespace: ${NODE_NAMESPACE}

--- a/assets/overlays/openstack-cinder/generated/hypershift/volumesnapshotclass.yaml
+++ b/assets/overlays/openstack-cinder/generated/hypershift/volumesnapshotclass.yaml
@@ -1,0 +1,16 @@
+# Generated file. Do not edit. Update using "make update".
+#
+# Loaded from overlays/openstack-cinder/base/volumesnapshotclass.yaml
+#
+#
+
+apiVersion: snapshot.storage.k8s.io/v1
+deletionPolicy: Delete
+driver: cinder.csi.openstack.org
+kind: VolumeSnapshotClass
+metadata:
+  annotations:
+    snapshot.storage.kubernetes.io/is-default-class: "true"
+  name: standard-csi
+parameters:
+  force-create: "false"

--- a/assets/overlays/openstack-cinder/generated/standalone/controller.yaml
+++ b/assets/overlays/openstack-cinder/generated/standalone/controller.yaml
@@ -61,16 +61,11 @@ spec:
         - /bin/cinder-csi-plugin
         - --provide-controller-service=true
         - --provide-node-service=false
-        - --nodeid=$(NODE_ID)
         - --endpoint=$(CSI_ENDPOINT)
         - --cloud-config=$(CLOUD_CONFIG)
         - --cluster=${CLUSTER_ID}
         - --v=${LOG_LEVEL}
         env:
-        - name: NODE_ID
-          valueFrom:
-            fieldRef:
-              fieldPath: spec.nodeName
         - name: CSI_ENDPOINT
           value: unix://csi/csi.sock
         - name: CLOUD_CONFIG

--- a/assets/overlays/openstack-cinder/generated/standalone/controller.yaml
+++ b/assets/overlays/openstack-cinder/generated/standalone/controller.yaml
@@ -358,6 +358,6 @@ spec:
           items:
           - key: ca-bundle.pem
             path: ca-bundle.pem
-          name: cloud-provider-config
+          name: cloud-conf
           optional: true
         name: cacert

--- a/assets/overlays/openstack-cinder/generated/standalone/controller.yaml
+++ b/assets/overlays/openstack-cinder/generated/standalone/controller.yaml
@@ -59,6 +59,8 @@ spec:
       containers:
       - args:
         - /bin/cinder-csi-plugin
+        - --provide-controller-service=true
+        - --provide-node-service=false
         - --nodeid=$(NODE_ID)
         - --endpoint=$(CSI_ENDPOINT)
         - --cloud-config=$(CLOUD_CONFIG)

--- a/assets/overlays/openstack-cinder/generated/standalone/node.yaml
+++ b/assets/overlays/openstack-cinder/generated/standalone/node.yaml
@@ -36,15 +36,10 @@ spec:
         - /bin/cinder-csi-plugin
         - --provide-controller-service=false
         - --provide-node-service=true
-        - --nodeid=$(NODE_ID)
         - --endpoint=$(CSI_ENDPOINT)
         - --cloud-config=$(CLOUD_CONFIG)
         - --v=${LOG_LEVEL}
         env:
-        - name: NODE_ID
-          valueFrom:
-            fieldRef:
-              fieldPath: spec.nodeName
         - name: CSI_ENDPOINT
           value: unix://csi/csi.sock
         - name: CLOUD_CONFIG

--- a/assets/overlays/openstack-cinder/generated/standalone/node.yaml
+++ b/assets/overlays/openstack-cinder/generated/standalone/node.yaml
@@ -34,6 +34,8 @@ spec:
       containers:
       - args:
         - /bin/cinder-csi-plugin
+        - --provide-controller-service=false
+        - --provide-node-service=true
         - --nodeid=$(NODE_ID)
         - --endpoint=$(CSI_ENDPOINT)
         - --cloud-config=$(CLOUD_CONFIG)

--- a/assets/overlays/openstack-cinder/generated/standalone/node.yaml
+++ b/assets/overlays/openstack-cinder/generated/standalone/node.yaml
@@ -187,7 +187,7 @@ spec:
           items:
           - key: ca-bundle.pem
             path: ca-bundle.pem
-          name: cloud-provider-config
+          name: cloud-conf
           optional: true
         name: cacert
       - configMap:

--- a/assets/overlays/openstack-cinder/patches/controller_add_driver.yaml
+++ b/assets/overlays/openstack-cinder/patches/controller_add_driver.yaml
@@ -37,16 +37,11 @@ spec:
             - /bin/cinder-csi-plugin
             - "--provide-controller-service=true"
             - "--provide-node-service=false"
-            - "--nodeid=$(NODE_ID)"
             - "--endpoint=$(CSI_ENDPOINT)"
             - "--cloud-config=$(CLOUD_CONFIG)"
             - "--cluster=${CLUSTER_ID}"
             - "--v=${LOG_LEVEL}"
           env:
-            - name: NODE_ID
-              valueFrom:
-                fieldRef:
-                  fieldPath: spec.nodeName
             - name: CSI_ENDPOINT
               value: unix://csi/csi.sock
             - name: CLOUD_CONFIG

--- a/assets/overlays/openstack-cinder/patches/controller_add_driver.yaml
+++ b/assets/overlays/openstack-cinder/patches/controller_add_driver.yaml
@@ -35,6 +35,8 @@ spec:
           imagePullPolicy: IfNotPresent
           args:
             - /bin/cinder-csi-plugin
+            - "--provide-controller-service=true"
+            - "--provide-node-service=false"
             - "--nodeid=$(NODE_ID)"
             - "--endpoint=$(CSI_ENDPOINT)"
             - "--cloud-config=$(CLOUD_CONFIG)"

--- a/assets/overlays/openstack-cinder/patches/controller_add_driver.yaml
+++ b/assets/overlays/openstack-cinder/patches/controller_add_driver.yaml
@@ -94,7 +94,7 @@ spec:
           # is not preset there. The certificate file will be created once the
           # ConfigMap is created / the certificate is added to it.
           configMap:
-            name: cloud-provider-config
+            name: cloud-conf
             items:
             - key: ca-bundle.pem
               path: ca-bundle.pem

--- a/assets/overlays/openstack-cinder/patches/controller_add_hypershift_volumes.yaml
+++ b/assets/overlays/openstack-cinder/patches/controller_add_hypershift_volumes.yaml
@@ -1,0 +1,8 @@
+spec:
+  template:
+    spec:
+      volumes:
+        - name: hosted-kubeconfig
+          secret:
+            defaultMode: 420
+            secretName: service-network-admin-kubeconfig

--- a/assets/overlays/openstack-cinder/patches/node_add_driver.yaml
+++ b/assets/overlays/openstack-cinder/patches/node_add_driver.yaml
@@ -23,15 +23,10 @@ spec:
             - /bin/cinder-csi-plugin
             - "--provide-controller-service=false"
             - "--provide-node-service=true"
-            - "--nodeid=$(NODE_ID)"
             - "--endpoint=$(CSI_ENDPOINT)"
             - "--cloud-config=$(CLOUD_CONFIG)"
             - "--v=${LOG_LEVEL}"
           env:
-            - name: NODE_ID
-              valueFrom:
-                fieldRef:
-                  fieldPath: spec.nodeName
             - name: CSI_ENDPOINT
               value: unix://csi/csi.sock
             - name: CLOUD_CONFIG

--- a/assets/overlays/openstack-cinder/patches/node_add_driver.yaml
+++ b/assets/overlays/openstack-cinder/patches/node_add_driver.yaml
@@ -21,6 +21,8 @@ spec:
           imagePullPolicy: IfNotPresent
           args :
             - /bin/cinder-csi-plugin
+            - "--provide-controller-service=false"
+            - "--provide-node-service=true"
             - "--nodeid=$(NODE_ID)"
             - "--endpoint=$(CSI_ENDPOINT)"
             - "--cloud-config=$(CLOUD_CONFIG)"

--- a/assets/overlays/openstack-cinder/patches/node_add_driver.yaml
+++ b/assets/overlays/openstack-cinder/patches/node_add_driver.yaml
@@ -77,7 +77,7 @@ spec:
           # is not preset there. The certificate file will be created once the
           # ConfigMap is created / the certificate is added to it.
           configMap:
-            name: cloud-provider-config
+            name: cloud-conf
             items:
             - key: ca-bundle.pem
               path: ca-bundle.pem

--- a/pkg/clients/builder.go
+++ b/pkg/clients/builder.go
@@ -28,7 +28,7 @@ import (
 
 // Builder is a helper to create Clients.
 type Builder struct {
-	userAgwent             string
+	userAgent              string
 	csiDriverName          string
 	guestNamespace         string
 	resync                 time.Duration
@@ -44,7 +44,7 @@ type Builder struct {
 // NewBuilder creates a new Builder.
 func NewBuilder(userAgent string, csiDriverName, guestNamespace string, controlPlaneNamespaces []string, controllerConfig *controllercmd.ControllerContext, resync time.Duration) *Builder {
 	return &Builder{
-		userAgwent:             userAgent,
+		userAgent:              userAgent,
 		csiDriverName:          csiDriverName,
 		guestNamespace:         guestNamespace,
 		resync:                 resync,
@@ -70,7 +70,7 @@ func (b *Builder) WithHyperShiftGuest(kubeConfigFile string, cloudConfigNamespac
 
 // BuildOrDie creates new Kubernetes clients.
 func (b *Builder) BuildOrDie(ctx context.Context) *Clients {
-	controlPlaneRestConfig := rest.AddUserAgent(b.controllerConfig.KubeConfig, b.userAgwent)
+	controlPlaneRestConfig := rest.AddUserAgent(b.controllerConfig.KubeConfig, b.userAgent)
 	controlPlaneKubeClient := kubeclient.NewForConfigOrDie(controlPlaneRestConfig)
 	controlPlaneKubeInformers := v1helpers.NewKubeInformersForNamespaces(controlPlaneKubeClient, b.controlPlaneNamespaces...)
 
@@ -97,7 +97,7 @@ func (b *Builder) BuildOrDie(ctx context.Context) *Clients {
 		if err != nil {
 			klog.Fatalf("error reading guesKubeConfig from %s: %v", b.guestKubeConfigFile, err)
 		}
-		guestKubeConfig = rest.AddUserAgent(guestKubeConfig, b.userAgwent)
+		guestKubeConfig = rest.AddUserAgent(guestKubeConfig, b.userAgent)
 		guestKubeClient = kubeclient.NewForConfigOrDie(guestKubeConfig)
 
 		// Create all events in the GUEST cluster.
@@ -108,7 +108,7 @@ func (b *Builder) BuildOrDie(ctx context.Context) *Clients {
 		if err != nil {
 			klog.Warningf("unable to get owner reference (falling back to namespace): %v", err)
 		}
-		b.client.EventRecorder = events.NewKubeRecorder(guestKubeClient.CoreV1().Events(b.guestNamespace), b.userAgwent, controllerRef)
+		b.client.EventRecorder = events.NewKubeRecorder(guestKubeClient.CoreV1().Events(b.guestNamespace), b.userAgent, controllerRef)
 
 		b.client.ControlPlaneHypeClient = hypextclient.NewForConfigOrDie(controlPlaneRestConfig)
 		b.client.ControlPlaneHypeInformer = hypextinformers.NewFilteredSharedInformerFactory(b.client.ControlPlaneHypeClient, b.resync, b.controllerConfig.OperatorNamespace, nil)

--- a/pkg/driver/openstack-cinder/openstack_cinder.go
+++ b/pkg/driver/openstack-cinder/openstack_cinder.go
@@ -25,9 +25,6 @@ const (
 	cinderConfigName      = "cloud-conf"
 	cloudCredSecretName   = "openstack-cloud-credentials"
 	metricsCertSecretName = "openstack-cinder-csi-driver-controller-metrics-serving-cert"
-	infrastructureName    = "cluster"
-	cloudConfigNamespace  = "openshift-config-managed"
-	cloudConfigName       = "kube-cloud-config"
 	caBundleKey           = "ca-bundle.pem"
 	trustedCAConfigMap    = "openstack-cinder-csi-driver-trusted-ca-bundle"
 

--- a/pkg/driver/openstack-cinder/openstack_cinder.go
+++ b/pkg/driver/openstack-cinder/openstack_cinder.go
@@ -2,7 +2,6 @@ package openstack_cinder
 
 import (
 	"context"
-	"fmt"
 
 	opv1 "github.com/openshift/api/operator/v1"
 	"github.com/openshift/csi-operator/assets"
@@ -16,7 +15,6 @@ import (
 	"github.com/openshift/library-go/pkg/operator/csi/csidrivercontrollerservicecontroller"
 	"github.com/openshift/library-go/pkg/operator/csi/csidrivernodeservicecontroller"
 	dc "github.com/openshift/library-go/pkg/operator/deploymentcontroller"
-	"k8s.io/klog/v2"
 )
 
 const (
@@ -112,11 +110,6 @@ func GetOpenStackCinderOperatorConfig() *config.OperatorConfig {
 // GetOpenStackCinderOperatorControllerConfig returns second half of runtime configuration of the CSI driver operator,
 // after a client connection + cluster flavour are established.
 func GetOpenStackCinderOperatorControllerConfig(ctx context.Context, flavour generator.ClusterFlavour, c *clients.Clients) (*config.OperatorControllerConfig, error) {
-	if flavour != generator.FlavourStandalone {
-		klog.Error(nil, "Flavour HyperShift is not supported!")
-		return nil, fmt.Errorf("Flavour HyperShift is not supported!")
-	}
-
 	cfg := operator.NewDefaultOperatorControllerConfig(flavour, c, "OpenStackCinder")
 
 	go c.ConfigInformers.Start(ctx.Done())

--- a/pkg/driver/openstack-cinder/openstack_cinder.go
+++ b/pkg/driver/openstack-cinder/openstack_cinder.go
@@ -129,7 +129,7 @@ func GetOpenStackCinderOperatorControllerConfig(ctx context.Context, flavour gen
 	cfg.AddDaemonSetHookBuilders(c, withCABundleDaemonSetHook, withClusterWideProxyDaemonSetHook, withConfigDaemonSetHook)
 	cfg.DaemonSetWatchedSecretNames = append(cfg.DaemonSetWatchedSecretNames, cloudCredSecretName)
 
-	configMapSyncer, err := createConfigMapSyncer(c)
+	configMapSyncer, err := createConfigMapSyncer(c, flavour)
 	if err != nil {
 		return nil, err
 	}
@@ -202,7 +202,8 @@ func withConfigDaemonSetHook(c *clients.Clients) (csidrivernodeservicecontroller
 // createConfigMapSyncer syncs config maps containing configuration for the CSI driver from the
 // user-managed namespace to the operator namespace, validating it and potentially transforming it
 // in the process
-func createConfigMapSyncer(c *clients.Clients) (factory.Controller, error) {
-	configSyncController := configsync.NewConfigSyncController(c)
-	return configSyncController, nil
+func createConfigMapSyncer(c *clients.Clients, flavour generator.ClusterFlavour) (factory.Controller, error) {
+	isHypershift := flavour == generator.FlavourHyperShift
+	configSyncController, err := configsync.NewConfigSyncController(c, isHypershift)
+	return configSyncController, err
 }

--- a/pkg/driver/openstack-cinder/openstack_cinder.go
+++ b/pkg/driver/openstack-cinder/openstack_cinder.go
@@ -57,7 +57,7 @@ func GetOpenStackCinderGeneratorConfig() *generator.CSIDriverGeneratorConfig {
 					"--timeout=3m",
 					"--feature-gates=Topology=$(ENABLE_TOPOLOGY)",
 					"--default-fstype=ext4",
-				).WithPatches(generator.StandaloneOnly,
+				).WithPatches(generator.AllFlavours,
 					"controller.yaml", "overlays/openstack-cinder/patches/provisioner_add_envvars.yaml",
 				),
 				commongenerator.DefaultAttacher.WithExtraArguments(
@@ -71,8 +71,10 @@ func GetOpenStackCinderGeneratorConfig() *generator.CSIDriverGeneratorConfig {
 					"--probe-timeout=10s",
 				),
 			},
-			Assets:       commongenerator.DefaultControllerAssets,
-			AssetPatches: commongenerator.DefaultAssetPatches,
+			Assets: commongenerator.DefaultControllerAssets,
+			AssetPatches: commongenerator.DefaultAssetPatches.WithPatches(generator.HyperShiftOnly,
+				"controller.yaml", "overlays/openstack-cinder/patches/controller_add_hypershift_volumes.yaml",
+			),
 		},
 
 		GuestConfig: &generator.GuestConfig{
@@ -91,9 +93,6 @@ func GetOpenStackCinderGeneratorConfig() *generator.CSIDriverGeneratorConfig {
 				"overlays/openstack-cinder/base/volumesnapshotclass.yaml",
 			),
 		},
-
-		// TODO(stephenfin): We'd like to support HyperShift. When we do, we should change this.
-		StandaloneOnly: true,
 	}
 }
 

--- a/pkg/driver/openstack-cinder/openstack_cinder.go
+++ b/pkg/driver/openstack-cinder/openstack_cinder.go
@@ -3,7 +3,6 @@ package openstack_cinder
 import (
 	"context"
 	"fmt"
-	"time"
 
 	opv1 "github.com/openshift/api/operator/v1"
 	"github.com/openshift/csi-operator/assets"
@@ -21,7 +20,6 @@ import (
 )
 
 const (
-	resyncInterval        = 20 * time.Minute
 	cinderConfigName      = "cloud-conf"
 	cloudCredSecretName   = "openstack-cloud-credentials"
 	metricsCertSecretName = "openstack-cinder-csi-driver-controller-metrics-serving-cert"
@@ -205,14 +203,6 @@ func withConfigDaemonSetHook(c *clients.Clients) (csidrivernodeservicecontroller
 // user-managed namespace to the operator namespace, validating it and potentially transforming it
 // in the process
 func createConfigMapSyncer(c *clients.Clients) (factory.Controller, error) {
-	configSyncController := configsync.NewConfigSyncController(
-		c.OperatorClient,
-		c.KubeClient,
-		c.KubeInformers,
-		c.ConfigInformers,
-		c.GuestNamespace,
-		resyncInterval,
-		c.EventRecorder)
-
+	configSyncController := configsync.NewConfigSyncController(c)
 	return configSyncController, nil
 }

--- a/pkg/openstack-cinder/config/configsync.go
+++ b/pkg/openstack-cinder/config/configsync.go
@@ -139,7 +139,7 @@ func translateConfigMap(cloudConfig *v1.ConfigMap, enableTopologyFeature bool, g
 	// Process the cloud configuration
 	content, ok := cloudConfig.Data[sourceConfigKey]
 	if !ok {
-		return nil, fmt.Errorf("OpenStack config map did not contain key %s", sourceConfigKey)
+		return nil, fmt.Errorf("OpenStack config map %s/%s did not contain key %s", cloudConfig.Namespace, cloudConfig.Name, sourceConfigKey)
 	}
 
 	cfg, err := ini.Load([]byte(content))

--- a/pkg/openstack-cinder/config/configsync.go
+++ b/pkg/openstack-cinder/config/configsync.go
@@ -190,6 +190,9 @@ func (c *ConfigSyncController) sync(ctx context.Context, syncCtx factory.SyncCon
 				"enable_topology": enableTopology,
 			},
 		}
+		if caCert != nil {
+			targetConfig.Data["ca-bundle.pem"] = *caCert
+		}
 		_, _, err = resourceapply.ApplyConfigMap(ctx, configDestination.kubeClient.CoreV1(), c.eventRecorder, targetConfig)
 		if err != nil {
 			return err

--- a/pkg/openstack-cinder/config/configsync.go
+++ b/pkg/openstack-cinder/config/configsync.go
@@ -159,7 +159,7 @@ func translateConfigMap(sourceConfig *v1.ConfigMap, sourceConfigKey string, enab
 			{"secret-namespace", "kube-system"},
 			{"kubeconfig-path", ""},
 		} {
-			if global.Key(o.k).String() != o.v {
+			if global.HasKey(o.k) && global.Key(o.k).String() != o.v {
 				return nil, fmt.Errorf("'[Global] %s' is set to a non-default value", o.k)
 			}
 			global.DeleteKey(o.k)

--- a/pkg/openstack-cinder/config/configsync_test.go
+++ b/pkg/openstack-cinder/config/configsync_test.go
@@ -137,11 +137,11 @@ cloud       = openstack`,
 					Namespace: "openshift-cluster-csi-drivers",
 				},
 				Data: map[string]string{
-					"config":          tc.target,
+					targetConfigKey:   tc.target,
 					"enable_topology": tc.expectedTopologyValue,
 				},
 			}
-			actualConfigMap, err := translateConfigMap(&sourceConfigMap, tc.generatedTopologyValue, expectedConfigMap.Namespace)
+			actualConfigMap, err := translateConfigMap(&sourceConfigMap, "config", tc.generatedTopologyValue, expectedConfigMap.Namespace)
 			if tc.errMsg != "" {
 				g.Expect(err).Should(MatchError(tc.errMsg))
 				return
@@ -149,7 +149,7 @@ cloud       = openstack`,
 				g.Expect(err).ToNot(HaveOccurred())
 				// First, compare the value of the clouds.conf value
 				// Note that the output is unsorted so we must reload and reparse the strings
-				expected, _ := expectedConfigMap.Data[sourceConfigKey]
+				expected, _ := expectedConfigMap.Data[targetConfigKey]
 				actual, _ := actualConfigMap.Data[targetConfigKey]
 				g.Expect(err).ToNot(HaveOccurred())
 

--- a/pkg/openstack-cinder/config/configsync_test.go
+++ b/pkg/openstack-cinder/config/configsync_test.go
@@ -6,156 +6,79 @@ import (
 
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/format"
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 )
 
-func TestTranslateConfigMap(t *testing.T) {
+func TestGenerateConfigMap(t *testing.T) {
 	format.MaxDepth = 100
 	format.TruncatedDiff = false
 
 	tc := []struct {
-		name                      string
-		source                    string
-		target                    string
-		generatedTopologyValue    bool
-		userProvidedTopologyValue string
-		expectedTopologyValue     string
-		errMsg                    string
+		name     string
+		source   []byte
+		caCert   *string
+		expected string
+		errMsg   string
 	}{
 		{
-			name: "Config with unsupported secret-namespace override",
-			source: `[Global]
-secret-namespace = foo
-secret-name = openstack-credentials`,
-			errMsg: "'[Global] secret-namespace' is set to a non-default value",
-		}, {
-			name: "Config with unsupported secret-name override",
-			source: `[Global]
-secret-namespace = kube-system
-secret-name = foo`,
-			errMsg: "'[Global] secret-name' is set to a non-default value",
-		}, {
-			name: "Config with unsupported kubeconfig-path override",
-			source: `[Global]
-secret-namespace = kube-system
-secret-name = openstack-credentials
-kubeconfig-path = https://foo`,
-			errMsg: "'[Global] kubeconfig-path' is set to a non-default value",
+			name:   "Unset config",
+			source: nil,
+			expected: `[Global]
+use-clouds  = true
+clouds-file = /etc/kubernetes/secret/clouds.yaml
+cloud       = openstack`,
 		}, {
 			name:   "Empty config",
-			source: "",
-			target: `[Global]
+			source: []byte(""),
+			expected: `[Global]
 use-clouds  = true
 clouds-file = /etc/kubernetes/secret/clouds.yaml
 cloud       = openstack`,
-			expectedTopologyValue: "false",
 		}, {
-			name: "Non-empty config",
-			source: `[BlockStorage]
-trust-device-path = /dev/sdb1`,
-			target: `[Global]
+			name: "Minimal config",
+			source: []byte(`[BlockStorage]
+ignore-volume-az = True`),
+			expected: `[BlockStorage]
+ignore-volume-az = True
+
+[Global]
 use-clouds  = true
 clouds-file = /etc/kubernetes/secret/clouds.yaml
 cloud       = openstack`,
-			expectedTopologyValue: "false",
 		}, {
-			name: "Multi-AZ deployment",
-			source: `
+			name:   "With CA cert",
+			source: nil,
+			caCert: ptr.To("not-so-secret CA data goes here"),
+			expected: `[Global]
+use-clouds  = true
+clouds-file = /etc/kubernetes/secret/clouds.yaml
+cloud       = openstack
+ca-file     = /etc/kubernetes/static-pod-resources/configmaps/cloud-config/ca-bundle.pem`,
+		}, {
+			name: "Legacy BlockStorage options are ignored",
+			source: []byte(`
 [BlockStorage]
-trust-device-path = /dev/sdb1`,
-			target: `[Global]
+trust-device-path = /dev/sdb1`),
+			expected: `[Global]
 use-clouds  = true
 clouds-file = /etc/kubernetes/secret/clouds.yaml
 cloud       = openstack`,
-			expectedTopologyValue: "false",
-		}, {
-			name: "User-provided AZ configuration is not overridden",
-			source: `
-[BlockStorage]
-trust-device-path = /dev/sdb1`,
-			target: `[Global]
-use-clouds  = true
-clouds-file = /etc/kubernetes/secret/clouds.yaml
-cloud       = openstack`,
-			expectedTopologyValue: "false",
-		}, {
-			name:   "No user-provided topology feature flag",
-			source: "",
-			target: `[Global]
-use-clouds  = true
-clouds-file = /etc/kubernetes/secret/clouds.yaml
-cloud       = openstack`,
-			generatedTopologyValue:    true,
-			userProvidedTopologyValue: "",
-			expectedTopologyValue:     "true",
-		}, {
-			name:   "User-provided topology feature flag matches auto-generated value",
-			source: "",
-			target: `[Global]
-use-clouds  = true
-clouds-file = /etc/kubernetes/secret/clouds.yaml
-cloud       = openstack`,
-			generatedTopologyValue:    true,
-			userProvidedTopologyValue: "true",
-			expectedTopologyValue:     "true",
-		}, {
-			name:   "User-provided topology feature flag conflicts with auto-generated value",
-			source: "",
-			target: `[Global]
-use-clouds  = true
-clouds-file = /etc/kubernetes/secret/clouds.yaml
-cloud       = openstack`,
-			generatedTopologyValue:    true,
-			userProvidedTopologyValue: "false",
-			expectedTopologyValue:     "false",
 		},
 	}
 
 	for _, tc := range tc {
 		t.Run(tc.name, func(t *testing.T) {
 			g := NewWithT(t)
-			sourceConfigMap := corev1.ConfigMap{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "cloud-provider-config",
-					Namespace: "openshift-config",
-				},
-				Data: map[string]string{
-					"config": tc.source,
-				},
-			}
-			if tc.userProvidedTopologyValue != "" {
-				sourceConfigMap.Data[enableTopologyKey] = tc.userProvidedTopologyValue
-			}
-			expectedConfigMap := corev1.ConfigMap{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "cinder-csi-config",
-					Namespace: "openshift-cluster-csi-drivers",
-				},
-				Data: map[string]string{
-					targetConfigKey:   tc.target,
-					"enable_topology": tc.expectedTopologyValue,
-				},
-			}
-			actualConfigMap, err := translateConfigMap(&sourceConfigMap, "config", tc.generatedTopologyValue, expectedConfigMap.Namespace)
+			actual, err := generateConfig(
+				[]byte(tc.source),
+				tc.caCert,
+			)
 			if tc.errMsg != "" {
 				g.Expect(err).Should(MatchError(tc.errMsg))
 				return
 			} else {
 				g.Expect(err).ToNot(HaveOccurred())
-				// First, compare the value of the clouds.conf value
-				// Note that the output is unsorted so we must reload and reparse the strings
-				expected, _ := expectedConfigMap.Data[targetConfigKey]
-				actual, _ := actualConfigMap.Data[targetConfigKey]
-				g.Expect(err).ToNot(HaveOccurred())
-
-				actual = strings.TrimSpace(actual)
-				g.Expect(expected).Should(Equal(actual))
-
-				// Then compare the value of the topology feature flag configuration
-				expected, _ = expectedConfigMap.Data[enableTopologyKey]
-				actual, _ = actualConfigMap.Data[enableTopologyKey]
-				g.Expect(expected).Should(Equal(actual))
+				g.Expect(strings.TrimSpace(tc.expected)).Should(Equal(strings.TrimSpace(actual)))
 			}
 		})
 	}

--- a/pkg/openstack-cinder/config/configsync_test.go
+++ b/pkg/openstack-cinder/config/configsync_test.go
@@ -53,11 +53,7 @@ cloud       = openstack`,
 		}, {
 			name: "Non-empty config",
 			source: `[BlockStorage]
-trust-device-path = /dev/sdb1
-
-[Global]
-secret-name = openstack-credentials
-secret-namespace = kube-system`,
+trust-device-path = /dev/sdb1`,
 			target: `[Global]
 use-clouds  = true
 clouds-file = /etc/kubernetes/secret/clouds.yaml


### PR DESCRIPTION
In #278, #275 and #298, we worked to integrate Cinder CSI driver support here, into `csi-operator`. With that out of the way, we can now move onto working on Hypershift support.

The changes required here are mostly minimal: we need to ensure that we sync our config map contain configuration for the drivers to the correct namespace. We also need to ensure that we pass through the guest kubeconfig to the controllers. All of this has been done elsewhere and should not be surprising. The main change is to our syncer. I would suggest reading the commit messages for more context, but the tl;dr: is that we modify this so that (a) it's able to run without a source config map, and (b) it's able to dump the results in multiple locations.

**Related changes**

- https://github.com/openshift/cluster-storage-operator/pull/525
- https://github.com/openshift/hypershift/pull/4936