### PR TITLE
OCPBUGS-44723: remove EFS driver metrics

### DIFF
--- a/assets/overlays/aws-efs/generated/standalone/controller.yaml
+++ b/assets/overlays/aws-efs/generated/standalone/controller.yaml
@@ -2,7 +2,6 @@
 #
 # Loaded from base/controller.yaml
 # Applied strategic merge patch overlays/aws-efs/patches/controller_add_driver.yaml
-# Applied strategic merge patch common/sidecars/controller_driver_kube_rbac_proxy.yaml
 # provisioner.yaml: Loaded from common/sidecars/provisioner.yaml
 # provisioner.yaml: Added arguments [--feature-gates=Topology=true --extra-create-metadata=true --timeout=5m --worker-threads=1]
 # Applied strategic merge patch provisioner.yaml
@@ -165,29 +164,6 @@ spec:
         volumeMounts:
         - mountPath: /csi
           name: socket-dir
-      - args:
-        - --secure-listen-address=0.0.0.0:9211
-        - --upstream=http://127.0.0.1:8211/
-        - --tls-cert-file=/etc/tls/private/tls.crt
-        - --tls-private-key-file=/etc/tls/private/tls.key
-        - --tls-cipher-suites=${TLS_CIPHER_SUITES}
-        - --tls-min-version=${TLS_MIN_VERSION}
-        - --logtostderr=true
-        image: ${KUBE_RBAC_PROXY_IMAGE}
-        imagePullPolicy: IfNotPresent
-        name: kube-rbac-proxy-8211
-        ports:
-        - containerPort: 9211
-          name: driver-m
-          protocol: TCP
-        resources:
-          requests:
-            cpu: 10m
-            memory: 20Mi
-        terminationMessagePolicy: FallbackToLogsOnError
-        volumeMounts:
-        - mountPath: /etc/tls/private
-          name: metrics-serving-cert
       hostNetwork: true
       initContainers:
       - command:

--- a/assets/overlays/aws-efs/generated/standalone/service.yaml
+++ b/assets/overlays/aws-efs/generated/standalone/service.yaml
@@ -2,7 +2,6 @@
 #
 # Loaded from base/controller_metrics_service.yaml
 # Applied strategic merge patch common/metrics/service_add_port.yaml
-# Applied strategic merge patch common/metrics/service_add_port.yaml
 #
 #
 
@@ -21,10 +20,6 @@ spec:
     port: 9212
     protocol: TCP
     targetPort: provisioner-m
-  - name: driver-m
-    port: 9211
-    protocol: TCP
-    targetPort: driver-m
   selector:
     app: aws-efs-csi-driver-controller
   sessionAffinity: None

--- a/assets/overlays/aws-efs/generated/standalone/servicemonitor.yaml
+++ b/assets/overlays/aws-efs/generated/standalone/servicemonitor.yaml
@@ -2,7 +2,6 @@
 #
 # Loaded from base/controller_metrics_servicemonitor.yaml
 # Applied JSON patch common/metrics/service_monitor_add_port.yaml.patch
-# Applied JSON patch common/metrics/service_monitor_add_port.yaml.patch
 #
 #
 
@@ -17,14 +16,6 @@ spec:
     interval: 30s
     path: /metrics
     port: provisioner-m
-    scheme: https
-    tlsConfig:
-      caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
-      serverName: aws-efs-csi-driver-controller-metrics.${NAMESPACE}.svc
-  - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
-    interval: 30s
-    path: /metrics
-    port: driver-m
     scheme: https
     tlsConfig:
       caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt

