### PR TITLE
OCPBUGS-41827: update injector to use a secret rather than an environment variable

### DIFF
--- a/assets/overlays/azure-disk/generated/hypershift/node.yaml
+++ b/assets/overlays/azure-disk/generated/hypershift/node.yaml
@@ -179,32 +179,9 @@ spec:
         - --output-file-path=/etc/merged-cloud-config/cloud.conf
         - --disable-identity-extension-auth
         - --enable-azure-workload-identity=${ENABLE_AZURE_WORKLOAD_IDENTITY}
+        - --creds-path=/etc/azure/credentials
         command:
         - /azure-config-credentials-injector
-        env:
-        - name: AZURE_CLIENT_ID
-          valueFrom:
-            secretKeyRef:
-              key: azure_client_id
-              name: azure-disk-credentials
-        - name: AZURE_CLIENT_SECRET
-          valueFrom:
-            secretKeyRef:
-              key: azure_client_secret
-              name: azure-disk-credentials
-              optional: true
-        - name: AZURE_TENANT_ID
-          valueFrom:
-            secretKeyRef:
-              key: azure_tenant_id
-              name: azure-disk-credentials
-              optional: true
-        - name: AZURE_FEDERATED_TOKEN_FILE
-          valueFrom:
-            secretKeyRef:
-              key: azure_federated_token_file
-              name: azure-disk-credentials
-              optional: true
         image: ${CLUSTER_CLOUD_CONTROLLER_MANAGER_OPERATOR_IMAGE}
         name: azure-inject-credentials
         terminationMessagePolicy: FallbackToLogsOnError
@@ -214,6 +191,9 @@ spec:
           readOnly: true
         - mountPath: /etc/merged-cloud-config
           name: cloud-config
+        - mountPath: /etc/azure/credentials
+          name: cloud-sa-volume
+          readOnly: true
       nodeSelector:
         kubernetes.io/os: linux
       priorityClassName: system-node-critical
@@ -251,6 +231,9 @@ spec:
       - configMap:
           name: azure-cloud-config
         name: src-cloud-config
+      - name: cloud-sa-volume
+        secret:
+          secretName: azure-disk-credentials
       - hostPath:
           path: /sys/bus/scsi/devices
           type: Directory

--- a/assets/overlays/azure-disk/generated/standalone/controller.yaml
+++ b/assets/overlays/azure-disk/generated/standalone/controller.yaml
@@ -337,32 +337,9 @@ spec:
         - --output-file-path=/etc/kubernetes/cloud.conf
         - --disable-identity-extension-auth
         - --enable-azure-workload-identity=${ENABLE_AZURE_WORKLOAD_IDENTITY}
+        - --creds-path=/etc/azure/credentials
         command:
         - /azure-config-credentials-injector
-        env:
-        - name: AZURE_CLIENT_ID
-          valueFrom:
-            secretKeyRef:
-              key: azure_client_id
-              name: azure-disk-credentials
-        - name: AZURE_CLIENT_SECRET
-          valueFrom:
-            secretKeyRef:
-              key: azure_client_secret
-              name: azure-disk-credentials
-              optional: true
-        - name: AZURE_TENANT_ID
-          valueFrom:
-            secretKeyRef:
-              key: azure_tenant_id
-              name: azure-disk-credentials
-              optional: true
-        - name: AZURE_FEDERATED_TOKEN_FILE
-          valueFrom:
-            secretKeyRef:
-              key: azure_federated_token_file
-              name: azure-disk-credentials
-              optional: true
         image: ${CLUSTER_CLOUD_CONTROLLER_MANAGER_OPERATOR_IMAGE}
         name: azure-inject-credentials
         terminationMessagePolicy: FallbackToLogsOnError
@@ -372,6 +349,9 @@ spec:
           readOnly: true
         - mountPath: /etc/kubernetes
           name: cloud-config
+        - mountPath: /etc/azure/credentials
+          name: cloud-sa-volume
+          readOnly: true
       nodeSelector:
         node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
@@ -393,6 +373,9 @@ spec:
         name: src-cloud-config
       - emptyDir: {}
         name: cloud-config
+      - name: cloud-sa-volume
+        secret:
+          secretName: azure-disk-credentials
       - name: bound-sa-token
         projected:
           sources:

