### PR TITLE
OSASINFRA-3731: openstack: Consume CA cert from CCO secret

### DIFF
--- a/assets/overlays/openstack-cinder/generated/hypershift/controller.yaml
+++ b/assets/overlays/openstack-cinder/generated/hypershift/controller.yaml
@@ -148,7 +148,7 @@ spec:
         - mountPath: /etc/kubernetes/config
           name: config-cinderplugin
           readOnly: true
-        - mountPath: /etc/kubernetes/secret
+        - mountPath: /etc/openstack
           name: cloud-credentials
           readOnly: true
       - args:

--- a/assets/overlays/openstack-cinder/generated/hypershift/controller.yaml
+++ b/assets/overlays/openstack-cinder/generated/hypershift/controller.yaml
@@ -52,7 +52,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: cacert,config-cinderplugin,secret-cinderplugin,socket-dir
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: cacert,config-cinderplugin,cloud-credentials,socket-dir
         openshift.io/required-scc: restricted-v2
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
@@ -140,16 +140,16 @@ spec:
           readOnlyRootFilesystem: true
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
+        - mountPath: /csi
+          name: socket-dir
         - mountPath: /etc/kubernetes/static-pod-resources/configmaps/cloud-config
           name: cacert
         - mountPath: /etc/kubernetes/config
           name: config-cinderplugin
           readOnly: true
         - mountPath: /etc/kubernetes/secret
-          name: secret-cinderplugin
+          name: cloud-credentials
           readOnly: true
-        - mountPath: /csi
-          name: socket-dir
       - args:
         - --secure-listen-address=0.0.0.0:9202
         - --upstream=http://127.0.0.1:8202/
@@ -432,7 +432,7 @@ spec:
       - name: metrics-serving-cert
         secret:
           secretName: openstack-cinder-csi-driver-controller-metrics-serving-cert
-      - name: secret-cinderplugin
+      - name: cloud-credentials
         secret:
           items:
           - key: clouds.yaml

--- a/assets/overlays/openstack-cinder/generated/hypershift/controller.yaml
+++ b/assets/overlays/openstack-cinder/generated/hypershift/controller.yaml
@@ -434,11 +434,19 @@ spec:
         secret:
           secretName: openstack-cinder-csi-driver-controller-metrics-serving-cert
       - name: cloud-credentials
-        secret:
-          items:
-          - key: clouds.yaml
-            path: clouds.yaml
-          secretName: openstack-cloud-credentials
+        projected:
+          sources:
+          - secret:
+              items:
+              - key: cacert
+                path: ca.crt
+              name: openstack-cloud-credentials
+              optional: true
+          - secret:
+              items:
+              - key: clouds.yaml
+                path: clouds.yaml
+              name: openstack-cloud-credentials
       - configMap:
           items:
           - key: cloud.conf

--- a/assets/overlays/openstack-cinder/generated/hypershift/controller.yaml
+++ b/assets/overlays/openstack-cinder/generated/hypershift/controller.yaml
@@ -144,6 +144,7 @@ spec:
           name: socket-dir
         - mountPath: /etc/kubernetes/static-pod-resources/configmaps/cloud-config
           name: cacert
+          readOnly: true
         - mountPath: /etc/kubernetes/config
           name: config-cinderplugin
           readOnly: true

--- a/assets/overlays/openstack-cinder/generated/hypershift/controller.yaml
+++ b/assets/overlays/openstack-cinder/generated/hypershift/controller.yaml
@@ -52,7 +52,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: cacert,config-cinderplugin,cloud-credentials,socket-dir
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: config-cinderplugin,cloud-credentials,legacy-cacert,socket-dir
         openshift.io/required-scc: restricted-v2
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
@@ -142,14 +142,14 @@ spec:
         volumeMounts:
         - mountPath: /csi
           name: socket-dir
-        - mountPath: /etc/kubernetes/static-pod-resources/configmaps/cloud-config
-          name: cacert
-          readOnly: true
         - mountPath: /etc/kubernetes/config
           name: config-cinderplugin
           readOnly: true
         - mountPath: /etc/openstack
           name: cloud-credentials
+          readOnly: true
+        - mountPath: /etc/kubernetes/static-pod-resources/configmaps/cloud-config
+          name: legacy-cacert
           readOnly: true
       - args:
         - --secure-listen-address=0.0.0.0:9202
@@ -451,7 +451,7 @@ spec:
             path: ca-bundle.pem
           name: cloud-conf
           optional: true
-        name: cacert
+        name: legacy-cacert
       - name: hosted-kubeconfig
         secret:
           defaultMode: 420

--- a/assets/overlays/openstack-cinder/generated/hypershift/node.yaml
+++ b/assets/overlays/openstack-cinder/generated/hypershift/node.yaml
@@ -98,7 +98,7 @@ spec:
         - mountPath: /etc/kubernetes/config
           name: config-cinderplugin
           readOnly: true
-        - mountPath: /etc/kubernetes/secret
+        - mountPath: /etc/openstack
           name: cloud-credentials
           readOnly: true
       - args:

--- a/assets/overlays/openstack-cinder/generated/hypershift/node.yaml
+++ b/assets/overlays/openstack-cinder/generated/hypershift/node.yaml
@@ -94,6 +94,7 @@ spec:
           name: sys-fs
         - mountPath: /etc/kubernetes/static-pod-resources/configmaps/cloud-config
           name: cacert
+          readOnly: true
         - mountPath: /etc/kubernetes/config
           name: config-cinderplugin
           readOnly: true

--- a/assets/overlays/openstack-cinder/generated/hypershift/node.yaml
+++ b/assets/overlays/openstack-cinder/generated/hypershift/node.yaml
@@ -198,11 +198,19 @@ spec:
         secret:
           secretName: openstack-cinder-csi-driver-node-metrics-serving-cert
       - name: cloud-credentials
-        secret:
-          items:
-          - key: clouds.yaml
-            path: clouds.yaml
-          secretName: openstack-cloud-credentials
+        projected:
+          sources:
+          - secret:
+              items:
+              - key: cacert
+                path: ca.crt
+              name: openstack-cloud-credentials
+              optional: true
+          - secret:
+              items:
+              - key: clouds.yaml
+                path: clouds.yaml
+              name: openstack-cloud-credentials
       - configMap:
           items:
           - key: cloud.conf

--- a/assets/overlays/openstack-cinder/generated/hypershift/node.yaml
+++ b/assets/overlays/openstack-cinder/generated/hypershift/node.yaml
@@ -98,7 +98,7 @@ spec:
           name: config-cinderplugin
           readOnly: true
         - mountPath: /etc/kubernetes/secret