--- a/pkg/driver/aws-efs/aws_efs.go
+++ b/pkg/driver/aws-efs/aws_efs.go
@@ -42,16 +42,8 @@ func GetAWSEFSGeneratorConfig() *generator.CSIDriverGeneratorConfig {
 		OutputDir:        generatedAssetBase,
 
 		ControllerConfig: &generator.ControlPlaneConfig{
-			DeploymentTemplateAssetName: "overlays/aws-efs/patches/controller_add_driver.yaml",
-			LivenessProbePort:           10302,
-			MetricsPorts: []generator.MetricsPort{
-				{
-					LocalPort:           commongenerator.AWSEFSLoopbackMetricsPortStart,
-					InjectKubeRBACProxy: true,
-					ExposedPort:         commongenerator.AWSEFSExposedMetricsPortStart,
-					Name:                "driver-m",
-				},
-			},
+			DeploymentTemplateAssetName:    "overlays/aws-efs/patches/controller_add_driver.yaml",
+			LivenessProbePort:              10302,
 			SidecarLocalMetricsPortStart:   commongenerator.AWSEFSLoopbackMetricsPortStart + 1,
 			SidecarExposedMetricsPortStart: commongenerator.AWSEFSExposedMetricsPortStart + 1,
 			Sidecars: []generator.SidecarConfig{


### PR DESCRIPTION
EFS driver does not support metrics, this was added by mistake when migrating code to this repo.

Before patch:
```
$ oc -n openshift-cluster-csi-drivers logs pod/aws-efs-csi-driver-controller-664d67f4d8-44lqg -c kube-rbac-proxy-8211
W1121 14:42:17.000703       1 deprecated.go:66]
==== Removed Flag Warning ======================

logtostderr is removed in the k8s upstream and has no effect any more.

===============================================

I1121 14:42:17.001127       1 kube-rbac-proxy.go:233] Valid token audiences:
I1121 14:42:17.001183       1 kube-rbac-proxy.go:347] Reading certificate files
I1121 14:42:17.001379       1 kube-rbac-proxy.go:395] Starting TCP socket on 0.0.0.0:9211
I1121 14:42:17.001613       1 kube-rbac-proxy.go:402] Listening securely on 0.0.0.0:9211
I1121 14:42:23.493167       1 log.go:245] http: proxy error: dial tcp 127.0.0.1:8211: connect: connection refused
I1121 14:42:33.744653       1 log.go:245] http: proxy error: dial tcp 127.0.0.1:8211: connect: connection refused
```

After patch:
```
$ oc -n openshift-cluster-csi-drivers logs pod/aws-efs-csi-driver-controller-547797bd4d-56djb
Defaulted container "csi-driver" out of: csi-driver, csi-provisioner, provisioner-kube-rbac-proxy, csi-liveness-probe, init-aws-credentials-file (init)
I1125 11:49:29.823515       1 config_dir.go:63] Mounted directories do not exist, creating directory at '/etc/amazon/efs'
I1125 11:49:29.824107       1 metadata.go:65] getting MetadataService...
I1125 11:49:29.826001       1 metadata.go:70] retrieving metadata from EC2 metadata service
I1125 11:49:29.828572       1 driver.go:116] Registering Node Server
I1125 11:49:29.828584       1 driver.go:118] Registering Controller Server
I1125 11:49:29.828592       1 driver.go:121] Starting efs-utils watchdog
I1125 11:49:29.828643       1 efs_watch_dog.go:216] Copying /etc/amazon/efs/efs-utils.conf since it doesn't exist
I1125 11:49:29.829548       1 efs_watch_dog.go:216] Copying /etc/amazon/efs/efs-utils.crt since it doesn't exist
I1125 11:49:29.830365       1 driver.go:127] Starting reaper
I1125 11:49:29.830394       1 driver.go:137] Listening for connections on address: &net.UnixAddr{Name:"/var/lib/csi/sockets/pluginproxy/csi.sock", Net:"unix"}
rbednar-mac:~ rbednar$ oc -n openshift-cluster-csi-drivers logs pod/aws-efs-csi-driver-controller-547797bd4d-56djb -c kube-rbac-proxy-8211
error: container kube-rbac-proxy-8211 is not valid for pod aws-efs-csi-driver-controller-547797bd4d-56djb
rbednar-mac:~ rbednar$ oc -n openshift-cluster-csi-drivers logs pod/aws-efs-csi-driver-controller-547797bd4d-56djb
Defaulted container "csi-driver" out of: csi-driver, csi-provisioner, provisioner-kube-rbac-proxy, csi-liveness-probe, init-aws-credentials-file (init)
I1125 11:49:29.823515       1 config_dir.go:63] Mounted directories do not exist, creating directory at '/etc/amazon/efs'
I1125 11:49:29.824107       1 metadata.go:65] getting MetadataService...
I1125 11:49:29.826001       1 metadata.go:70] retrieving metadata from EC2 metadata service
I1125 11:49:29.828572       1 driver.go:116] Registering Node Server
I1125 11:49:29.828584       1 driver.go:118] Registering Controller Server
I1125 11:49:29.828592       1 driver.go:121] Starting efs-utils watchdog
I1125 11:49:29.828643       1 efs_watch_dog.go:216] Copying /etc/amazon/efs/efs-utils.conf since it doesn't exist
I1125 11:49:29.829548       1 efs_watch_dog.go:216] Copying /etc/amazon/efs/efs-utils.crt since it doesn't exist
I1125 11:49:29.830365       1 driver.go:127] Starting reaper
I1125 11:49:29.830394       1 driver.go:137] Listening for connections on address: &net.UnixAddr{Name:"/var/lib/csi/sockets/pluginproxy/csi.sock", Net:"unix"}
```

```
oc -n openshift-cluster-csi-drivers logs pod/aws-efs-csi-driver-controller-547797bd4d-56djb -c kube-rbac-proxy-8211
error: container kube-rbac-proxy-8211 is not valid for pod aws-efs-csi-driver-controller-547797bd4d-56djb
```

cc @openshift/storage 