--- a/assets/overlays/azure-disk/generated/standalone/node.yaml
+++ b/assets/overlays/azure-disk/generated/standalone/node.yaml
@@ -179,32 +179,9 @@ spec:
         - --output-file-path=/etc/merged-cloud-config/cloud.conf
         - --disable-identity-extension-auth
         - --enable-azure-workload-identity=${ENABLE_AZURE_WORKLOAD_IDENTITY}
+        - --creds-path=/etc/azure/credentials
         command:
         - /azure-config-credentials-injector
-        env:
-        - name: AZURE_CLIENT_ID
-          valueFrom:
-            secretKeyRef:
-              key: azure_client_id
-              name: azure-disk-credentials
-        - name: AZURE_CLIENT_SECRET
-          valueFrom:
-            secretKeyRef:
-              key: azure_client_secret
-              name: azure-disk-credentials
-              optional: true
-        - name: AZURE_TENANT_ID
-          valueFrom:
-            secretKeyRef:
-              key: azure_tenant_id
-              name: azure-disk-credentials
-              optional: true
-        - name: AZURE_FEDERATED_TOKEN_FILE
-          valueFrom:
-            secretKeyRef:
-              key: azure_federated_token_file
-              name: azure-disk-credentials
-              optional: true
         image: ${CLUSTER_CLOUD_CONTROLLER_MANAGER_OPERATOR_IMAGE}
         name: azure-inject-credentials
         terminationMessagePolicy: FallbackToLogsOnError
@@ -214,6 +191,9 @@ spec:
           readOnly: true
         - mountPath: /etc/merged-cloud-config
           name: cloud-config
+        - mountPath: /etc/azure/credentials
+          name: cloud-sa-volume
+          readOnly: true
       nodeSelector:
         kubernetes.io/os: linux
       priorityClassName: system-node-critical
@@ -251,6 +231,9 @@ spec:
       - configMap:
           name: azure-cloud-config
         name: src-cloud-config
+      - name: cloud-sa-volume
+        secret:
+          secretName: azure-disk-credentials
       - hostPath:
           path: /sys/bus/scsi/devices
           type: Directory

--- a/assets/overlays/azure-disk/patches/controller_add_standalone_injector.yaml
+++ b/assets/overlays/azure-disk/patches/controller_add_standalone_injector.yaml
@@ -19,30 +19,7 @@ spec:
             # Force disable node's managed identity, azure-disk-credentials Secret should be used.
             - --disable-identity-extension-auth
             - --enable-azure-workload-identity=${ENABLE_AZURE_WORKLOAD_IDENTITY}
-          env:
-            - name: AZURE_CLIENT_ID
-              valueFrom:
-                secretKeyRef:
-                  name: azure-disk-credentials
-                  key: azure_client_id
-            - name: AZURE_CLIENT_SECRET
-              valueFrom:
-                secretKeyRef:
-                  name: azure-disk-credentials
-                  key: azure_client_secret
-                  optional: true
-            - name: AZURE_TENANT_ID
-              valueFrom:
-                secretKeyRef:
-                  name: azure-disk-credentials
-                  key: azure_tenant_id
-                  optional: true
-            - name: AZURE_FEDERATED_TOKEN_FILE
-              valueFrom:
-                secretKeyRef:
-                  name: azure-disk-credentials
-                  key: azure_federated_token_file
-                  optional: true
+            - --creds-path=/etc/azure/credentials
           terminationMessagePolicy: FallbackToLogsOnError
           volumeMounts:
             - name: src-cloud-config
@@ -50,12 +27,18 @@ spec:
               readOnly: true
             - name: cloud-config
               mountPath: /etc/kubernetes
+            - name: cloud-sa-volume
+              readOnly: true
+              mountPath: /etc/azure/credentials
       volumes:
         - name: src-cloud-config
           configMap:
             name: azure-cloud-config
         - emptyDir: {}
           name: cloud-config
+        - name: cloud-sa-volume
+          secret:
+            secretName: azure-disk-credentials
         - name: bound-sa-token
           projected:
             sources:

--- a/assets/overlays/azure-disk/patches/node_add_driver.yaml
+++ b/assets/overlays/azure-disk/patches/node_add_driver.yaml
@@ -82,30 +82,7 @@ spec:
             # Force disable node's managed identity, azure-disk-credentials Secret should be used.
             - --disable-identity-extension-auth
             - --enable-azure-workload-identity=${ENABLE_AZURE_WORKLOAD_IDENTITY}
-          env:
-            - name: AZURE_CLIENT_ID
-              valueFrom:
-                secretKeyRef:
-                  name: azure-disk-credentials
-                  key: azure_client_id
-            - name: AZURE_CLIENT_SECRET
-              valueFrom:
-                secretKeyRef:
-                  name: azure-disk-credentials
-                  key: azure_client_secret
-                  optional: true
-            - name: AZURE_TENANT_ID
-              valueFrom:
-                secretKeyRef:
-                  name: azure-disk-credentials
-                  key: azure_tenant_id
-                  optional: true
-            - name: AZURE_FEDERATED_TOKEN_FILE
-              valueFrom:
-                secretKeyRef:
-                  name: azure-disk-credentials
-                  key: azure_federated_token_file
-                  optional: true
+            - --creds-path=/etc/azure/credentials
           terminationMessagePolicy: FallbackToLogsOnError
           volumeMounts:
             - name: src-cloud-config
@@ -113,10 +90,16 @@ spec:
               readOnly: true
             - name: cloud-config
               mountPath: /etc/merged-cloud-config
+            - name: cloud-sa-volume
+              readOnly: true
+              mountPath: /etc/azure/credentials
       volumes:
         - name: src-cloud-config
           configMap:
             name: azure-cloud-config
+        - name: cloud-sa-volume
+          secret:
+            secretName: azure-disk-credentials
         - hostPath:
             path: /sys/bus/scsi/devices
             type: Directory

--- a/assets/overlays/azure-file/generated/hypershift/node.yaml
+++ b/assets/overlays/azure-file/generated/hypershift/node.yaml
@@ -158,32 +158,9 @@ spec:
         - --output-file-path=/etc/merged-cloud-config/cloud.conf
         - --disable-identity-extension-auth
         - --enable-azure-workload-identity=${ENABLE_AZURE_WORKLOAD_IDENTITY}
+        - --creds-path=/etc/azure/credentials
         command:
         - /azure-config-credentials-injector
-        env:
-        - name: AZURE_CLIENT_ID
-          valueFrom:
-            secretKeyRef:
-              key: azure_client_id
-              name: azure-file-credentials
-        - name: AZURE_CLIENT_SECRET
-          valueFrom:
-            secretKeyRef:
-              key: azure_client_secret
-              name: azure-file-credentials
-              optional: true
-        - name: AZURE_TENANT_ID
-          valueFrom:
-            secretKeyRef:
-              key: azure_tenant_id
-              name: azure-file-credentials
-              optional: true
-        - name: AZURE_FEDERATED_TOKEN_FILE
-          valueFrom:
-            secretKeyRef:
-              key: azure_federated_token_file
-              name: azure-file-credentials
-              optional: true
         image: ${CLUSTER_CLOUD_CONTROLLER_MANAGER_OPERATOR_IMAGE}
         name: azure-inject-credentials
         terminationMessagePolicy: FallbackToLogsOnError
@@ -193,6 +170,9 @@ spec:
           readOnly: true
         - mountPath: /etc/merged-cloud-config
           name: cloud-config
+        - mountPath: /etc/azure/credentials
+          name: cloud-sa-volume
+          readOnly: true
       nodeSelector:
         kubernetes.io/os: linux
       priorityClassName: system-node-critical
@@ -230,6 +210,9 @@ spec:
       - configMap:
           name: azure-cloud-config
         name: src-cloud-config
+      - name: cloud-sa-volume
+        secret:
+          secretName: azure-file-credentials
       - hostPath:
           path: /sys/bus/scsi/devices
           type: Directory

--- a/assets/overlays/azure-file/generated/standalone/controller.yaml
+++ b/assets/overlays/azure-file/generated/standalone/controller.yaml
@@ -336,32 +336,9 @@ spec:
         - --output-file-path=/etc/kubernetes/cloud.conf
         - --disable-identity-extension-auth
         - --enable-azure-workload-identity=${ENABLE_AZURE_WORKLOAD_IDENTITY}