-          name: secret-cinderplugin
+          name: cloud-credentials
           readOnly: true
       - args:
         - --csi-address=/csi/csi.sock
@@ -196,6 +196,18 @@ spec:
       - name: metrics-serving-cert
         secret:
           secretName: openstack-cinder-csi-driver-node-metrics-serving-cert
+      - name: cloud-credentials
+        secret:
+          items:
+          - key: clouds.yaml
+            path: clouds.yaml
+          secretName: openstack-cloud-credentials
+      - configMap:
+          items:
+          - key: cloud.conf
+            path: cloud.conf
+          name: cloud-conf
+        name: config-cinderplugin
       - configMap:
           items:
           - key: ca-bundle.pem
@@ -203,18 +215,6 @@ spec:
           name: cloud-conf
           optional: true
         name: cacert
-      - configMap:
-          items:
-          - key: cloud.conf
-            path: cloud.conf
-          name: cloud-conf
-        name: config-cinderplugin
-      - name: secret-cinderplugin
-        secret:
-          items:
-          - key: clouds.yaml
-            path: clouds.yaml
-          secretName: openstack-cloud-credentials
   updateStrategy:
     rollingUpdate:
       maxUnavailable: 10%

--- a/assets/overlays/openstack-cinder/generated/hypershift/node.yaml
+++ b/assets/overlays/openstack-cinder/generated/hypershift/node.yaml
@@ -92,14 +92,14 @@ spec:
           name: etc-selinux
         - mountPath: /sys/fs
           name: sys-fs
-        - mountPath: /etc/kubernetes/static-pod-resources/configmaps/cloud-config
-          name: cacert
-          readOnly: true
         - mountPath: /etc/kubernetes/config
           name: config-cinderplugin
           readOnly: true
         - mountPath: /etc/openstack
           name: cloud-credentials
+          readOnly: true
+        - mountPath: /etc/kubernetes/static-pod-resources/configmaps/cloud-config
+          name: legacy-cacert
           readOnly: true
       - args:
         - --csi-address=/csi/csi.sock
@@ -215,7 +215,7 @@ spec:
             path: ca-bundle.pem
           name: cloud-conf
           optional: true
-        name: cacert
+        name: legacy-cacert
   updateStrategy:
     rollingUpdate:
       maxUnavailable: 10%

--- a/assets/overlays/openstack-cinder/generated/standalone/controller.yaml
+++ b/assets/overlays/openstack-cinder/generated/standalone/controller.yaml
@@ -112,7 +112,7 @@ spec:
         - mountPath: /etc/kubernetes/config
           name: config-cinderplugin
           readOnly: true
-        - mountPath: /etc/kubernetes/secret
+        - mountPath: /etc/openstack
           name: cloud-credentials
           readOnly: true
       - args:

--- a/assets/overlays/openstack-cinder/generated/standalone/controller.yaml
+++ b/assets/overlays/openstack-cinder/generated/standalone/controller.yaml
@@ -108,6 +108,7 @@ spec:
           name: socket-dir
         - mountPath: /etc/kubernetes/static-pod-resources/configmaps/cloud-config
           name: cacert
+          readOnly: true
         - mountPath: /etc/kubernetes/config
           name: config-cinderplugin
           readOnly: true

--- a/assets/overlays/openstack-cinder/generated/standalone/controller.yaml
+++ b/assets/overlays/openstack-cinder/generated/standalone/controller.yaml
@@ -371,11 +371,19 @@ spec:
         secret:
           secretName: openstack-cinder-csi-driver-controller-metrics-serving-cert
       - name: cloud-credentials
-        secret:
-          items:
-          - key: clouds.yaml
-            path: clouds.yaml
-          secretName: openstack-cloud-credentials
+        projected:
+          sources:
+          - secret:
+              items:
+              - key: cacert
+                path: ca.crt
+              name: openstack-cloud-credentials
+              optional: true
+          - secret:
+              items:
+              - key: clouds.yaml
+                path: clouds.yaml
+              name: openstack-cloud-credentials
       - configMap:
           items:
           - key: cloud.conf

--- a/assets/overlays/openstack-cinder/generated/standalone/controller.yaml
+++ b/assets/overlays/openstack-cinder/generated/standalone/controller.yaml
@@ -41,7 +41,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: cacert,config-cinderplugin,secret-cinderplugin,socket-dir
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: cacert,config-cinderplugin,cloud-credentials,socket-dir
         openshift.io/required-scc: restricted-v2
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
@@ -104,16 +104,16 @@ spec:
           readOnlyRootFilesystem: true
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
+        - mountPath: /csi
+          name: socket-dir
         - mountPath: /etc/kubernetes/static-pod-resources/configmaps/cloud-config
           name: cacert
         - mountPath: /etc/kubernetes/config
           name: config-cinderplugin
           readOnly: true
         - mountPath: /etc/kubernetes/secret
-          name: secret-cinderplugin
+          name: cloud-credentials
           readOnly: true
-        - mountPath: /csi
-          name: socket-dir
       - args:
         - --secure-listen-address=0.0.0.0:9202
         - --upstream=http://127.0.0.1:8202/
@@ -369,7 +369,7 @@ spec:
       - name: metrics-serving-cert
         secret:
           secretName: openstack-cinder-csi-driver-controller-metrics-serving-cert
-      - name: secret-cinderplugin
+      - name: cloud-credentials
         secret:
           items:
           - key: clouds.yaml

--- a/assets/overlays/openstack-cinder/generated/standalone/controller.yaml
+++ b/assets/overlays/openstack-cinder/generated/standalone/controller.yaml
@@ -41,7 +41,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: cacert,config-cinderplugin,cloud-credentials,socket-dir
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: config-cinderplugin,cloud-credentials,legacy-cacert,socket-dir
         openshift.io/required-scc: restricted-v2
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
@@ -106,14 +106,14 @@ spec:
         volumeMounts:
         - mountPath: /csi
           name: socket-dir
-        - mountPath: /etc/kubernetes/static-pod-resources/configmaps/cloud-config
-          name: cacert
-          readOnly: true
         - mountPath: /etc/kubernetes/config
           name: config-cinderplugin
           readOnly: true
         - mountPath: /etc/openstack
           name: cloud-credentials
+          readOnly: true
+        - mountPath: /etc/kubernetes/static-pod-resources/configmaps/cloud-config
+          name: legacy-cacert
           readOnly: true
       - args:
         - --secure-listen-address=0.0.0.0:9202
