### PR TITLE
OCPBUGS-45182: add startupProbe to `csi-driver`

### DIFF
--- a/assets/overlays/openstack-manila/generated/hypershift/controller.yaml
+++ b/assets/overlays/openstack-manila/generated/hypershift/controller.yaml
@@ -126,6 +126,15 @@ spec:
           requests:
             cpu: 10m
             memory: 50Mi
+        startupProbe:
+          exec:
+            command:
+            - sh
+            - -c
+            - test -S /plugin/csi-nfs.sock
+          failureThreshold: 6
+          initialDelaySeconds: 30
+          periodSeconds: 5
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /plugin

--- a/assets/overlays/openstack-manila/generated/standalone/controller.yaml
+++ b/assets/overlays/openstack-manila/generated/standalone/controller.yaml
@@ -96,6 +96,15 @@ spec:
           requests:
             cpu: 10m
             memory: 50Mi
+        startupProbe:
+          exec:
+            command:
+            - sh
+            - -c
+            - test -S /plugin/csi-nfs.sock
+          failureThreshold: 6
+          initialDelaySeconds: 30
+          periodSeconds: 5
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /plugin

--- a/assets/overlays/openstack-manila/patches/controller_add_driver.yaml
+++ b/assets/overlays/openstack-manila/patches/controller_add_driver.yaml
@@ -81,6 +81,17 @@ spec:
             timeoutSeconds: 10
             periodSeconds: 30
             failureThreshold: 5
+          # CSI driver initialization requires that the NFS driver socket
+          # exists which should take less than a minute.
+          startupProbe:
+            exec:
+              command:
+              - sh
+              - -c
+              - "test -S /plugin/csi-nfs.sock"
+            initialDelaySeconds: 30
+            periodSeconds: 5
+            failureThreshold: 6
           volumeMounts:
             - name: socket-dir
               mountPath: /plugin


### PR DESCRIPTION
The csi-driver container requires an NFS socket (handled by csi-driver-nfs) to be created before it can operate.
If the socket is not available at startup, the pod will restart unnecessarily due to initialization failure.

Using a postStart hook to check for the socket is not reliable, as Kubernetes does not guarantee the hook will execute before the container's entrypoint starts.

This patch introduces a startupProbe to verify the existence of the NFS socket.
The probe will run for up to one minute, allowing sufficient time for the socket to be created and avoiding premature pod restarts.
The existing livenessProbe remains responsible for ongoing health checks.