### PR TITLE
OCPBUGS-45267: openstack-manila: modify assets selectors

### DIFF
--- a/assets/overlays/openstack-manila/generated/hypershift/controller.yaml
+++ b/assets/overlays/openstack-manila/generated/hypershift/controller.yaml
@@ -20,6 +20,7 @@
 # Applied strategic merge patch common/hypershift/controller_add_affinity_tolerations.yaml
 # Applied strategic merge patch overlays/openstack-manila/patches/controller_add_hypershift_volumes.yaml
 # Applied strategic merge patch overlays/openstack-manila/patches/controller_rename_config_map.yaml
+# Applied strategic merge patch overlays/openstack-manila/patches/modify_anti_affinity_selector.yaml
 #
 #
 
@@ -82,7 +83,8 @@ spec:
           - podAffinityTerm:
               labelSelector:
                 matchLabels:
-                  app: manila-csi-driver-controller
+                  app: openstack-manila-csi
+                  component: controllerplugin
               topologyKey: kubernetes.io/hostname
             weight: 100
       containers:

--- a/assets/overlays/openstack-manila/generated/hypershift/controller_pdb.yaml
+++ b/assets/overlays/openstack-manila/generated/hypershift/controller_pdb.yaml
@@ -1,6 +1,7 @@
 # Generated file. Do not edit. Update using "make update".
 #
 # Loaded from base/controller_pdb.yaml
+# Applied strategic merge patch overlays/openstack-manila/patches/modify_match_labels.yaml
 #
 #
 
@@ -13,5 +14,6 @@ spec:
   maxUnavailable: 1
   selector:
     matchLabels:
-      app: manila-csi-driver-controller
+      app: openstack-manila-csi
+      component: controllerplugin
   unhealthyPodEvictionPolicy: AlwaysAllow

--- a/assets/overlays/openstack-manila/generated/hypershift/service.yaml
+++ b/assets/overlays/openstack-manila/generated/hypershift/service.yaml
@@ -5,6 +5,7 @@
 # Applied strategic merge patch common/metrics/service_add_port.yaml
 # Applied strategic merge patch common/metrics/service_add_port.yaml
 # Applied strategic merge patch common/metrics/service_add_port.yaml
+# Applied strategic merge patch overlays/openstack-manila/patches/modify_service_selector.yaml
 #
 #
 
@@ -36,6 +37,7 @@ spec:
     protocol: TCP
     targetPort: driver-m
   selector:
-    app: manila-csi-driver-controller
+    app: openstack-manila-csi
+    component: controllerplugin
   sessionAffinity: None
   type: ClusterIP

--- a/assets/overlays/openstack-manila/generated/standalone/controller.yaml
+++ b/assets/overlays/openstack-manila/generated/standalone/controller.yaml
@@ -15,6 +15,7 @@
 # livenessprobe.yaml: Added arguments [--probe-timeout=10s]
 # Applied strategic merge patch livenessprobe.yaml
 # Applied strategic merge patch common/standalone/controller_add_affinity.yaml
+# Applied strategic merge patch overlays/openstack-manila/patches/modify_anti_affinity_selector.yaml
 #
 #
 
@@ -52,7 +53,8 @@ spec:
           - podAffinityTerm:
               labelSelector:
                 matchLabels:
-                  app: manila-csi-driver-controller
+                  app: openstack-manila-csi
+                  component: controllerplugin
               topologyKey: kubernetes.io/hostname
             weight: 100
       containers:

--- a/assets/overlays/openstack-manila/generated/standalone/controller_pdb.yaml
+++ b/assets/overlays/openstack-manila/generated/standalone/controller_pdb.yaml
@@ -1,6 +1,7 @@
 # Generated file. Do not edit. Update using "make update".
 #
 # Loaded from base/controller_pdb.yaml
+# Applied strategic merge patch overlays/openstack-manila/patches/modify_match_labels.yaml
 #
 #
 