@@ -388,4 +388,4 @@ spec:
             path: ca-bundle.pem
           name: cloud-conf
           optional: true
-        name: cacert
+        name: legacy-cacert

--- a/assets/overlays/openstack-cinder/generated/standalone/node.yaml
+++ b/assets/overlays/openstack-cinder/generated/standalone/node.yaml
@@ -98,7 +98,7 @@ spec:
         - mountPath: /etc/kubernetes/config
           name: config-cinderplugin
           readOnly: true
-        - mountPath: /etc/kubernetes/secret
+        - mountPath: /etc/openstack
           name: cloud-credentials
           readOnly: true
       - args:

--- a/assets/overlays/openstack-cinder/generated/standalone/node.yaml
+++ b/assets/overlays/openstack-cinder/generated/standalone/node.yaml
@@ -94,6 +94,7 @@ spec:
           name: sys-fs
         - mountPath: /etc/kubernetes/static-pod-resources/configmaps/cloud-config
           name: cacert
+          readOnly: true
         - mountPath: /etc/kubernetes/config
           name: config-cinderplugin
           readOnly: true

--- a/assets/overlays/openstack-cinder/generated/standalone/node.yaml
+++ b/assets/overlays/openstack-cinder/generated/standalone/node.yaml
@@ -198,11 +198,19 @@ spec:
         secret:
           secretName: openstack-cinder-csi-driver-node-metrics-serving-cert
       - name: cloud-credentials
-        secret:
-          items:
-          - key: clouds.yaml
-            path: clouds.yaml
-          secretName: openstack-cloud-credentials
+        projected:
+          sources:
+          - secret:
+              items:
+              - key: cacert
+                path: ca.crt
+              name: openstack-cloud-credentials
+              optional: true
+          - secret:
+              items:
+              - key: clouds.yaml
+                path: clouds.yaml
+              name: openstack-cloud-credentials
       - configMap:
           items:
           - key: cloud.conf

--- a/assets/overlays/openstack-cinder/generated/standalone/node.yaml
+++ b/assets/overlays/openstack-cinder/generated/standalone/node.yaml
@@ -98,7 +98,7 @@ spec:
           name: config-cinderplugin
           readOnly: true
         - mountPath: /etc/kubernetes/secret
-          name: secret-cinderplugin
+          name: cloud-credentials
           readOnly: true
       - args:
         - --csi-address=/csi/csi.sock
@@ -196,6 +196,18 @@ spec:
       - name: metrics-serving-cert
         secret:
           secretName: openstack-cinder-csi-driver-node-metrics-serving-cert
+      - name: cloud-credentials
+        secret:
+          items:
+          - key: clouds.yaml
+            path: clouds.yaml
+          secretName: openstack-cloud-credentials
+      - configMap:
+          items:
+          - key: cloud.conf
+            path: cloud.conf
+          name: cloud-conf
+        name: config-cinderplugin
       - configMap:
           items:
           - key: ca-bundle.pem
@@ -203,18 +215,6 @@ spec:
           name: cloud-conf
           optional: true
         name: cacert
-      - configMap:
-          items:
-          - key: cloud.conf
-            path: cloud.conf
-          name: cloud-conf
-        name: config-cinderplugin
-      - name: secret-cinderplugin
-        secret:
-          items:
-          - key: clouds.yaml
-            path: clouds.yaml
-          secretName: openstack-cloud-credentials
   updateStrategy:
     rollingUpdate:
       maxUnavailable: 10%

--- a/assets/overlays/openstack-cinder/generated/standalone/node.yaml
+++ b/assets/overlays/openstack-cinder/generated/standalone/node.yaml
@@ -92,14 +92,14 @@ spec:
           name: etc-selinux
         - mountPath: /sys/fs
           name: sys-fs
-        - mountPath: /etc/kubernetes/static-pod-resources/configmaps/cloud-config
-          name: cacert
-          readOnly: true
         - mountPath: /etc/kubernetes/config
           name: config-cinderplugin
           readOnly: true
         - mountPath: /etc/openstack
           name: cloud-credentials
+          readOnly: true
+        - mountPath: /etc/kubernetes/static-pod-resources/configmaps/cloud-config
+          name: legacy-cacert
           readOnly: true
       - args:
         - --csi-address=/csi/csi.sock
@@ -215,7 +215,7 @@ spec:
             path: ca-bundle.pem
           name: cloud-conf
           optional: true
-        name: cacert
+        name: legacy-cacert
   updateStrategy:
     rollingUpdate:
       maxUnavailable: 10%

--- a/assets/overlays/openstack-cinder/patches/controller_add_driver.yaml
+++ b/assets/overlays/openstack-cinder/patches/controller_add_driver.yaml
@@ -80,6 +80,7 @@ spec:
             - name: cloud-credentials
               mountPath: /etc/openstack
               readOnly: true
+            # TODO(stephenfin): Remove in 4.22
             - name: legacy-cacert
               mountPath: /etc/kubernetes/static-pod-resources/configmaps/cloud-config
               readOnly: true
@@ -90,17 +91,26 @@ spec:
           terminationMessagePolicy: FallbackToLogsOnError
       volumes:
         - name: cloud-credentials
-          secret:
-            secretName: openstack-cloud-credentials
-            items:
-              - key: clouds.yaml
-                path: clouds.yaml
+          projected:
+            sources:
+              - secret:
+                  name: openstack-cloud-credentials
+                  items:
+                    - key: cacert
+                      path: ca.crt
+                  optional: true
+              - secret:
+                  name: openstack-cloud-credentials
+                  items:
+                    - key: clouds.yaml
+                      path: clouds.yaml
         - name: config-cinderplugin
           configMap:
             name: cloud-conf
             items:
               - key: cloud.conf
                 path: cloud.conf
+        # TODO(stephenfin): Remove in 4.22
         - name: legacy-cacert
           configMap:
             name: cloud-conf

--- a/assets/overlays/openstack-cinder/patches/controller_add_driver.yaml
+++ b/assets/overlays/openstack-cinder/patches/controller_add_driver.yaml
@@ -8,7 +8,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: "cacert,config-cinderplugin,secret-cinderplugin,socket-dir"
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: "cacert,config-cinderplugin,cloud-credentials,socket-dir"
         openshift.io/required-scc: restricted-v2
       labels:
         openshift.storage.network-policy.all-egress: allow
@@ -71,23 +71,24 @@ spec:
             periodSeconds: 30
             failureThreshold: 5
           volumeMounts:
