### PR TITLE
OSASINFRA-3626: Resize support with the OpenStack Manila CSI Driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Lifecycle Manager (OLM).
 * azure-disk-csi-driver-operator
 * azure-file-csi-driver-operator
 * openstack-cinder-csi-driver-operator
+* openstack-manila-csi-driver-operator
 * smb-csi-driver-operator
 
 ## Automatic generation of CSI driver assets

--- a/assets/overlays/openstack-manila/generated/hypershift/controller.yaml
+++ b/assets/overlays/openstack-manila/generated/hypershift/controller.yaml
@@ -8,6 +8,7 @@
 # provisioner.yaml: Applied JSON patch common/hypershift/sidecar_add_kubeconfig.yaml.patch
 # Applied strategic merge patch provisioner.yaml
 # resizer.yaml: Loaded from common/sidecars/resizer.yaml
+# resizer.yaml: Added arguments [--timeout=240s --handle-volume-inuse-error=false]
 # resizer.yaml: Applied JSON patch common/hypershift/sidecar_add_kubeconfig.yaml.patch
 # Applied strategic merge patch resizer.yaml
 # snapshotter.yaml: Loaded from common/sidecars/snapshotter.yaml
@@ -235,6 +236,8 @@ spec:
         - --leader-election-retry-period=${LEADER_ELECTION_RETRY_PERIOD}
         - --leader-election-namespace=${NODE_NAMESPACE}
         - --v=${LOG_LEVEL}
+        - --timeout=240s
+        - --handle-volume-inuse-error=false
         - --kubeconfig=$(KUBECONFIG)
         env:
         - name: KUBECONFIG

--- a/assets/overlays/openstack-manila/generated/standalone/controller.yaml
+++ b/assets/overlays/openstack-manila/generated/standalone/controller.yaml
@@ -7,6 +7,7 @@
 # provisioner.yaml: Added arguments [--timeout=120s --feature-gates=Topology=true]
 # Applied strategic merge patch provisioner.yaml
 # resizer.yaml: Loaded from common/sidecars/resizer.yaml
+# resizer.yaml: Added arguments [--timeout=240s --handle-volume-inuse-error=false]
 # Applied strategic merge patch resizer.yaml
 # snapshotter.yaml: Loaded from common/sidecars/snapshotter.yaml
 # Applied strategic merge patch snapshotter.yaml
@@ -199,6 +200,8 @@ spec:
         - --leader-election-retry-period=${LEADER_ELECTION_RETRY_PERIOD}
         - --leader-election-namespace=${NODE_NAMESPACE}
         - --v=${LOG_LEVEL}
+        - --timeout=240s
+        - --handle-volume-inuse-error=false
         env: []
         image: ${RESIZER_IMAGE}
         imagePullPolicy: IfNotPresent

--- a/test/e2e/openstack-manila/manifest.yaml
+++ b/test/e2e/openstack-manila/manifest.yaml
@@ -26,3 +26,5 @@ DriverInfo:
     multipods: true
     RWX: true
     multiplePVsSameID: true
+    controllerExpansion: true
+    nodeExpansion: false


### PR DESCRIPTION
Volume expansion is a mandatory feature supported
within back end drivers in OpenStack Manila. To
enable this with the Manila CSI driver, the operator needs to specify the external resizer sidecar along with its appropriate RBAC, and set "allowVolumeExpansion" to True. Volume expansion for NAS shared file systems is a controller-only operation; there's no node plugin operations necessary unlike block storage.