### PR TITLE
NO-JIRA: Add openstack-approvers to root OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,9 +1,4 @@
 approvers:
-- jsafrane
-- tsmetana
-- gnufied
-- bertinatto
-- dobsonj
-- RomanBednar
-- mpatlasov
+- openshift-storage-maintainers
+- openstack-approvers
 component: "Storage / Operators"

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -4,10 +4,6 @@ aliases:
   openstack-approvers:
   - EmilienM
   - mandre
-  - MaysaMacedo
-  - mdbooth
-  - pierreprinetti
-  - stephenfin
   openshift-storage-maintainers:
   - jsafrane
   - tsmetana


### PR DESCRIPTION
To allow us to review/approve OpenStack-related changes to `openshift/release`, since the `OWNERS` files there are auto-generated from this one.

This was previously suggested on https://github.com/openshift/csi-operator/pull/299.
