### PR TITLE
STOR-2263: correct smb csi driver test manifest

### DIFF
--- a/test/e2e/samba/manifest.yaml
+++ b/test/e2e/samba/manifest.yaml
@@ -14,7 +14,7 @@ DriverInfo:
     exec: true
     volumeLimits: false
     controllerExpansion: true
-    nodeExpansion: true
+    nodeExpansion: false
     snapshotDataSource: false
     RWX: true
     pvcDataSource: true


### PR DESCRIPTION
- Upstream fix -> https://github.com/kubernetes-csi/csi-driver-smb/pull/931
- Correct the smb csi driver test manifest(actually the driver does not support `nodeExpansion `), follow up of https://github.com/openshift/csi-operator/pull/358#discussion_r1961987181 .