### PR TITLE
OCPBUGS-48507: openstack-manila: update PodDisruptionBudget name

### DIFF
--- a/assets/overlays/openstack-manila/generated/hypershift/controller_pdb.yaml
+++ b/assets/overlays/openstack-manila/generated/hypershift/controller_pdb.yaml
@@ -1,14 +1,14 @@
 # Generated file. Do not edit. Update using "make update".
 #
 # Loaded from base/controller_pdb.yaml
-# Applied strategic merge patch overlays/openstack-manila/patches/modify_match_labels.yaml
+# Applied strategic merge patch overlays/openstack-manila/patches/modify_pdb.yaml
 #
 #
 
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
-  name: manila-csi-driver-controller-pdb
+  name: openstack-manila-csi-controllerplugin-pdb
   namespace: ${NAMESPACE}
 spec:
   maxUnavailable: 1

--- a/assets/overlays/openstack-manila/generated/standalone/controller_pdb.yaml
+++ b/assets/overlays/openstack-manila/generated/standalone/controller_pdb.yaml
@@ -1,14 +1,14 @@
 # Generated file. Do not edit. Update using "make update".
 #
 # Loaded from base/controller_pdb.yaml
-# Applied strategic merge patch overlays/openstack-manila/patches/modify_match_labels.yaml
+# Applied strategic merge patch overlays/openstack-manila/patches/modify_pdb.yaml
 #
 #
 
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
-  name: manila-csi-driver-controller-pdb
+  name: openstack-manila-csi-controllerplugin-pdb
   namespace: ${NAMESPACE}
 spec:
   maxUnavailable: 1

--- a/assets/overlays/openstack-manila/patches/modify_pdb.yaml
+++ b/assets/overlays/openstack-manila/patches/modify_pdb.yaml
@@ -1,3 +1,5 @@
+metadata:
+  name: openstack-manila-csi-controllerplugin-pdb
 spec:
   selector:
     matchLabels:

--- a/pkg/driver/openstack-manila/openstack_manila.go
+++ b/pkg/driver/openstack-manila/openstack_manila.go
@@ -86,7 +86,7 @@ func GetOpenStackManilaGeneratorConfig() *generator.CSIDriverGeneratorConfig {
 				"controller.yaml", "overlays/openstack-manila/patches/controller_rename_config_map.yaml",
 			).WithPatches(generator.AllFlavours,
 				"service.yaml", "overlays/openstack-manila/patches/modify_service_selector.yaml",
-				"controller_pdb.yaml", "overlays/openstack-manila/patches/modify_match_labels.yaml",
+				"controller_pdb.yaml", "overlays/openstack-manila/patches/modify_pdb.yaml",
 				"controller.yaml", "overlays/openstack-manila/patches/modify_anti_affinity_selector.yaml",
 			),
 		},


### PR DESCRIPTION
In previous releases the PodDisruptionBudget is named openstack-manila-csi-controllerplugin-pdb instead of manila-csi-driver-controller-pdb, which is the name currently generated by csi-operator. This prevents upgrades from being successful. To fix the issue the asset is renamed with the same name as used in previous releases.