+            - name: socket-dir
+              mountPath: /csi
+            # credentials and configuration
             - name: cacert
               mountPath: /etc/kubernetes/static-pod-resources/configmaps/cloud-config
             - name: config-cinderplugin
               mountPath: /etc/kubernetes/config
               readOnly: true
-            - name: secret-cinderplugin
+            - name: cloud-credentials
               mountPath: /etc/kubernetes/secret
               readOnly: true
-            - name: socket-dir
-              mountPath: /csi
           resources:
             requests:
               memory: 50Mi
               cpu: 10m
           terminationMessagePolicy: FallbackToLogsOnError
       volumes:
-        - name: secret-cinderplugin
+        - name: cloud-credentials
           secret:
             secretName: openstack-cloud-credentials
             items:
@@ -100,14 +101,9 @@ spec:
               - key: cloud.conf
                 path: cloud.conf
         - name: cacert
-          # If present, extract ca-bundle.pem to
-          # /etc/kubernetes/static-pod-resources/configmaps/cloud-config
-          # Let the pod start when the ConfigMap does not exist or the certificate
-          # is not preset there. The certificate file will be created once the
-          # ConfigMap is created / the certificate is added to it.
           configMap:
             name: cloud-conf
             items:
-            - key: ca-bundle.pem
-              path: ca-bundle.pem
+              - key: ca-bundle.pem
+                path: ca-bundle.pem
             optional: true

--- a/assets/overlays/openstack-cinder/patches/controller_add_driver.yaml
+++ b/assets/overlays/openstack-cinder/patches/controller_add_driver.yaml
@@ -76,6 +76,7 @@ spec:
             # credentials and configuration
             - name: cacert
               mountPath: /etc/kubernetes/static-pod-resources/configmaps/cloud-config
+              readOnly: true
             - name: config-cinderplugin
               mountPath: /etc/kubernetes/config
               readOnly: true

--- a/assets/overlays/openstack-cinder/patches/controller_add_driver.yaml
+++ b/assets/overlays/openstack-cinder/patches/controller_add_driver.yaml
@@ -8,7 +8,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: "cacert,config-cinderplugin,cloud-credentials,socket-dir"
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: "config-cinderplugin,cloud-credentials,legacy-cacert,socket-dir"
         openshift.io/required-scc: restricted-v2
       labels:
         openshift.storage.network-policy.all-egress: allow
@@ -74,14 +74,14 @@ spec:
             - name: socket-dir
               mountPath: /csi
             # credentials and configuration
-            - name: cacert
-              mountPath: /etc/kubernetes/static-pod-resources/configmaps/cloud-config
-              readOnly: true
             - name: config-cinderplugin
               mountPath: /etc/kubernetes/config
               readOnly: true
             - name: cloud-credentials
               mountPath: /etc/openstack
+              readOnly: true
+            - name: legacy-cacert
+              mountPath: /etc/kubernetes/static-pod-resources/configmaps/cloud-config
               readOnly: true
           resources:
             requests:
@@ -101,7 +101,7 @@ spec:
             items:
               - key: cloud.conf
                 path: cloud.conf
-        - name: cacert
+        - name: legacy-cacert
           configMap:
             name: cloud-conf
             items:

--- a/assets/overlays/openstack-cinder/patches/controller_add_driver.yaml
+++ b/assets/overlays/openstack-cinder/patches/controller_add_driver.yaml
@@ -81,7 +81,7 @@ spec:
               mountPath: /etc/kubernetes/config
               readOnly: true
             - name: cloud-credentials
-              mountPath: /etc/kubernetes/secret
+              mountPath: /etc/openstack
               readOnly: true
           resources:
             requests:

--- a/assets/overlays/openstack-cinder/patches/node_add_driver.yaml
+++ b/assets/overlays/openstack-cinder/patches/node_add_driver.yaml
@@ -51,14 +51,14 @@ spec:
             - name: sys-fs
               mountPath: /sys/fs
             # credentials and configuration
-            - name: cacert
-              mountPath: /etc/kubernetes/static-pod-resources/configmaps/cloud-config
-              readOnly: true
             - name: config-cinderplugin
               mountPath: /etc/kubernetes/config
               readOnly: true
             - name: cloud-credentials
               mountPath: /etc/openstack
+              readOnly: true
+            - name: legacy-cacert
+              mountPath: /etc/kubernetes/static-pod-resources/configmaps/cloud-config
               readOnly: true
           ports:
             - name: healthz
@@ -91,7 +91,7 @@ spec:
             items:
               - key: cloud.conf
                 path: cloud.conf
-        - name: cacert
+        - name: legacy-cacert
           configMap:
             name: cloud-conf
             items:

--- a/assets/overlays/openstack-cinder/patches/node_add_driver.yaml
+++ b/assets/overlays/openstack-cinder/patches/node_add_driver.yaml
@@ -50,12 +50,13 @@ spec:
               mountPath: /etc/selinux
             - name: sys-fs
               mountPath: /sys/fs
+            # credentials and configuration
             - name: cacert
               mountPath: /etc/kubernetes/static-pod-resources/configmaps/cloud-config
             - name: config-cinderplugin
               mountPath: /etc/kubernetes/config
               readOnly: true
-            - name: secret-cinderplugin
+            - name: cloud-credentials
               mountPath: /etc/kubernetes/secret
               readOnly: true
           ports:
@@ -77,26 +78,22 @@ spec:
               cpu: 10m
           terminationMessagePolicy: FallbackToLogsOnError
       volumes:
-        - name: cacert
-          # Extract ca-bundle.pem to /etc/kubernetes/static-pod-resources/configmaps/cloud-config if present.
-          # Let the pod start when the ConfigMap does not exist or the certificate
-          # is not preset there. The certificate file will be created once the
-          # ConfigMap is created / the certificate is added to it.
-          configMap:
-            name: cloud-conf
+        - name: cloud-credentials
+          secret:
+            secretName: openstack-cloud-credentials
             items:
-            - key: ca-bundle.pem
-              path: ca-bundle.pem
-            optional: true
+              - key: clouds.yaml
+                path: clouds.yaml
         - name: config-cinderplugin
           configMap:
             name: cloud-conf
             items:
               - key: cloud.conf
                 path: cloud.conf
-        - name: secret-cinderplugin
-          secret:
-            secretName: openstack-cloud-credentials
+        - name: cacert
+          configMap:
+            name: cloud-conf
             items:
-              - key: clouds.yaml
-                path: clouds.yaml
+              - key: ca-bundle.pem
+                path: ca-bundle.pem
+            optional: true

