### PR TITLE
NO-JIRA: Remove `inject-proxy` annotations for aws-ebs, aws-efs node daemonsets

### DIFF
--- a/assets/overlays/aws-ebs/generated/hypershift/node.yaml
+++ b/assets/overlays/aws-ebs/generated/hypershift/node.yaml
@@ -14,7 +14,6 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   annotations:
-    config.openshift.io/inject-proxy: csi-driver
     config.openshift.io/inject-proxy-cabundle: csi-driver
   name: aws-ebs-csi-driver-node
   namespace: ${NODE_NAMESPACE}

--- a/assets/overlays/aws-ebs/generated/standalone/node.yaml
+++ b/assets/overlays/aws-ebs/generated/standalone/node.yaml
@@ -14,7 +14,6 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   annotations:
-    config.openshift.io/inject-proxy: csi-driver
     config.openshift.io/inject-proxy-cabundle: csi-driver
   name: aws-ebs-csi-driver-node
   namespace: ${NODE_NAMESPACE}

--- a/assets/overlays/aws-ebs/patches/node_add_driver.yaml
+++ b/assets/overlays/aws-ebs/patches/node_add_driver.yaml
@@ -2,7 +2,6 @@ kind: DaemonSet
 apiVersion: apps/v1
 metadata:
   annotations:
-    config.openshift.io/inject-proxy: csi-driver
     config.openshift.io/inject-proxy-cabundle: csi-driver
 spec:
   template:

--- a/assets/overlays/aws-efs/generated/standalone/node.yaml
+++ b/assets/overlays/aws-efs/generated/standalone/node.yaml
@@ -14,7 +14,6 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   annotations:
-    config.openshift.io/inject-proxy: csi-driver
     config.openshift.io/inject-proxy-cabundle: csi-driver
   name: aws-efs-csi-driver-node
   namespace: ${NAMESPACE}

--- a/assets/overlays/aws-efs/patches/node_add_driver.yaml
+++ b/assets/overlays/aws-efs/patches/node_add_driver.yaml
@@ -4,7 +4,6 @@ metadata:
   name: aws-efs-csi-driver-node
   namespace: ${NAMESPACE}
   annotations:
-    config.openshift.io/inject-proxy: csi-driver
     config.openshift.io/inject-proxy-cabundle: csi-driver
 spec:
   selector:


### PR DESCRIPTION
There is no proxy hook configured for either driver making this a no-op. Remove it.
