### PR TITLE
HOSTEDCP-2032: Set azure disk & file Secrets Store CSI Volume

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,6 +28,7 @@ require (
 	k8s.io/client-go v0.30.2
 	k8s.io/component-base v0.30.2
 	k8s.io/klog/v2 v2.130.1
+	k8s.io/utils v0.0.0-20240711033017-18e509b52bc8
 	sigs.k8s.io/kustomize/kyaml v0.17.1
 	sigs.k8s.io/yaml v1.4.0
 )
@@ -119,7 +120,6 @@ require (
 	k8s.io/kms v0.30.2 // indirect
 	k8s.io/kube-aggregator v0.30.2 // indirect
 	k8s.io/kube-openapi v0.0.0-20240709000822-3c01b740850f // indirect
-	k8s.io/utils v0.0.0-20240711033017-18e509b52bc8 // indirect
 	sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.30.3 // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
 	sigs.k8s.io/kube-storage-version-migrator v0.0.6-0.20230721195810-5c8923c5ff96 // indirect


### PR DESCRIPTION
Set the azure-disk and azure-file Secrets Store CSI volumes and volume mounts when the following environment variables are passed to the csi-operator pod - ARO_HCP_SECRET_PROVIDER_CLASS_FOR_FILE, ARO_HCP_SECRET_PROVIDER_CLASS_FOR_DISK.