--- a/assets/overlays/openstack-cinder/patches/node_add_driver.yaml
+++ b/assets/overlays/openstack-cinder/patches/node_add_driver.yaml
@@ -53,6 +53,7 @@ spec:
             # credentials and configuration
             - name: cacert
               mountPath: /etc/kubernetes/static-pod-resources/configmaps/cloud-config
+              readOnly: true
             - name: config-cinderplugin
               mountPath: /etc/kubernetes/config
               readOnly: true

--- a/assets/overlays/openstack-cinder/patches/node_add_driver.yaml
+++ b/assets/overlays/openstack-cinder/patches/node_add_driver.yaml
@@ -58,7 +58,7 @@ spec:
               mountPath: /etc/kubernetes/config
               readOnly: true
             - name: cloud-credentials
-              mountPath: /etc/kubernetes/secret
+              mountPath: /etc/openstack
               readOnly: true
           ports:
             - name: healthz

--- a/assets/overlays/openstack-cinder/patches/node_add_driver.yaml
+++ b/assets/overlays/openstack-cinder/patches/node_add_driver.yaml
@@ -57,6 +57,7 @@ spec:
             - name: cloud-credentials
               mountPath: /etc/openstack
               readOnly: true
+            # TODO(stephenfin): Remove in 4.22
             - name: legacy-cacert
               mountPath: /etc/kubernetes/static-pod-resources/configmaps/cloud-config
               readOnly: true
@@ -80,17 +81,26 @@ spec:
           terminationMessagePolicy: FallbackToLogsOnError
       volumes:
         - name: cloud-credentials
-          secret:
-            secretName: openstack-cloud-credentials
-            items:
-              - key: clouds.yaml
-                path: clouds.yaml
+          projected:
+            sources:
+              - secret:
+                  name: openstack-cloud-credentials
+                  items:
+                    - key: cacert
+                      path: ca.crt
+                  optional: true
+              - secret:
+                  name: openstack-cloud-credentials
+                  items:
+                    - key: clouds.yaml
+                      path: clouds.yaml
         - name: config-cinderplugin
           configMap:
             name: cloud-conf
             items:
               - key: cloud.conf
                 path: cloud.conf
+        # TODO(stephenfin): Remove in 4.22
         - name: legacy-cacert
           configMap:
             name: cloud-conf

--- a/assets/overlays/openstack-manila/generated/hypershift/controller.yaml
+++ b/assets/overlays/openstack-manila/generated/hypershift/controller.yaml
@@ -147,7 +147,7 @@ spec:
         - mountPath: /plugin
           name: socket-dir
         - mountPath: /etc/kubernetes/static-pod-resources/configmaps/cloud-config
-          name: cacert
+          name: legacy-cacert
         - mountPath: /etc/openstack
           name: cloud-credentials
           readOnly: true
@@ -389,7 +389,7 @@ spec:
             path: ca-bundle.pem
           name: openstack-cloud-config
           optional: true
-        name: cacert
+        name: legacy-cacert
       - name: hosted-kubeconfig
         secret:
           defaultMode: 420

--- a/assets/overlays/openstack-manila/generated/hypershift/controller.yaml
+++ b/assets/overlays/openstack-manila/generated/hypershift/controller.yaml
@@ -146,11 +146,12 @@ spec:
         volumeMounts:
         - mountPath: /plugin
           name: socket-dir
+        - mountPath: /etc/openstack
+          name: cloud-credentials
         - mountPath: /etc/kubernetes/static-pod-resources/configmaps/cloud-config
           name: legacy-cacert
         - mountPath: /etc/openstack
           name: cloud-credentials
-          readOnly: true
       - args:
         - --nodeid=$(NODE_ID)
         - --endpoint=unix://plugin/csi-nfs.sock

--- a/assets/overlays/openstack-manila/generated/hypershift/node.yaml
+++ b/assets/overlays/openstack-manila/generated/hypershift/node.yaml
@@ -93,6 +93,9 @@ spec:
           name: etc-selinux
         - mountPath: /sys/fs
           name: sys-fs
+        - mountPath: /etc/openstack
+          name: cloud-credentials
+          readOnly: true
         - mountPath: /etc/kubernetes/static-pod-resources/configmaps/cloud-config
           name: legacy-cacert
       - args:

--- a/assets/overlays/openstack-manila/generated/hypershift/node.yaml
+++ b/assets/overlays/openstack-manila/generated/hypershift/node.yaml
@@ -89,12 +89,12 @@ spec:
           name: plugin-dir
         - mountPath: /var/lib/kubelet/plugins/csi-nfsplugin
           name: fwd-plugin-dir
-        - mountPath: /etc/kubernetes/static-pod-resources/configmaps/cloud-config
-          name: cacert
         - mountPath: /etc/selinux
           name: etc-selinux
         - mountPath: /sys/fs
           name: sys-fs
+        - mountPath: /etc/kubernetes/static-pod-resources/configmaps/cloud-config
+          name: legacy-cacert
       - args:
         - --csi-address=/csi/csi.sock
         - --http-endpoint=127.0.0.1:10305
@@ -212,7 +212,7 @@ spec:
             path: ca-bundle.pem
           name: cloud-provider-config
           optional: true
-        name: cacert
+        name: legacy-cacert
   updateStrategy:
     rollingUpdate:
       maxUnavailable: 10%

--- a/assets/overlays/openstack-manila/generated/standalone/controller.yaml
+++ b/assets/overlays/openstack-manila/generated/standalone/controller.yaml
@@ -111,7 +111,7 @@ spec:
         - mountPath: /plugin
           name: socket-dir
         - mountPath: /etc/kubernetes/static-pod-resources/configmaps/cloud-config
-          name: cacert
+          name: legacy-cacert
         - mountPath: /etc/openstack
           name: cloud-credentials
           readOnly: true
@@ -332,4 +332,4 @@ spec:
             path: ca-bundle.pem
           name: cloud-provider-config
           optional: true
-        name: cacert
+        name: legacy-cacert

--- a/assets/overlays/openstack-manila/generated/standalone/controller.yaml
+++ b/assets/overlays/openstack-manila/generated/standalone/controller.yaml
@@ -110,11 +110,12 @@ spec:
         volumeMounts:
         - mountPath: /plugin
           name: socket-dir
+        - mountPath: /etc/openstack
+          name: cloud-credentials
         - mountPath: /etc/kubernetes/static-pod-resources/configmaps/cloud-config
           name: legacy-cacert
         - mountPath: /etc/openstack
           name: cloud-credentials
-          readOnly: true
       - args:
         - --nodeid=$(NODE_ID)
         - --endpoint=unix://plugin/csi-nfs.sock

