### PR TITLE
OSASINFRA-3683: openstack-manila: Remove --nodeid parameter

### DIFF
--- a/assets/overlays/openstack-manila/base/node_nfs.yaml
+++ b/assets/overlays/openstack-manila/base/node_nfs.yaml
@@ -38,9 +38,9 @@ spec:
               cpu: 10m
           args:
             - --v=${LOG_LEVEL}
-            - "--nodeid=$(NODE_ID)"
-            - "--endpoint=unix://plugin/csi.sock"
-            - "--mount-permissions=0777"
+            - --nodeid=$(NODE_ID)
+            - --endpoint=unix://plugin/csi.sock
+            - --mount-permissions=0777
           env:
             - name: NODE_ID
               valueFrom:

--- a/assets/overlays/openstack-manila/generated/hypershift/controller.yaml
+++ b/assets/overlays/openstack-manila/generated/hypershift/controller.yaml
@@ -92,7 +92,6 @@ spec:
         - --provide-node-service=false
         - --v=${LOG_LEVEL}
         - --cluster-id=${CLUSTER_ID}
-        - --nodeid=$(NODE_ID)
         - --endpoint=$(CSI_ENDPOINT)
         - --drivername=$(DRIVER_NAME)
         - --share-protocol-selector=$(MANILA_SHARE_PROTO)
@@ -100,10 +99,6 @@ spec:
         env:
         - name: DRIVER_NAME
           value: manila.csi.openstack.org
-        - name: NODE_ID
-          valueFrom:
-            fieldRef:
-              fieldPath: spec.nodeName
         - name: CSI_ENDPOINT
           value: unix:///plugin/csi.sock
         - name: MANILA_SHARE_PROTO

--- a/assets/overlays/openstack-manila/generated/hypershift/node.yaml
+++ b/assets/overlays/openstack-manila/generated/hypershift/node.yaml
@@ -38,7 +38,6 @@ spec:
         - --provide-controller-service=false
         - --provide-node-service=true
         - --v=${LOG_LEVEL}
-        - --nodeid=$(NODE_ID)
         - --endpoint=$(CSI_ENDPOINT)
         - --drivername=$(DRIVER_NAME)
         - --share-protocol-selector=$(MANILA_SHARE_PROTO)
@@ -46,10 +45,6 @@ spec:
         env:
         - name: DRIVER_NAME
           value: manila.csi.openstack.org
-        - name: NODE_ID
-          valueFrom:
-            fieldRef:
-              fieldPath: spec.nodeName
         - name: CSI_ENDPOINT
           value: unix:///var/lib/kubelet/plugins/manila.csi.openstack.org/csi.sock
         - name: FWD_CSI_ENDPOINT

--- a/assets/overlays/openstack-manila/generated/standalone/controller.yaml
+++ b/assets/overlays/openstack-manila/generated/standalone/controller.yaml
@@ -62,7 +62,6 @@ spec:
         - --provide-node-service=false
         - --v=${LOG_LEVEL}
         - --cluster-id=${CLUSTER_ID}
-        - --nodeid=$(NODE_ID)
         - --endpoint=$(CSI_ENDPOINT)
         - --drivername=$(DRIVER_NAME)
         - --share-protocol-selector=$(MANILA_SHARE_PROTO)
@@ -70,10 +69,6 @@ spec:
         env:
         - name: DRIVER_NAME
           value: manila.csi.openstack.org
-        - name: NODE_ID
-          valueFrom:
-            fieldRef:
-              fieldPath: spec.nodeName
         - name: CSI_ENDPOINT
           value: unix:///plugin/csi.sock
         - name: MANILA_SHARE_PROTO

--- a/assets/overlays/openstack-manila/generated/standalone/node.yaml
+++ b/assets/overlays/openstack-manila/generated/standalone/node.yaml
@@ -38,7 +38,6 @@ spec:
         - --provide-controller-service=false
         - --provide-node-service=true
         - --v=${LOG_LEVEL}
