### PR TITLE
OCPBUGS-43653: Add missing credentials secret hook

### DIFF
--- a/pkg/driver/openstack-cinder/openstack_cinder.go
+++ b/pkg/driver/openstack-cinder/openstack_cinder.go
@@ -129,9 +129,10 @@ func GetOpenStackCinderOperatorControllerConfig(ctx context.Context, flavour gen
 
 	// Hooks to run on all clusters
 	cfg.AddDeploymentHookBuilders(c, withCABundleDeploymentHook, withConfigDeploymentHook)
-	cfg.AddDaemonSetHookBuilders(c, withCABundleDaemonSetHook, withConfigDaemonSetHook)
-
 	cfg.DeploymentWatchedSecretNames = append(cfg.DeploymentWatchedSecretNames, cloudCredSecretName, metricsCertSecretName)
+
+	cfg.AddDaemonSetHookBuilders(c, withCABundleDaemonSetHook, withConfigDaemonSetHook)
+	cfg.DaemonSetWatchedSecretNames = append(cfg.DaemonSetWatchedSecretNames, cloudCredSecretName)
 
 	configMapSyncer, err := createConfigMapSyncer(c)
 	if err != nil {

--- a/pkg/operator/config/config.go
+++ b/pkg/operator/config/config.go
@@ -49,11 +49,14 @@ type OperatorControllerConfig struct {
 	DeploymentHooks []deploymentcontroller.DeploymentHookFunc
 	// List of informers that should be added to the Deployment controller.
 	DeploymentInformers []factory.Informer
-	// List of secrets that should be watched by the Deployment controller. Change of content of these secrets
-	// will cause redeployment of the controller.
+	// List of secrets that should be watched by the Deployment controller. Any change of content of these secrets
+	// will cause redeployment of the controller. You will typically want to include your cloud credentials secret
+	// and metric certificate secret in here, if they exist/are required.
 	DeploymentWatchedSecretNames []string
 
-	// List of secrets that should be watched by daemonset controller
+	// List of secrets that should be watched by DaemonSet controller. Any change of content of these secrets
+	// will cause redeployment of the node pods. You will typically want to include your cloud credentials secret
+	// in here, if one exists/is required.
 	DaemonSetWatchedSecretNames []string
 
 	// List of library-go style controllers to run in the control-plane namespace.


### PR DESCRIPTION
This is responsible for ensuring the daemonset is updated (and therefore new pods are rolled out) whenever credentials are changed. While we were doing this for the deployment (which manages controller pods), we had missed it for the deployment (which managed node pods). Correct that oversight.