--- a/assets/overlays/openstack-manila/generated/standalone/node.yaml
+++ b/assets/overlays/openstack-manila/generated/standalone/node.yaml
@@ -93,6 +93,9 @@ spec:
           name: etc-selinux
         - mountPath: /sys/fs
           name: sys-fs
+        - mountPath: /etc/openstack
+          name: cloud-credentials
+          readOnly: true
         - mountPath: /etc/kubernetes/static-pod-resources/configmaps/cloud-config
           name: legacy-cacert
       - args:

--- a/assets/overlays/openstack-manila/generated/standalone/node.yaml
+++ b/assets/overlays/openstack-manila/generated/standalone/node.yaml
@@ -89,12 +89,12 @@ spec:
           name: plugin-dir
         - mountPath: /var/lib/kubelet/plugins/csi-nfsplugin
           name: fwd-plugin-dir
-        - mountPath: /etc/kubernetes/static-pod-resources/configmaps/cloud-config
-          name: cacert
         - mountPath: /etc/selinux
           name: etc-selinux
         - mountPath: /sys/fs
           name: sys-fs
+        - mountPath: /etc/kubernetes/static-pod-resources/configmaps/cloud-config
+          name: legacy-cacert
       - args:
         - --csi-address=/csi/csi.sock
         - --http-endpoint=127.0.0.1:10305
@@ -212,7 +212,7 @@ spec:
             path: ca-bundle.pem
           name: cloud-provider-config
           optional: true
-        name: cacert
+        name: legacy-cacert
   updateStrategy:
     rollingUpdate:
       maxUnavailable: 10%

--- a/assets/overlays/openstack-manila/patches/controller_add_driver.yaml
+++ b/assets/overlays/openstack-manila/patches/controller_add_driver.yaml
@@ -80,7 +80,7 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /plugin
-            - name: cacert
+            - name: legacy-cacert
               mountPath: /etc/kubernetes/static-pod-resources/configmaps/cloud-config
             - name: cloud-credentials
               mountPath: /etc/openstack
@@ -122,12 +122,7 @@ spec:
                 path: clouds.yaml
         - name: socket-dir
           emptyDir: {}
-        - name: cacert
-          # If present, extract ca-bundle.pem to
-          # /etc/kubernetes/static-pod-resources/configmaps/cloud-config
-          # Let the pod start when the ConfigMap does not exist or the certificate
-          # is not preset there. The certificate file will be created once the
-          # ConfigMap is created / the cerificate is added to it.
+        - name: legacy-cacert
           configMap:
             name: cloud-provider-config
             items:

--- a/assets/overlays/openstack-manila/patches/controller_add_driver.yaml
+++ b/assets/overlays/openstack-manila/patches/controller_add_driver.yaml
@@ -80,6 +80,8 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /plugin
+            - name: cloud-credentials
+              mountPath: /etc/openstack
             - name: legacy-cacert
               mountPath: /etc/kubernetes/static-pod-resources/configmaps/cloud-config
             - name: cloud-credentials
@@ -122,7 +124,17 @@ spec:
                 path: clouds.yaml
         - name: socket-dir
           emptyDir: {}
+        - name: cloud-credentials
+          secret:
+            secretName: manila-cloud-credentials
+            # TODO(stephenfin): We should also mount the clouds.yaml file
+            # here and start consuming that rather than converting it into
+            # the cloud.conf format
+            items:
+              - key: cacert
+                path: ca.crt
         - name: legacy-cacert
+          # TODO(stephenfin): Remove in 4.22
           configMap:
             name: cloud-provider-config
             items:

--- a/assets/overlays/openstack-manila/patches/controller_rename_config_map.yaml
+++ b/assets/overlays/openstack-manila/patches/controller_rename_config_map.yaml
@@ -2,10 +2,11 @@ spec:
   template:
     spec:
       volumes:
+        # TODO(stephenfin): Remove in 4.22
         - name: legacy-cacert
           configMap:
+            name: openstack-cloud-config
             items:
             - key: ca-bundle.pem
               path: ca-bundle.pem
-            name: openstack-cloud-config
             optional: true

--- a/assets/overlays/openstack-manila/patches/controller_rename_config_map.yaml
+++ b/assets/overlays/openstack-manila/patches/controller_rename_config_map.yaml
@@ -2,10 +2,10 @@ spec:
   template:
     spec:
       volumes:
-      - configMap:
-          items:
-          - key: ca-bundle.pem
-            path: ca-bundle.pem
-          name: openstack-cloud-config
-          optional: true
-        name: cacert
+        - name: legacy-cacert
+          configMap:
+            items:
+            - key: ca-bundle.pem
+              path: ca-bundle.pem
+            name: openstack-cloud-config
+            optional: true

--- a/assets/overlays/openstack-manila/patches/node_add_driver.yaml
+++ b/assets/overlays/openstack-manila/patches/node_add_driver.yaml
@@ -66,12 +66,13 @@ spec:
               mountPath: /var/lib/kubelet/plugins/manila.csi.openstack.org
             - name: fwd-plugin-dir
               mountPath: /var/lib/kubelet/plugins/csi-nfsplugin
-            - name: cacert
-              mountPath: /etc/kubernetes/static-pod-resources/configmaps/cloud-config
             - name: etc-selinux
               mountPath: /etc/selinux
             - name: sys-fs
               mountPath: /sys/fs
+            # credentials and configuration
+            - name: legacy-cacert
+              mountPath: /etc/kubernetes/static-pod-resources/configmaps/cloud-config
           ports:
             - name: healthz
               containerPort: 10305
@@ -109,17 +110,6 @@ spec:
           hostPath:
             path: /var/lib/kubelet/plugins/csi-nfsplugin
             type: DirectoryOrCreate
-        - name: cacert
-          # Extract ca-bundle.pem to /etc/kubernetes/static-pod-resources/configmaps/cloud-config if present.
-          # Let the pod start when the ConfigMap does not exist or the certificate
-          # is not preset there. The certificate file will be created once the
-          # ConfigMap is created / the cerificate is added to it.
-          configMap:
-            name: cloud-provider-config
-            items:
-            - key: ca-bundle.pem
-              path: ca-bundle.pem
-            optional: true
         - name: etc-selinux
           hostPath:
             path: /etc/selinux
@@ -128,3 +118,10 @@ spec:
           hostPath:
             path: /sys/fs
             type: Directory
+        - name: legacy-cacert
+          configMap:
+            name: cloud-provider-config
+            items:
+            - key: ca-bundle.pem
+              path: ca-bundle.pem
+            optional: true