-        - --nodeid=$(NODE_ID)
         - --endpoint=$(CSI_ENDPOINT)
         - --drivername=$(DRIVER_NAME)
         - --share-protocol-selector=$(MANILA_SHARE_PROTO)
@@ -46,10 +45,6 @@ spec:
         env:
         - name: DRIVER_NAME
           value: manila.csi.openstack.org
-        - name: NODE_ID
-          valueFrom:
-            fieldRef:
-              fieldPath: spec.nodeName
         - name: CSI_ENDPOINT
           value: unix:///var/lib/kubelet/plugins/manila.csi.openstack.org/csi.sock
         - name: FWD_CSI_ENDPOINT

--- a/assets/overlays/openstack-manila/patches/controller_add_driver.yaml
+++ b/assets/overlays/openstack-manila/patches/controller_add_driver.yaml
@@ -42,7 +42,6 @@ spec:
             - --provide-node-service=false
             - --v=${LOG_LEVEL}
             - --cluster-id=${CLUSTER_ID}
-            - --nodeid=$(NODE_ID)
             - --endpoint=$(CSI_ENDPOINT)
             - --drivername=$(DRIVER_NAME)
             - --share-protocol-selector=$(MANILA_SHARE_PROTO)
@@ -50,10 +49,6 @@ spec:
           env:
             - name: DRIVER_NAME
               value: manila.csi.openstack.org
-            - name: NODE_ID
-              valueFrom:
-                fieldRef:
-                  fieldPath: spec.nodeName
             - name: CSI_ENDPOINT
               value: unix:///plugin/csi.sock
             - name: MANILA_SHARE_PROTO
@@ -88,9 +83,9 @@ spec:
           image: ${NFS_DRIVER_IMAGE}
           imagePullPolicy: IfNotPresent
           args:
-            - "--nodeid=$(NODE_ID)"
-            - "--endpoint=unix://plugin/csi-nfs.sock"
-            - "--mount-permissions=0777"
+            - --nodeid=$(NODE_ID)
+            - --endpoint=unix://plugin/csi-nfs.sock
+            - --mount-permissions=0777
           env:
             - name: NODE_ID
               valueFrom:

--- a/assets/overlays/openstack-manila/patches/node_add_driver.yaml
+++ b/assets/overlays/openstack-manila/patches/node_add_driver.yaml
@@ -40,18 +40,13 @@ spec:
             - "--provide-controller-service=false"
             - "--provide-node-service=true"
             - --v=${LOG_LEVEL}
-            - "--nodeid=$(NODE_ID)"
-            - "--endpoint=$(CSI_ENDPOINT)"
-            - "--drivername=$(DRIVER_NAME)"
-            - "--share-protocol-selector=$(MANILA_SHARE_PROTO)"
-            - "--fwdendpoint=$(FWD_CSI_ENDPOINT)"
+            - --endpoint=$(CSI_ENDPOINT)
+            - --drivername=$(DRIVER_NAME)
+            - --share-protocol-selector=$(MANILA_SHARE_PROTO)
+            - --fwdendpoint=$(FWD_CSI_ENDPOINT)
           env:
             - name: DRIVER_NAME
               value: manila.csi.openstack.org
-            - name: NODE_ID
-              valueFrom:
-                fieldRef:
-                  fieldPath: spec.nodeName
             - name: CSI_ENDPOINT
               value: unix:///var/lib/kubelet/plugins/manila.csi.openstack.org/csi.sock
             - name: FWD_CSI_ENDPOINT


### PR DESCRIPTION
This option is deprecated as the driver can now auto-configure this [1]. We can also remove some unnecessary quoting.

Note that we don't remove the option from the NFS driver as that is a separate binary that doesn't support this auto-configuration.

[1] https://github.com/kubernetes/cloud-provider-openstack/pull/2734

Signed-off-by: Stephen Finucane <stephenfin@redhat.com>