+        - --creds-path=/etc/azure/credentials
         command:
         - /azure-config-credentials-injector
-        env:
-        - name: AZURE_CLIENT_ID
-          valueFrom:
-            secretKeyRef:
-              key: azure_client_id
-              name: azure-file-credentials
-        - name: AZURE_CLIENT_SECRET
-          valueFrom:
-            secretKeyRef:
-              key: azure_client_secret
-              name: azure-file-credentials
-              optional: true
-        - name: AZURE_TENANT_ID
-          valueFrom:
-            secretKeyRef:
-              key: azure_tenant_id
-              name: azure-file-credentials
-              optional: true
-        - name: AZURE_FEDERATED_TOKEN_FILE
-          valueFrom:
-            secretKeyRef:
-              key: azure_federated_token_file
-              name: azure-file-credentials
-              optional: true
         image: ${CLUSTER_CLOUD_CONTROLLER_MANAGER_OPERATOR_IMAGE}
         name: azure-inject-credentials
         terminationMessagePolicy: FallbackToLogsOnError
@@ -371,6 +348,9 @@ spec:
           readOnly: true
         - mountPath: /etc/kubernetes
           name: cloud-config
+        - mountPath: /etc/azure/credentials
+          name: cloud-sa-volume
+          readOnly: true
       nodeSelector:
         node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
@@ -390,6 +370,9 @@ spec:
       - configMap:
           name: azure-cloud-config
         name: src-cloud-config
+      - name: cloud-sa-volume
+        secret:
+          secretName: azure-file-credentials
       - emptyDir: {}
         name: cloud-config
       - name: bound-sa-token

--- a/assets/overlays/azure-file/generated/standalone/node.yaml
+++ b/assets/overlays/azure-file/generated/standalone/node.yaml
@@ -158,32 +158,9 @@ spec:
         - --output-file-path=/etc/merged-cloud-config/cloud.conf
         - --disable-identity-extension-auth
         - --enable-azure-workload-identity=${ENABLE_AZURE_WORKLOAD_IDENTITY}
+        - --creds-path=/etc/azure/credentials
         command:
         - /azure-config-credentials-injector
-        env:
-        - name: AZURE_CLIENT_ID
-          valueFrom:
-            secretKeyRef:
-              key: azure_client_id
-              name: azure-file-credentials
-        - name: AZURE_CLIENT_SECRET
-          valueFrom:
-            secretKeyRef:
-              key: azure_client_secret
-              name: azure-file-credentials
-              optional: true
-        - name: AZURE_TENANT_ID
-          valueFrom:
-            secretKeyRef:
-              key: azure_tenant_id
-              name: azure-file-credentials
-              optional: true
-        - name: AZURE_FEDERATED_TOKEN_FILE
-          valueFrom:
-            secretKeyRef:
-              key: azure_federated_token_file
-              name: azure-file-credentials
-              optional: true
         image: ${CLUSTER_CLOUD_CONTROLLER_MANAGER_OPERATOR_IMAGE}
         name: azure-inject-credentials
         terminationMessagePolicy: FallbackToLogsOnError
@@ -193,6 +170,9 @@ spec:
           readOnly: true
         - mountPath: /etc/merged-cloud-config
           name: cloud-config
+        - mountPath: /etc/azure/credentials
+          name: cloud-sa-volume
+          readOnly: true
       nodeSelector:
         kubernetes.io/os: linux
       priorityClassName: system-node-critical
@@ -230,6 +210,9 @@ spec:
       - configMap:
           name: azure-cloud-config
         name: src-cloud-config
+      - name: cloud-sa-volume
+        secret:
+          secretName: azure-file-credentials
       - hostPath:
           path: /sys/bus/scsi/devices
           type: Directory

--- a/assets/overlays/azure-file/patches/controller_add_standalone_injector.yaml
+++ b/assets/overlays/azure-file/patches/controller_add_standalone_injector.yaml
@@ -19,30 +19,7 @@ spec:
             # Force disable node's managed identity, azure-file-credentials Secret should be used.
             - --disable-identity-extension-auth
             - --enable-azure-workload-identity=${ENABLE_AZURE_WORKLOAD_IDENTITY}