--- a/assets/overlays/openstack-manila/patches/node_add_driver.yaml
+++ b/assets/overlays/openstack-manila/patches/node_add_driver.yaml
@@ -71,6 +71,8 @@ spec:
             - name: sys-fs
               mountPath: /sys/fs
             # credentials and configuration
+            - name: cloud-credentials
+              mountPath: /etc/openstack
             - name: legacy-cacert
               mountPath: /etc/kubernetes/static-pod-resources/configmaps/cloud-config
           ports:
@@ -118,6 +120,16 @@ spec:
           hostPath:
             path: /sys/fs
             type: Directory
+        - name: cloud-credentials
+          secret:
+            secretName: manila-cloud-credentials
+            # TODO(stephenfin): We should also mount the clouds.yaml file
+            # here and start consuming that rather than converting it into
+            # the cloud.conf format
+            items:
+              - key: cacert
+                path: ca.crt
+        # TODO(stephenfin): Remove in 4.22
         - name: legacy-cacert
           configMap:
             name: cloud-provider-config

--- a/pkg/openstack-cinder/config/configsync.go
+++ b/pkg/openstack-cinder/config/configsync.go
@@ -37,6 +37,13 @@ type configDestination struct {
 	kubeClient kubernetes.Interface
 }
 
+type caCertSource string
+
+const (
+	configCACertSource caCertSource = "config"
+	secretCACertSource caCertSource = "secret"
+)
+
 // This ConfigSyncController generates the configuration file needed for the Cinder CSI controller
 // and driver, including optional configuration from the user, and save it to a config map in a
 // well-known location that both services can use
@@ -159,27 +166,39 @@ func (c *ConfigSyncController) sync(ctx context.Context, syncCtx factory.SyncCon
 		enableTopology = strconv.FormatBool(enableTopologyFeature)
 	}
 
-	// ...and we watch the clusters-${NAME} namespace (on the control plane cluster)
-	configMapLister = c.controlPlaneInformers.InformersFor(c.controlPlaneNamespace).Core().V1().ConfigMaps().Lister()
+	secretLister := c.controlPlaneInformers.InformersFor(c.controlPlaneNamespace).Core().V1().Secrets().Lister()
 
-	// FIXME(stephenfin): We extract the CA cert from the cloud-provider-config because we know
-	// it will exist here in both a standalone (IPI) deployment and in both clusters in a
-	// Hypershift deployment. However, this is less than ideal: cloud providers and CSI drivers are
-	// now separate things and we should be able to get this information from the credentials
-	// secret, along with our clouds.yaml. Fixing this will requires changes to
-	// cloud-credential-operator and hypershift (because the latter doesn't currently use the
-	// former). Once we have that feature, we should rejig this.
-	cloudProviderConfig := "cloud-provider-config"
-	if c.isHypershift {
-		// unfortunately hypershift uses a different name
-		cloudProviderConfig = "openstack-cloud-config"
-	}
-	caCert, err := getCACert(configMapLister, c.controlPlaneNamespace, cloudProviderConfig)
+	var caCertSource caCertSource
+
+	hasCACert, err := hasCACert(secretLister, c.controlPlaneNamespace, "openstack-cloud-credentials")
 	if err != nil {
 		return err
 	}
 
-	generatedConfig, err := generateConfig(sourceConfig, caCert)
+	if hasCACert {
+		caCertSource = secretCACertSource
+	} else {
+		// TODO(stephenfin): Remove this fallback in 4.22. At that point, the
+		// cloud-credentials-operator will have ensured the root credential has
+		// been updated.
+		configMapLister = c.controlPlaneInformers.InformersFor(c.controlPlaneNamespace).Core().V1().ConfigMaps().Lister()
+		cloudProviderConfig := "cloud-provider-config"
+		if c.isHypershift {
+			// unfortunately hypershift uses a different name
+			cloudProviderConfig = "openstack-cloud-config"
+		}
+
+		hasCACert, err = getCACertLegacy(configMapLister, c.controlPlaneNamespace, cloudProviderConfig)
+		if err != nil {
+			return err
+		}
+
+		if hasCACert {
+			caCertSource = configCACertSource
+		}
+	}
+
+	generatedConfig, err := generateConfig(sourceConfig, caCertSource)
 	if err != nil {
 		return err
 	}
@@ -195,9 +214,6 @@ func (c *ConfigSyncController) sync(ctx context.Context, syncCtx factory.SyncCon
 				"enable_topology": enableTopology,
 			},
 		}