@@ -13,5 +14,6 @@ spec:
   maxUnavailable: 1
   selector:
     matchLabels:
-      app: manila-csi-driver-controller
+      app: openstack-manila-csi
+      component: controllerplugin
   unhealthyPodEvictionPolicy: AlwaysAllow

--- a/assets/overlays/openstack-manila/generated/standalone/service.yaml
+++ b/assets/overlays/openstack-manila/generated/standalone/service.yaml
@@ -5,6 +5,7 @@
 # Applied strategic merge patch common/metrics/service_add_port.yaml
 # Applied strategic merge patch common/metrics/service_add_port.yaml
 # Applied strategic merge patch common/metrics/service_add_port.yaml
+# Applied strategic merge patch overlays/openstack-manila/patches/modify_service_selector.yaml
 #
 #
 
@@ -36,6 +37,7 @@ spec:
     protocol: TCP
     targetPort: driver-m
   selector:
-    app: manila-csi-driver-controller
+    app: openstack-manila-csi
+    component: controllerplugin
   sessionAffinity: None
   type: ClusterIP

--- a/assets/overlays/openstack-manila/patches/controller_add_driver.yaml
+++ b/assets/overlays/openstack-manila/patches/controller_add_driver.yaml
@@ -33,16 +33,6 @@ spec:
         - key: node-role.kubernetes.io/master
           operator: Exists
           effect: "NoSchedule"
-      affinity:
-        podAntiAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-            - weight: 100
-              podAffinityTerm:
-                labelSelector:
-                  matchLabels:
-                    app: openstack-manila-csi
-                    component: controllerplugin
-                topologyKey: kubernetes.io/hostname
       containers:
         - name: csi-driver
           image: ${DRIVER_IMAGE}

--- a/assets/overlays/openstack-manila/patches/modify_anti_affinity_selector.yaml
+++ b/assets/overlays/openstack-manila/patches/modify_anti_affinity_selector.yaml
@@ -1,0 +1,13 @@
+spec:
+  template:
+    spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: openstack-manila-csi
+                  component: controllerplugin
+              topologyKey: kubernetes.io/hostname
+            weight: 100

--- a/assets/overlays/openstack-manila/patches/modify_match_labels.yaml
+++ b/assets/overlays/openstack-manila/patches/modify_match_labels.yaml
@@ -1,0 +1,5 @@
+spec:
+  selector:
+    matchLabels:
+      app: openstack-manila-csi
+      component: controllerplugin

--- a/assets/overlays/openstack-manila/patches/modify_service_selector.yaml
+++ b/assets/overlays/openstack-manila/patches/modify_service_selector.yaml
@@ -1,0 +1,4 @@
+spec:
+  selector:
+    app: openstack-manila-csi
+    component: controllerplugin

--- a/pkg/driver/openstack-manila/openstack_manila.go
+++ b/pkg/driver/openstack-manila/openstack_manila.go
@@ -84,6 +84,10 @@ func GetOpenStackManilaGeneratorConfig() *generator.CSIDriverGeneratorConfig {
 			AssetPatches: commongenerator.DefaultAssetPatches.WithPatches(generator.HyperShiftOnly,
 				"controller.yaml", "overlays/openstack-manila/patches/controller_add_hypershift_volumes.yaml",
 				"controller.yaml", "overlays/openstack-manila/patches/controller_rename_config_map.yaml",
+			).WithPatches(generator.AllFlavours,
+				"service.yaml", "overlays/openstack-manila/patches/modify_service_selector.yaml",
+				"controller_pdb.yaml", "overlays/openstack-manila/patches/modify_match_labels.yaml",
+				"controller.yaml", "overlays/openstack-manila/patches/modify_anti_affinity_selector.yaml",
 			),
 		},
 


### PR DESCRIPTION
This commit updates the selectors used in the controller Deployment,
PodDisruptionBudget and the controller metrics Service to actually use
the labels that are enforced in the controller.