-          env:
-            - name: AZURE_CLIENT_ID
-              valueFrom:
-                secretKeyRef:
-                  name: azure-file-credentials
-                  key: azure_client_id
-            - name: AZURE_CLIENT_SECRET
-              valueFrom:
-                secretKeyRef:
-                  name: azure-file-credentials
-                  key: azure_client_secret
-                  optional: true
-            - name: AZURE_TENANT_ID
-              valueFrom:
-                secretKeyRef:
-                  name: azure-file-credentials
-                  key: azure_tenant_id
-                  optional: true
-            - name: AZURE_FEDERATED_TOKEN_FILE
-              valueFrom:
-                secretKeyRef:
-                  name: azure-file-credentials
-                  key: azure_federated_token_file
-                  optional: true
+            - --creds-path=/etc/azure/credentials
           terminationMessagePolicy: FallbackToLogsOnError
           volumeMounts:
             - name: src-cloud-config
@@ -50,10 +27,16 @@ spec:
               readOnly: true
             - name: cloud-config
               mountPath: /etc/kubernetes
+            - name: cloud-sa-volume
+              readOnly: true
+              mountPath: /etc/azure/credentials
       volumes:
         - name: src-cloud-config
           configMap:
             name: azure-cloud-config
+        - name: cloud-sa-volume
+          secret:
+            secretName: azure-file-credentials
         - emptyDir: {}
           name: cloud-config
         - name: bound-sa-token

--- a/assets/overlays/azure-file/patches/node_add_driver.yaml
+++ b/assets/overlays/azure-file/patches/node_add_driver.yaml
@@ -85,30 +85,7 @@ spec:
             # Force disable node's managed identity, azure-file-credentials Secret should be used.
             - --disable-identity-extension-auth
             - --enable-azure-workload-identity=${ENABLE_AZURE_WORKLOAD_IDENTITY}
-          env:
-            - name: AZURE_CLIENT_ID
-              valueFrom:
-                secretKeyRef:
-                  name: azure-file-credentials
-                  key: azure_client_id
-            - name: AZURE_CLIENT_SECRET
-              valueFrom:
-                secretKeyRef:
-                  name: azure-file-credentials
-                  key: azure_client_secret
-                  optional: true
-            - name: AZURE_TENANT_ID
-              valueFrom:
-                secretKeyRef:
-                  name: azure-file-credentials
-                  key: azure_tenant_id
-                  optional: true
-            - name: AZURE_FEDERATED_TOKEN_FILE
-              valueFrom:
-                secretKeyRef:
-                  name: azure-file-credentials
-                  key: azure_federated_token_file
-                  optional: true
+            - --creds-path=/etc/azure/credentials
           terminationMessagePolicy: FallbackToLogsOnError
           volumeMounts:
             - name: src-cloud-config
@@ -116,10 +93,16 @@ spec:
               readOnly: true
             - name: cloud-config
               mountPath: /etc/merged-cloud-config
+            - name: cloud-sa-volume
+              readOnly: true
+              mountPath: /etc/azure/credentials
       volumes:
         - name: src-cloud-config
           configMap:
             name: azure-cloud-config
+        - name: cloud-sa-volume
+          secret:
+            secretName: azure-file-credentials
         - hostPath:
             path: /sys/bus/scsi/devices
             type: Directory


### PR DESCRIPTION
Based on discussion https://github.com/openshift/cluster-cloud-controller-manager-operator/pull/380#issuecomment-2668448871  pr https://github.com/openshift/cluster-cloud-controller-manager-operator/pull/385 will keep both the secret and environment variables methods, then this pr can be merged, then remove environment variables in pr https://github.com/openshift/cluster-cloud-controller-manager-operator/pull/380

Built image [build 4.18,openshift/cluster-cloud-controller-manager-operator#385](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/release-openshift-origin-installer-launch-aws-modern/1894239232529010688) and installed cluster on azure and ash, cluster install succeed.
Built image [build 4.18,openshift/cluster-cloud-controller-manager-operator#385, openshift/csi-operator#357](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/release-openshift-origin-installer-launch-aws-modern/1894239702202978304) and installed cluster on azure and ash, cluster install succeed.

Now ASH install is blocked by bug https://issues.redhat.com/browse/OCPBUGS-51090, once this bug is fixed, I will check this pr again.  