-		if caCert != nil {
-			targetConfig.Data["ca-bundle.pem"] = *caCert
-		}
 		_, _, err = resourceapply.ApplyConfigMap(ctx, configDestination.kubeClient.CoreV1(), c.eventRecorder, targetConfig)
 		if err != nil {
 			return err
@@ -206,18 +222,35 @@ func (c *ConfigSyncController) sync(ctx context.Context, syncCtx factory.SyncCon
 	return nil
 }
 
-// getCACert gets the (optional) embedded CA Cert provided in a config map by either the Installer
-// or the hypershift-operator so that we can inject it into our config files
-func getCACert(configMapLister corelisters.ConfigMapLister, ns, name string) (*string, error) {
+// hasCACert determines whether there is a CA Cert provided in the credentials
+// secret by either the cloud-credential-operator or hypershift-operator so
+// that we can inject it into our configuration
+func hasCACert(secretLister corelisters.SecretLister, ns, name string) (bool, error) {
+	cm, err := secretLister.Secrets(ns).Get(name)
+	if err != nil {
+		return false, err
+	}
+	caCert, ok := cm.Data["cacert"]
+	if !ok || len(caCert) == 0 {
+		return false, nil
+	}
+	return true, nil
+}
+
+// getCACertLegacy determines whether there is a CA Cert provided in the cloud
+// provider config map by either the Installer or the hypershift-operator so
+// that we can inject it into our config files. This is the legacy path for the
+// transition period as the CA cert is now provided in the credentials secret
+func getCACertLegacy(configMapLister corelisters.ConfigMapLister, ns, name string) (bool, error) {
 	cm, err := configMapLister.ConfigMaps(ns).Get(name)
 	if err != nil {
-		return nil, err
+		return false, err
 	}
 	caCert, ok := cm.Data["ca-bundle.pem"]
 	if !ok || len(caCert) == 0 {
-		return nil, nil
+		return false, nil
 	}
-	return &caCert, nil
+	return true, nil
 }
 
 // getSourceConfig extracts any source configuration present in any of the provided for the legacy,
@@ -258,7 +291,7 @@ func getSourceConfig(
 // '[BlockStorage]' section (and only that section) will be used in generation.
 func generateConfig(
 	sourceContent []byte,
-	caCert *string,
+	caCertSource caCertSource,
 ) (string, error) {
 	var cfg *ini.File
 
@@ -304,12 +337,18 @@ func generateConfig(
 		}
 	}
 
-	if caCert != nil {
+	if caCertSource != "" {
 		// We don't have a (non-deprecated) way to inject the CA cert itself into the config
 		// file, so instead we pass a file path. The path itself may look like a magic value but
 		// its where we have configured both the deployment (for controller) and daemonset (for
 		// driver) assets to mount the cert, if present.
-		_, err = global.NewKey("ca-file", "/etc/kubernetes/static-pod-resources/configmaps/cloud-config/ca-bundle.pem")
+		var path string
+		if caCertSource == secretCACertSource {
+			path = caFile
+		} else { // legacy path
+			path = legacyCAFile
+		}
+		_, err = global.NewKey("ca-file", path)
 		if err != nil {
 			return "", err
 		}

--- a/pkg/openstack-cinder/config/configsync.go
+++ b/pkg/openstack-cinder/config/configsync.go
@@ -295,7 +295,7 @@ func generateConfig(
 	}
 	for _, o := range []struct{ k, v string }{
 		{"use-clouds", "true"},
-		{"clouds-file", "/etc/kubernetes/secret/clouds.yaml"},
+		{"clouds-file", "/etc/openstack/clouds.yaml"},
 		{"cloud", "openstack"},
 	} {
 		_, err = global.NewKey(o.k, o.v)

--- a/pkg/openstack-cinder/config/configsync_test.go
+++ b/pkg/openstack-cinder/config/configsync_test.go
@@ -25,14 +25,14 @@ func TestGenerateConfigMap(t *testing.T) {
 			source: nil,
 			expected: `[Global]
 use-clouds  = true
-clouds-file = /etc/kubernetes/secret/clouds.yaml
+clouds-file = /etc/openstack/clouds.yaml
 cloud       = openstack`,
 		}, {
 			name:   "Empty config",
 			source: []byte(""),
 			expected: `[Global]
 use-clouds  = true
-clouds-file = /etc/kubernetes/secret/clouds.yaml
+clouds-file = /etc/openstack/clouds.yaml
 cloud       = openstack`,
 		}, {
 			name: "Minimal config",
@@ -43,7 +43,7 @@ ignore-volume-az = True
 
 [Global]
 use-clouds  = true
-clouds-file = /etc/kubernetes/secret/clouds.yaml
+clouds-file = /etc/openstack/clouds.yaml
 cloud       = openstack`,
 		}, {
 			name:   "With CA cert",
@@ -51,7 +51,7 @@ cloud       = openstack`,
 			caCert: ptr.To("not-so-secret CA data goes here"),
 			expected: `[Global]
 use-clouds  = true
-clouds-file = /etc/kubernetes/secret/clouds.yaml
+clouds-file = /etc/openstack/clouds.yaml
 cloud       = openstack
 ca-file     = /etc/kubernetes/static-pod-resources/configmaps/cloud-config/ca-bundle.pem`,
 		}, {
@@ -61,7 +61,7 @@ ca-file     = /etc/kubernetes/static-pod-resources/configmaps/cloud-config/ca-bu
 trust-device-path = /dev/sdb1`),
 			expected: `[Global]
 use-clouds  = true
-clouds-file = /etc/kubernetes/secret/clouds.yaml
+clouds-file = /etc/openstack/clouds.yaml
 cloud       = openstack`,
 		},
 	}

--- a/pkg/openstack-cinder/config/const.go
+++ b/pkg/openstack-cinder/config/const.go
@@ -1,0 +1,5 @@
+package config
+
+// caFile/legacyCAFile is based on the path defined in the assets
+const caFile = "/etc/openstack/ca.crt"
+const legacyCAFile = "/etc/kubernetes/static-pod-resources/configmaps/cloud-config/ca-bundle.pem"

--- a/pkg/openstack-manila/client/openstack.go
+++ b/pkg/openstack-manila/client/openstack.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
+	"errors"
 	"fmt"
 	"net/http"
 	"os"
@@ -58,7 +59,7 @@ func (o *openStackClient) GetShareTypes() ([]sharetypes.ShareType, error) {
 	provider.UserAgent = ua
 
 	cert, err := getCloudProviderCert()
-	if err != nil && !os.IsNotExist(err) {
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
 		return nil, fmt.Errorf("failed to get cloud provider CA certificate: %w", err)
 	}
 
@@ -120,5 +121,11 @@ func getCloudFromFile(filename string) (*clientconfig.Cloud, error) {
 }
 
 func getCloudProviderCert() ([]byte, error) {
-	return os.ReadFile(util.CertFile)
+	data, err := os.ReadFile(util.CertFile)
+	if err == nil || !errors.Is(err, os.ErrNotExist) {
+		return data, err
+	}
+
+	// legacy path; remove in 5.1
+	return os.ReadFile(util.LegacyCertFile)
 }

--- a/pkg/openstack-manila/util/const.go
+++ b/pkg/openstack-manila/util/const.go
@@ -11,7 +11,8 @@ const (
 
 	// OpenStack config file name (as present in the operator Deployment)
 	CloudConfigFilename = "/etc/openstack/clouds.yaml"
-	CertFile            = "/etc/openstack-ca/ca-bundle.pem"
+	CertFile            = "/etc/openstack/ca.crt"
+	LegacyCertFile      = "/etc/openstack-ca/ca-bundle.pem"
 
 	// Name of cloud in secret provided by cloud-credentials-operator
 	CloudName = "openstack"


### PR DESCRIPTION
In openshift/cloud-credential-operator/pull/780, we have added the ability for `cloud-credential-operator` to consume a CA cert from the root credentials secret and to include in the credentials secrets it provisions.
In openshift/installer/pull/9194, we have modified the Installer to start setting this field where necessary.
In openshift/cluster-storage-operator/pull/557, we modified cluster-storage-operator to pass this CA cert through to the `csi-operator` when present.

Adapt the assets and controllers for both the openstack-cinder and openstack-manila CSI drivers to start consuming this field, where present. We maintain fallbacks for the previous locations of the cert for now, but these can be removed in the next release.

This needs to wait for the CCO change to be approved before we merge this. It also needs the CSO change to merge first.

Dependencies:

- [ ] https://github.com/openshift/cluster-storage-operator/pull/557

/hold
