### PR TITLE
OCPBUGS-50493: Use 127.0.0.1 for healtz http-endpoints

### DIFF
--- a/assets/common/sidecars/host_network_livenessprobe.yaml
+++ b/assets/common/sidecars/host_network_livenessprobe.yaml
@@ -1,0 +1,22 @@
+# This sidecar is injected to DaemonSet
+spec:
+  template:
+    spec:
+      containers:
+        - name: csi-liveness-probe
+          image: ${LIVENESS_PROBE_IMAGE}
+          imagePullPolicy: IfNotPresent
+          terminationMessagePolicy: FallbackToLogsOnError
+          args:
+            - --csi-address=/csi/csi.sock
+            - --http-endpoint=127.0.0.1:${LIVENESS_PROBE_PORT}
+            - --v=${LOG_LEVEL}
+          # Empty env. instead of nil for json patch to append new env. vars there
+          env: []
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /csi
+          resources:
+            requests:
+              memory: 50Mi
+              cpu: 10m

--- a/assets/common/sidecars/node_driver_registrar.yaml
+++ b/assets/common/sidecars/node_driver_registrar.yaml
@@ -12,7 +12,7 @@ spec:
           args:
             - --csi-address=/csi/csi.sock
             - --kubelet-registration-path=/var/lib/kubelet/plugins/${DRIVER_NAME}/csi.sock
-            - --http-endpoint=:${NODE_DRIVER_REGISTRAR_HEALTH_PORT}
+            - --http-endpoint=127.0.0.1:${NODE_DRIVER_REGISTRAR_HEALTH_PORT}
             - --v=${LOG_LEVEL}
           # Empty env. instead of nil for json patch to append new env. vars there
           env: []
@@ -31,6 +31,7 @@ spec:
               protocol: TCP
           livenessProbe:
             httpGet:
+              host: 127.0.0.1
               path: /healthz
               port: rhealthz
             initialDelaySeconds: 10

--- a/assets/common/sidecars/pod_network_livenessprobe.yaml
+++ b/assets/common/sidecars/pod_network_livenessprobe.yaml
@@ -1,4 +1,4 @@
-# This sidecar is injected both to Deployment and DaemonSet
+# This sidecar is injected to Deployment
 spec:
   template:
     spec:

--- a/assets/overlays/aws-ebs/generated/hypershift/controller.yaml
+++ b/assets/overlays/aws-ebs/generated/hypershift/controller.yaml
@@ -19,9 +19,9 @@
 # snapshotter.yaml: Added arguments [--extra-create-metadata --kube-api-qps=20 --kube-api-burst=100 --worker-threads=100]
 # snapshotter.yaml: Applied JSON patch common/hypershift/sidecar_add_kubeconfig.yaml.patch
 # Applied strategic merge patch snapshotter.yaml
-# livenessprobe.yaml: Loaded from common/sidecars/livenessprobe.yaml
-# livenessprobe.yaml: Added arguments [--probe-timeout=3s]
-# Applied strategic merge patch livenessprobe.yaml
+# pod_network_livenessprobe.yaml: Loaded from common/sidecars/pod_network_livenessprobe.yaml
+# pod_network_livenessprobe.yaml: Added arguments [--probe-timeout=3s]
+# Applied strategic merge patch pod_network_livenessprobe.yaml
 # Applied strategic merge patch common/hypershift/controller_add_affinity_tolerations.yaml
 # Applied strategic merge patch overlays/aws-ebs/patches/controller_add_hypershift_controller_minter.yaml
 #

--- a/assets/overlays/aws-ebs/generated/hypershift/node.yaml
+++ b/assets/overlays/aws-ebs/generated/hypershift/node.yaml
@@ -4,9 +4,9 @@
 # Applied strategic merge patch overlays/aws-ebs/patches/node_add_driver.yaml
 # node_driver_registrar.yaml: Loaded from common/sidecars/node_driver_registrar.yaml
 # Applied strategic merge patch node_driver_registrar.yaml
-# livenessprobe.yaml: Loaded from common/sidecars/livenessprobe.yaml
-# livenessprobe.yaml: Added arguments [--probe-timeout=3s]
-# Applied strategic merge patch livenessprobe.yaml
+# host_network_livenessprobe.yaml: Loaded from common/sidecars/host_network_livenessprobe.yaml
+# host_network_livenessprobe.yaml: Added arguments [--probe-timeout=3s]
+# Applied strategic merge patch host_network_livenessprobe.yaml
 #
 #
 
@@ -45,6 +45,7 @@ spec:
         livenessProbe:
           failureThreshold: 5
           httpGet:
+            host: 127.0.0.1
             path: /healthz
             port: healthz
           initialDelaySeconds: 10
@@ -77,7 +78,7 @@ spec:
       - args:
         - --csi-address=/csi/csi.sock
         - --kubelet-registration-path=/var/lib/kubelet/plugins/ebs.csi.aws.com/csi.sock
-        - --http-endpoint=:10309
+        - --http-endpoint=127.0.0.1:10309
         - --v=${LOG_LEVEL}
         env: []
         image: ${NODE_DRIVER_REGISTRAR_IMAGE}
@@ -92,6 +93,7 @@ spec:
         livenessProbe:
           failureThreshold: 5
           httpGet:
+            host: 127.0.0.1
             path: /healthz
             port: rhealthz
           initialDelaySeconds: 10
@@ -116,7 +118,7 @@ spec:
           name: registration-dir
       - args:
         - --csi-address=/csi/csi.sock
-        - --health-port=10300
+        - --http-endpoint=127.0.0.1:10300
         - --v=${LOG_LEVEL}
         - --probe-timeout=3s
         env: []

--- a/assets/overlays/aws-ebs/generated/standalone/controller.yaml
+++ b/assets/overlays/aws-ebs/generated/standalone/controller.yaml
@@ -15,9 +15,9 @@
 # snapshotter.yaml: Loaded from common/sidecars/snapshotter.yaml
 # snapshotter.yaml: Added arguments [--extra-create-metadata --kube-api-qps=20 --kube-api-burst=100 --worker-threads=100]
 # Applied strategic merge patch snapshotter.yaml
-# livenessprobe.yaml: Loaded from common/sidecars/livenessprobe.yaml
-# livenessprobe.yaml: Added arguments [--probe-timeout=3s]
-# Applied strategic merge patch livenessprobe.yaml
+# pod_network_livenessprobe.yaml: Loaded from common/sidecars/pod_network_livenessprobe.yaml
+# pod_network_livenessprobe.yaml: Added arguments [--probe-timeout=3s]
+# Applied strategic merge patch pod_network_livenessprobe.yaml
 # Applied strategic merge patch common/standalone/controller_add_affinity.yaml
 #
 #

--- a/assets/overlays/aws-ebs/generated/standalone/node.yaml
+++ b/assets/overlays/aws-ebs/generated/standalone/node.yaml
@@ -4,9 +4,9 @@
 # Applied strategic merge patch overlays/aws-ebs/patches/node_add_driver.yaml
 # node_driver_registrar.yaml: Loaded from common/sidecars/node_driver_registrar.yaml
 # Applied strategic merge patch node_driver_registrar.yaml
-# livenessprobe.yaml: Loaded from common/sidecars/livenessprobe.yaml
-# livenessprobe.yaml: Added arguments [--probe-timeout=3s]
-# Applied strategic merge patch livenessprobe.yaml
+# host_network_livenessprobe.yaml: Loaded from common/sidecars/host_network_livenessprobe.yaml
+# host_network_livenessprobe.yaml: Added arguments [--probe-timeout=3s]
+# Applied strategic merge patch host_network_livenessprobe.yaml
 #
 #
 
@@ -45,6 +45,7 @@ spec:
         livenessProbe:
           failureThreshold: 5
           httpGet:
+            host: 127.0.0.1
             path: /healthz
             port: healthz
           initialDelaySeconds: 10
@@ -77,7 +78,7 @@ spec:
       - args:
         - --csi-address=/csi/csi.sock
         - --kubelet-registration-path=/var/lib/kubelet/plugins/ebs.csi.aws.com/csi.sock
-        - --http-endpoint=:10309
+        - --http-endpoint=127.0.0.1:10309
         - --v=${LOG_LEVEL}
         env: []
         image: ${NODE_DRIVER_REGISTRAR_IMAGE}
@@ -92,6 +93,7 @@ spec:
         livenessProbe:
           failureThreshold: 5
           httpGet:
+            host: 127.0.0.1
             path: /healthz
             port: rhealthz
           initialDelaySeconds: 10
@@ -116,7 +118,7 @@ spec:
           name: registration-dir
       - args:
         - --csi-address=/csi/csi.sock
-        - --health-port=10300
+        - --http-endpoint=127.0.0.1:10300
         - --v=${LOG_LEVEL}
         - --probe-timeout=3s
         env: []

--- a/assets/overlays/aws-ebs/patches/node_add_driver.yaml
+++ b/assets/overlays/aws-ebs/patches/node_add_driver.yaml
@@ -33,6 +33,7 @@ spec:
               protocol: TCP
           livenessProbe:
             httpGet:
+              host: 127.0.0.1
               path: /healthz
               port: healthz
             initialDelaySeconds: 10

--- a/assets/overlays/aws-efs/generated/standalone/controller.yaml
+++ b/assets/overlays/aws-efs/generated/standalone/controller.yaml
@@ -5,9 +5,9 @@
 # provisioner.yaml: Loaded from common/sidecars/provisioner.yaml
 # provisioner.yaml: Added arguments [--feature-gates=Topology=true --extra-create-metadata=true --timeout=5m --worker-threads=1]
 # Applied strategic merge patch provisioner.yaml
-# livenessprobe.yaml: Loaded from common/sidecars/livenessprobe.yaml
-# livenessprobe.yaml: Added arguments [--probe-timeout=3s]
-# Applied strategic merge patch livenessprobe.yaml
+# pod_network_livenessprobe.yaml: Loaded from common/sidecars/pod_network_livenessprobe.yaml
+# pod_network_livenessprobe.yaml: Added arguments [--probe-timeout=3s]
+# Applied strategic merge patch pod_network_livenessprobe.yaml
 #
 #
 

--- a/assets/overlays/aws-efs/generated/standalone/node.yaml
+++ b/assets/overlays/aws-efs/generated/standalone/node.yaml
@@ -4,9 +4,9 @@
 # Applied strategic merge patch overlays/aws-efs/patches/node_add_driver.yaml
 # node_driver_registrar.yaml: Loaded from common/sidecars/node_driver_registrar.yaml
 # Applied strategic merge patch node_driver_registrar.yaml
-# livenessprobe.yaml: Loaded from common/sidecars/livenessprobe.yaml
-# livenessprobe.yaml: Added arguments [--probe-timeout=3s]
-# Applied strategic merge patch livenessprobe.yaml
+# host_network_livenessprobe.yaml: Loaded from common/sidecars/host_network_livenessprobe.yaml
+# host_network_livenessprobe.yaml: Added arguments [--probe-timeout=3s]
+# Applied strategic merge patch host_network_livenessprobe.yaml
 #
 #
 
@@ -42,6 +42,7 @@ spec:
         livenessProbe:
           failureThreshold: 5
           httpGet:
+            host: 127.0.0.1
             path: /healthz
             port: healthz
           initialDelaySeconds: 10
@@ -80,7 +81,7 @@ spec:
       - args:
         - --csi-address=/csi/csi.sock
         - --kubelet-registration-path=/var/lib/kubelet/plugins/efs.csi.aws.com/csi.sock
-        - --http-endpoint=:10305
+        - --http-endpoint=127.0.0.1:10305
         - --v=${LOG_LEVEL}
         env: []
         image: ${NODE_DRIVER_REGISTRAR_IMAGE}
@@ -95,6 +96,7 @@ spec:
         livenessProbe:
           failureThreshold: 5
           httpGet:
+            host: 127.0.0.1
             path: /healthz
             port: rhealthz
           initialDelaySeconds: 10
@@ -119,7 +121,7 @@ spec:
           name: registration-dir
       - args:
         - --csi-address=/csi/csi.sock
-        - --health-port=10303
+        - --http-endpoint=127.0.0.1:10303
         - --v=${LOG_LEVEL}
         - --probe-timeout=3s
         env: []

--- a/assets/overlays/aws-efs/patches/node_add_driver.yaml
+++ b/assets/overlays/aws-efs/patches/node_add_driver.yaml
@@ -65,6 +65,7 @@ spec:
               protocol: TCP
           livenessProbe:
             httpGet:
+              host: 127.0.0.1
               path: /healthz
               port: healthz
             initialDelaySeconds: 10

--- a/assets/overlays/azure-disk/generated/hypershift/controller.yaml
+++ b/assets/overlays/azure-disk/generated/hypershift/controller.yaml
@@ -19,9 +19,9 @@
 # snapshotter.yaml: Added arguments [--timeout=600s]
 # snapshotter.yaml: Applied JSON patch common/hypershift/sidecar_add_kubeconfig.yaml.patch
 # Applied strategic merge patch snapshotter.yaml
-# livenessprobe.yaml: Loaded from common/sidecars/livenessprobe.yaml
-# livenessprobe.yaml: Added arguments [--probe-timeout=3s]
-# Applied strategic merge patch livenessprobe.yaml
+# pod_network_livenessprobe.yaml: Loaded from common/sidecars/pod_network_livenessprobe.yaml
+# pod_network_livenessprobe.yaml: Added arguments [--probe-timeout=3s]
+# Applied strategic merge patch pod_network_livenessprobe.yaml
 # Applied strategic merge patch common/hypershift/controller_add_affinity_tolerations.yaml
 # Applied strategic merge patch overlays/azure-disk/patches/controller_add_hypershift_controller.yaml
 #

--- a/assets/overlays/azure-disk/generated/hypershift/node.yaml
+++ b/assets/overlays/azure-disk/generated/hypershift/node.yaml
@@ -5,9 +5,9 @@
 # Applied strategic merge patch common/sidecars/node_driver_kube_rbac_proxy.yaml
 # node_driver_registrar.yaml: Loaded from common/sidecars/node_driver_registrar.yaml
 # Applied strategic merge patch node_driver_registrar.yaml
-# livenessprobe.yaml: Loaded from common/sidecars/livenessprobe.yaml
-# livenessprobe.yaml: Added arguments [--probe-timeout=3s]
-# Applied strategic merge patch livenessprobe.yaml
+# host_network_livenessprobe.yaml: Loaded from common/sidecars/host_network_livenessprobe.yaml
+# host_network_livenessprobe.yaml: Added arguments [--probe-timeout=3s]
+# Applied strategic merge patch host_network_livenessprobe.yaml
 #
 #
 
@@ -57,6 +57,7 @@ spec:
         livenessProbe:
           failureThreshold: 5
           httpGet:
+            host: 127.0.0.1
             path: /healthz
             port: healthz
           initialDelaySeconds: 10
@@ -119,7 +120,7 @@ spec:
       - args:
         - --csi-address=/csi/csi.sock
         - --kubelet-registration-path=/var/lib/kubelet/plugins/disk.csi.azure.com/csi.sock
-        - --http-endpoint=:10304
+        - --http-endpoint=127.0.0.1:10304
         - --v=${LOG_LEVEL}
         env: []
         image: ${NODE_DRIVER_REGISTRAR_IMAGE}
@@ -134,6 +135,7 @@ spec:
         livenessProbe:
           failureThreshold: 5
           httpGet:
+            host: 127.0.0.1
             path: /healthz
             port: rhealthz
           initialDelaySeconds: 10
@@ -158,7 +160,7 @@ spec:
           name: registration-dir
       - args:
         - --csi-address=/csi/csi.sock
-        - --health-port=10300
+        - --http-endpoint=127.0.0.1:10300
         - --v=${LOG_LEVEL}
         - --probe-timeout=3s
         env: []

--- a/assets/overlays/azure-disk/generated/standalone/controller.yaml
+++ b/assets/overlays/azure-disk/generated/standalone/controller.yaml
@@ -15,9 +15,9 @@
 # snapshotter.yaml: Loaded from common/sidecars/snapshotter.yaml
 # snapshotter.yaml: Added arguments [--timeout=600s]
 # Applied strategic merge patch snapshotter.yaml
-# livenessprobe.yaml: Loaded from common/sidecars/livenessprobe.yaml
-# livenessprobe.yaml: Added arguments [--probe-timeout=3s]
-# Applied strategic merge patch livenessprobe.yaml
+# pod_network_livenessprobe.yaml: Loaded from common/sidecars/pod_network_livenessprobe.yaml
+# pod_network_livenessprobe.yaml: Added arguments [--probe-timeout=3s]
+# Applied strategic merge patch pod_network_livenessprobe.yaml
 # Applied strategic merge patch common/standalone/controller_add_affinity.yaml
 # Applied strategic merge patch overlays/azure-disk/patches/controller_add_standalone_injector.yaml
 #

--- a/assets/overlays/azure-disk/generated/standalone/node.yaml
+++ b/assets/overlays/azure-disk/generated/standalone/node.yaml
@@ -5,9 +5,9 @@
 # Applied strategic merge patch common/sidecars/node_driver_kube_rbac_proxy.yaml
 # node_driver_registrar.yaml: Loaded from common/sidecars/node_driver_registrar.yaml
 # Applied strategic merge patch node_driver_registrar.yaml
-# livenessprobe.yaml: Loaded from common/sidecars/livenessprobe.yaml
-# livenessprobe.yaml: Added arguments [--probe-timeout=3s]
-# Applied strategic merge patch livenessprobe.yaml
+# host_network_livenessprobe.yaml: Loaded from common/sidecars/host_network_livenessprobe.yaml
+# host_network_livenessprobe.yaml: Added arguments [--probe-timeout=3s]
+# Applied strategic merge patch host_network_livenessprobe.yaml
 #
 #
 
@@ -57,6 +57,7 @@ spec:
         livenessProbe:
           failureThreshold: 5
           httpGet:
+            host: 127.0.0.1
             path: /healthz
             port: healthz
           initialDelaySeconds: 10
@@ -119,7 +120,7 @@ spec:
       - args:
         - --csi-address=/csi/csi.sock
         - --kubelet-registration-path=/var/lib/kubelet/plugins/disk.csi.azure.com/csi.sock
-        - --http-endpoint=:10304
+        - --http-endpoint=127.0.0.1:10304
         - --v=${LOG_LEVEL}
         env: []
         image: ${NODE_DRIVER_REGISTRAR_IMAGE}
@@ -134,6 +135,7 @@ spec:
         livenessProbe:
           failureThreshold: 5
           httpGet:
+            host: 127.0.0.1
             path: /healthz
             port: rhealthz
           initialDelaySeconds: 10
@@ -158,7 +160,7 @@ spec:
           name: registration-dir
       - args:
         - --csi-address=/csi/csi.sock
-        - --health-port=10300
+        - --http-endpoint=127.0.0.1:10300
         - --v=${LOG_LEVEL}
         - --probe-timeout=3s
         env: []

--- a/assets/overlays/azure-disk/patches/node_add_driver.yaml
+++ b/assets/overlays/azure-disk/patches/node_add_driver.yaml
@@ -48,6 +48,7 @@ spec:
               protocol: TCP
           livenessProbe:
             httpGet:
+              host: 127.0.0.1
               path: /healthz
               port: healthz
             initialDelaySeconds: 10

--- a/assets/overlays/azure-file/generated/hypershift/controller.yaml
+++ b/assets/overlays/azure-file/generated/hypershift/controller.yaml
@@ -19,9 +19,9 @@
 # snapshotter.yaml: Added arguments [--timeout=600s]
 # snapshotter.yaml: Applied JSON patch common/hypershift/sidecar_add_kubeconfig.yaml.patch
 # Applied strategic merge patch snapshotter.yaml
-# livenessprobe.yaml: Loaded from common/sidecars/livenessprobe.yaml
-# livenessprobe.yaml: Added arguments [--probe-timeout=3s]
-# Applied strategic merge patch livenessprobe.yaml
+# pod_network_livenessprobe.yaml: Loaded from common/sidecars/pod_network_livenessprobe.yaml
+# pod_network_livenessprobe.yaml: Added arguments [--probe-timeout=3s]
+# Applied strategic merge patch pod_network_livenessprobe.yaml
 # Applied strategic merge patch common/hypershift/controller_add_affinity_tolerations.yaml
 # Applied strategic merge patch overlays/azure-file/patches/controller_add_hypershift_controller.yaml
 # Applied JSON patch overlays/azure-file/patches/controller_add_driver_kubeconfig_hypershift.yaml.patch

--- a/assets/overlays/azure-file/generated/hypershift/node.yaml
+++ b/assets/overlays/azure-file/generated/hypershift/node.yaml
@@ -4,9 +4,9 @@
 # Applied strategic merge patch overlays/azure-file/patches/node_add_driver.yaml
 # node_driver_registrar.yaml: Loaded from common/sidecars/node_driver_registrar.yaml
 # Applied strategic merge patch node_driver_registrar.yaml
-# livenessprobe.yaml: Loaded from common/sidecars/livenessprobe.yaml
-# livenessprobe.yaml: Added arguments [--probe-timeout=3s]
-# Applied strategic merge patch livenessprobe.yaml
+# host_network_livenessprobe.yaml: Loaded from common/sidecars/host_network_livenessprobe.yaml
+# host_network_livenessprobe.yaml: Added arguments [--probe-timeout=3s]
+# Applied strategic merge patch host_network_livenessprobe.yaml
 #
 #
 
@@ -55,6 +55,7 @@ spec:
         livenessProbe:
           failureThreshold: 5
           httpGet:
+            host: 127.0.0.1
             path: /healthz
             port: healthz
           initialDelaySeconds: 10
@@ -97,7 +98,7 @@ spec:
       - args:
         - --csi-address=/csi/csi.sock
         - --kubelet-registration-path=/var/lib/kubelet/plugins/file.csi.azure.com/csi.sock
-        - --http-endpoint=:10305
+        - --http-endpoint=127.0.0.1:10305
         - --v=${LOG_LEVEL}
         env: []
         image: ${NODE_DRIVER_REGISTRAR_IMAGE}
@@ -112,6 +113,7 @@ spec:
         livenessProbe:
           failureThreshold: 5
           httpGet:
+            host: 127.0.0.1
             path: /healthz
             port: rhealthz
           initialDelaySeconds: 10
@@ -136,7 +138,7 @@ spec:
           name: registration-dir
       - args:
         - --csi-address=/csi/csi.sock
-        - --health-port=10302
+        - --http-endpoint=127.0.0.1:10302
         - --v=${LOG_LEVEL}
         - --probe-timeout=3s
         env: []

--- a/assets/overlays/azure-file/generated/standalone/controller.yaml
+++ b/assets/overlays/azure-file/generated/standalone/controller.yaml
@@ -15,9 +15,9 @@
 # snapshotter.yaml: Loaded from common/sidecars/snapshotter.yaml
 # snapshotter.yaml: Added arguments [--timeout=600s]
 # Applied strategic merge patch snapshotter.yaml
-# livenessprobe.yaml: Loaded from common/sidecars/livenessprobe.yaml
-# livenessprobe.yaml: Added arguments [--probe-timeout=3s]
-# Applied strategic merge patch livenessprobe.yaml
+# pod_network_livenessprobe.yaml: Loaded from common/sidecars/pod_network_livenessprobe.yaml
+# pod_network_livenessprobe.yaml: Added arguments [--probe-timeout=3s]
+# Applied strategic merge patch pod_network_livenessprobe.yaml
 # Applied strategic merge patch common/standalone/controller_add_affinity.yaml
 # Applied strategic merge patch overlays/azure-file/patches/controller_add_standalone_injector.yaml
 #

--- a/assets/overlays/azure-file/generated/standalone/node.yaml
+++ b/assets/overlays/azure-file/generated/standalone/node.yaml
@@ -4,9 +4,9 @@
 # Applied strategic merge patch overlays/azure-file/patches/node_add_driver.yaml
 # node_driver_registrar.yaml: Loaded from common/sidecars/node_driver_registrar.yaml
 # Applied strategic merge patch node_driver_registrar.yaml
-# livenessprobe.yaml: Loaded from common/sidecars/livenessprobe.yaml
-# livenessprobe.yaml: Added arguments [--probe-timeout=3s]
-# Applied strategic merge patch livenessprobe.yaml
+# host_network_livenessprobe.yaml: Loaded from common/sidecars/host_network_livenessprobe.yaml
+# host_network_livenessprobe.yaml: Added arguments [--probe-timeout=3s]
+# Applied strategic merge patch host_network_livenessprobe.yaml
 #
 #
 
@@ -55,6 +55,7 @@ spec:
         livenessProbe:
           failureThreshold: 5
           httpGet:
+            host: 127.0.0.1
             path: /healthz
             port: healthz
           initialDelaySeconds: 10
@@ -97,7 +98,7 @@ spec:
       - args:
         - --csi-address=/csi/csi.sock
         - --kubelet-registration-path=/var/lib/kubelet/plugins/file.csi.azure.com/csi.sock
-        - --http-endpoint=:10305
+        - --http-endpoint=127.0.0.1:10305
         - --v=${LOG_LEVEL}
         env: []
         image: ${NODE_DRIVER_REGISTRAR_IMAGE}
@@ -112,6 +113,7 @@ spec:
         livenessProbe:
           failureThreshold: 5
           httpGet:
+            host: 127.0.0.1
             path: /healthz
             port: rhealthz
           initialDelaySeconds: 10
@@ -136,7 +138,7 @@ spec:
           name: registration-dir
       - args:
         - --csi-address=/csi/csi.sock
-        - --health-port=10302
+        - --http-endpoint=127.0.0.1:10302
         - --v=${LOG_LEVEL}
         - --probe-timeout=3s
         env: []

--- a/assets/overlays/azure-file/patches/node_add_driver.yaml
+++ b/assets/overlays/azure-file/patches/node_add_driver.yaml
@@ -45,6 +45,7 @@ spec:
               protocol: TCP
           livenessProbe:
             httpGet:
+              host: 127.0.0.1
               path: /healthz
               port: healthz
             initialDelaySeconds: 10

--- a/assets/overlays/openstack-cinder/generated/hypershift/controller.yaml
+++ b/assets/overlays/openstack-cinder/generated/hypershift/controller.yaml
@@ -17,9 +17,9 @@
 # snapshotter.yaml: Loaded from common/sidecars/snapshotter.yaml
 # snapshotter.yaml: Applied JSON patch common/hypershift/sidecar_add_kubeconfig.yaml.patch
 # Applied strategic merge patch snapshotter.yaml
-# livenessprobe.yaml: Loaded from common/sidecars/livenessprobe.yaml
-# livenessprobe.yaml: Added arguments [--probe-timeout=10s]
-# Applied strategic merge patch livenessprobe.yaml
+# pod_network_livenessprobe.yaml: Loaded from common/sidecars/pod_network_livenessprobe.yaml
+# pod_network_livenessprobe.yaml: Added arguments [--probe-timeout=10s]
+# Applied strategic merge patch pod_network_livenessprobe.yaml
 # Applied strategic merge patch common/hypershift/controller_add_affinity_tolerations.yaml
 # Applied strategic merge patch overlays/openstack-cinder/patches/controller_add_hypershift_volumes.yaml
 #

--- a/assets/overlays/openstack-cinder/generated/hypershift/node.yaml
+++ b/assets/overlays/openstack-cinder/generated/hypershift/node.yaml
@@ -2,9 +2,9 @@
 #
 # Loaded from base/node.yaml
 # Applied strategic merge patch overlays/openstack-cinder/patches/node_add_driver.yaml
-# livenessprobe.yaml: Loaded from common/sidecars/livenessprobe.yaml
-# livenessprobe.yaml: Added arguments [--probe-timeout=10s]
-# Applied strategic merge patch livenessprobe.yaml
+# host_network_livenessprobe.yaml: Loaded from common/sidecars/host_network_livenessprobe.yaml
+# host_network_livenessprobe.yaml: Added arguments [--probe-timeout=10s]
+# Applied strategic merge patch host_network_livenessprobe.yaml
 # node_driver_registrar.yaml: Loaded from common/sidecars/node_driver_registrar.yaml
 # Applied strategic merge patch node_driver_registrar.yaml
 #
@@ -49,6 +49,7 @@ spec:
         livenessProbe:
           failureThreshold: 5
           httpGet:
+            host: 127.0.0.1
             path: /healthz
             port: healthz
           initialDelaySeconds: 10
@@ -93,7 +94,7 @@ spec:
           readOnly: true
       - args:
         - --csi-address=/csi/csi.sock
-        - --health-port=10300
+        - --http-endpoint=127.0.0.1:10300
         - --v=${LOG_LEVEL}
         - --probe-timeout=10s
         env: []
@@ -111,7 +112,7 @@ spec:
       - args:
         - --csi-address=/csi/csi.sock
         - --kubelet-registration-path=/var/lib/kubelet/plugins/cinder.csi.openstack.org/csi.sock
-        - --http-endpoint=:10304
+        - --http-endpoint=127.0.0.1:10304
         - --v=${LOG_LEVEL}
         env: []
         image: ${NODE_DRIVER_REGISTRAR_IMAGE}
@@ -126,6 +127,7 @@ spec:
         livenessProbe:
           failureThreshold: 5
           httpGet:
+            host: 127.0.0.1
             path: /healthz
             port: rhealthz
           initialDelaySeconds: 10

--- a/assets/overlays/openstack-cinder/generated/standalone/controller.yaml
+++ b/assets/overlays/openstack-cinder/generated/standalone/controller.yaml
@@ -13,9 +13,9 @@
 # Applied strategic merge patch resizer.yaml
 # snapshotter.yaml: Loaded from common/sidecars/snapshotter.yaml
 # Applied strategic merge patch snapshotter.yaml
-# livenessprobe.yaml: Loaded from common/sidecars/livenessprobe.yaml
-# livenessprobe.yaml: Added arguments [--probe-timeout=10s]
-# Applied strategic merge patch livenessprobe.yaml
+# pod_network_livenessprobe.yaml: Loaded from common/sidecars/pod_network_livenessprobe.yaml
+# pod_network_livenessprobe.yaml: Added arguments [--probe-timeout=10s]
+# Applied strategic merge patch pod_network_livenessprobe.yaml
 # Applied strategic merge patch common/standalone/controller_add_affinity.yaml
 #
 #

--- a/assets/overlays/openstack-cinder/generated/standalone/node.yaml
+++ b/assets/overlays/openstack-cinder/generated/standalone/node.yaml
@@ -2,9 +2,9 @@
 #
 # Loaded from base/node.yaml
 # Applied strategic merge patch overlays/openstack-cinder/patches/node_add_driver.yaml
-# livenessprobe.yaml: Loaded from common/sidecars/livenessprobe.yaml
-# livenessprobe.yaml: Added arguments [--probe-timeout=10s]
-# Applied strategic merge patch livenessprobe.yaml
+# host_network_livenessprobe.yaml: Loaded from common/sidecars/host_network_livenessprobe.yaml
+# host_network_livenessprobe.yaml: Added arguments [--probe-timeout=10s]
+# Applied strategic merge patch host_network_livenessprobe.yaml
 # node_driver_registrar.yaml: Loaded from common/sidecars/node_driver_registrar.yaml
 # Applied strategic merge patch node_driver_registrar.yaml
 #
@@ -49,6 +49,7 @@ spec:
         livenessProbe:
           failureThreshold: 5
           httpGet:
+            host: 127.0.0.1
             path: /healthz
             port: healthz
           initialDelaySeconds: 10
@@ -93,7 +94,7 @@ spec:
           readOnly: true
       - args:
         - --csi-address=/csi/csi.sock
-        - --health-port=10300
+        - --http-endpoint=127.0.0.1:10300
         - --v=${LOG_LEVEL}
         - --probe-timeout=10s
         env: []
@@ -111,7 +112,7 @@ spec:
       - args:
         - --csi-address=/csi/csi.sock
         - --kubelet-registration-path=/var/lib/kubelet/plugins/cinder.csi.openstack.org/csi.sock
-        - --http-endpoint=:10304
+        - --http-endpoint=127.0.0.1:10304
         - --v=${LOG_LEVEL}
         env: []
         image: ${NODE_DRIVER_REGISTRAR_IMAGE}
@@ -126,6 +127,7 @@ spec:
         livenessProbe:
           failureThreshold: 5
           httpGet:
+            host: 127.0.0.1
             path: /healthz
             port: rhealthz
           initialDelaySeconds: 10

--- a/assets/overlays/openstack-cinder/patches/node_add_driver.yaml
+++ b/assets/overlays/openstack-cinder/patches/node_add_driver.yaml
@@ -54,11 +54,11 @@ spec:
               readOnly: true
           ports:
             - name: healthz
-              # Due to hostNetwork, this port is open on all nodes!
               containerPort: 10300
               protocol: TCP
           livenessProbe:
             httpGet:
+              host: 127.0.0.1
               path: /healthz
               port: healthz
             initialDelaySeconds: 10

--- a/assets/overlays/openstack-manila/generated/hypershift/controller.yaml
+++ b/assets/overlays/openstack-manila/generated/hypershift/controller.yaml
@@ -14,9 +14,9 @@
 # snapshotter.yaml: Loaded from common/sidecars/snapshotter.yaml
 # snapshotter.yaml: Applied JSON patch common/hypershift/sidecar_add_kubeconfig.yaml.patch
 # Applied strategic merge patch snapshotter.yaml
-# livenessprobe.yaml: Loaded from common/sidecars/livenessprobe.yaml
-# livenessprobe.yaml: Added arguments [--probe-timeout=10s]
-# Applied strategic merge patch livenessprobe.yaml
+# pod_network_livenessprobe.yaml: Loaded from common/sidecars/pod_network_livenessprobe.yaml
+# pod_network_livenessprobe.yaml: Added arguments [--probe-timeout=10s]
+# Applied strategic merge patch pod_network_livenessprobe.yaml
 # Applied strategic merge patch common/hypershift/controller_add_affinity_tolerations.yaml
 # Applied strategic merge patch overlays/openstack-manila/patches/controller_add_hypershift_volumes.yaml
 # Applied strategic merge patch overlays/openstack-manila/patches/controller_rename_config_map.yaml

--- a/assets/overlays/openstack-manila/generated/hypershift/node.yaml
+++ b/assets/overlays/openstack-manila/generated/hypershift/node.yaml
@@ -2,9 +2,9 @@
 #
 # Loaded from base/node.yaml
 # Applied strategic merge patch overlays/openstack-manila/patches/node_add_driver.yaml
-# livenessprobe.yaml: Loaded from common/sidecars/livenessprobe.yaml
-# livenessprobe.yaml: Added arguments [--probe-timeout=10s]
-# Applied strategic merge patch livenessprobe.yaml
+# host_network_livenessprobe.yaml: Loaded from common/sidecars/host_network_livenessprobe.yaml
+# host_network_livenessprobe.yaml: Added arguments [--probe-timeout=10s]
+# Applied strategic merge patch host_network_livenessprobe.yaml
 # node_driver_registrar.yaml: Loaded from common/sidecars/node_driver_registrar.yaml
 # Applied strategic merge patch node_driver_registrar.yaml
 #
@@ -61,6 +61,7 @@ spec:
         livenessProbe:
           failureThreshold: 5
           httpGet:
+            host: 127.0.0.1
             path: /healthz
             port: healthz
           initialDelaySeconds: 10
@@ -91,7 +92,7 @@ spec:
           name: sys-fs
       - args:
         - --csi-address=/csi/csi.sock
-        - --health-port=10305
+        - --http-endpoint=127.0.0.1:10305
         - --v=${LOG_LEVEL}
         - --probe-timeout=10s
         env: []
@@ -109,7 +110,7 @@ spec:
       - args:
         - --csi-address=/csi/csi.sock
         - --kubelet-registration-path=/var/lib/kubelet/plugins/manila.csi.openstack.org/csi.sock
-        - --http-endpoint=:10307
+        - --http-endpoint=127.0.0.1:10307
         - --v=${LOG_LEVEL}
         env: []
         image: ${NODE_DRIVER_REGISTRAR_IMAGE}
@@ -124,6 +125,7 @@ spec:
         livenessProbe:
           failureThreshold: 5
           httpGet:
+            host: 127.0.0.1
             path: /healthz
             port: rhealthz
           initialDelaySeconds: 10

--- a/assets/overlays/openstack-manila/generated/standalone/controller.yaml
+++ b/assets/overlays/openstack-manila/generated/standalone/controller.yaml
@@ -11,9 +11,9 @@
 # Applied strategic merge patch resizer.yaml
 # snapshotter.yaml: Loaded from common/sidecars/snapshotter.yaml
 # Applied strategic merge patch snapshotter.yaml
-# livenessprobe.yaml: Loaded from common/sidecars/livenessprobe.yaml
-# livenessprobe.yaml: Added arguments [--probe-timeout=10s]
-# Applied strategic merge patch livenessprobe.yaml
+# pod_network_livenessprobe.yaml: Loaded from common/sidecars/pod_network_livenessprobe.yaml
+# pod_network_livenessprobe.yaml: Added arguments [--probe-timeout=10s]
+# Applied strategic merge patch pod_network_livenessprobe.yaml
 # Applied strategic merge patch common/standalone/controller_add_affinity.yaml
 # Applied strategic merge patch overlays/openstack-manila/patches/modify_anti_affinity_selector.yaml
 #

--- a/assets/overlays/openstack-manila/generated/standalone/node.yaml
+++ b/assets/overlays/openstack-manila/generated/standalone/node.yaml
@@ -2,9 +2,9 @@
 #
 # Loaded from base/node.yaml
 # Applied strategic merge patch overlays/openstack-manila/patches/node_add_driver.yaml
-# livenessprobe.yaml: Loaded from common/sidecars/livenessprobe.yaml
-# livenessprobe.yaml: Added arguments [--probe-timeout=10s]
-# Applied strategic merge patch livenessprobe.yaml
+# host_network_livenessprobe.yaml: Loaded from common/sidecars/host_network_livenessprobe.yaml
+# host_network_livenessprobe.yaml: Added arguments [--probe-timeout=10s]
+# Applied strategic merge patch host_network_livenessprobe.yaml
 # node_driver_registrar.yaml: Loaded from common/sidecars/node_driver_registrar.yaml
 # Applied strategic merge patch node_driver_registrar.yaml
 #
@@ -61,6 +61,7 @@ spec:
         livenessProbe:
           failureThreshold: 5
           httpGet:
+            host: 127.0.0.1
             path: /healthz
             port: healthz
           initialDelaySeconds: 10
@@ -91,7 +92,7 @@ spec:
           name: sys-fs
       - args:
         - --csi-address=/csi/csi.sock
-        - --health-port=10305
+        - --http-endpoint=127.0.0.1:10305
         - --v=${LOG_LEVEL}
         - --probe-timeout=10s
         env: []
@@ -109,7 +110,7 @@ spec:
       - args:
         - --csi-address=/csi/csi.sock
         - --kubelet-registration-path=/var/lib/kubelet/plugins/manila.csi.openstack.org/csi.sock
-        - --http-endpoint=:10307
+        - --http-endpoint=127.0.0.1:10307
         - --v=${LOG_LEVEL}
         env: []
         image: ${NODE_DRIVER_REGISTRAR_IMAGE}
@@ -124,6 +125,7 @@ spec:
         livenessProbe:
           failureThreshold: 5
           httpGet:
+            host: 127.0.0.1
             path: /healthz
             port: rhealthz
           initialDelaySeconds: 10

--- a/assets/overlays/openstack-manila/patches/node_add_driver.yaml
+++ b/assets/overlays/openstack-manila/patches/node_add_driver.yaml
@@ -71,11 +71,11 @@ spec:
               mountPath: /sys/fs
           ports:
             - name: healthz
-              # Due to hostNetwork, this port is open on all nodes!
               containerPort: 10305
               protocol: TCP
           livenessProbe:
             httpGet:
+              host: 127.0.0.1
               path: /healthz
               port: healthz
             initialDelaySeconds: 10

--- a/assets/overlays/samba/generated/standalone/controller.yaml
+++ b/assets/overlays/samba/generated/standalone/controller.yaml
@@ -9,9 +9,9 @@
 # resizer.yaml: Loaded from common/sidecars/resizer.yaml
 # resizer.yaml: Added arguments [--timeout=120s -handle-volume-inuse-error=false]
 # Applied strategic merge patch resizer.yaml
-# livenessprobe.yaml: Loaded from common/sidecars/livenessprobe.yaml
-# livenessprobe.yaml: Added arguments [--probe-timeout=3s]
-# Applied strategic merge patch livenessprobe.yaml
+# pod_network_livenessprobe.yaml: Loaded from common/sidecars/pod_network_livenessprobe.yaml
+# pod_network_livenessprobe.yaml: Added arguments [--probe-timeout=3s]
+# Applied strategic merge patch pod_network_livenessprobe.yaml
 # Applied strategic merge patch common/standalone/controller_add_affinity.yaml
 #
 #

--- a/assets/overlays/samba/generated/standalone/node.yaml
+++ b/assets/overlays/samba/generated/standalone/node.yaml
@@ -4,9 +4,9 @@
 # Applied strategic merge patch overlays/samba/patches/node_add_driver.yaml
 # node_driver_registrar.yaml: Loaded from common/sidecars/node_driver_registrar.yaml
 # Applied strategic merge patch node_driver_registrar.yaml
-# livenessprobe.yaml: Loaded from common/sidecars/livenessprobe.yaml
-# livenessprobe.yaml: Added arguments [--probe-timeout=3s]
-# Applied strategic merge patch livenessprobe.yaml
+# host_network_livenessprobe.yaml: Loaded from common/sidecars/host_network_livenessprobe.yaml
+# host_network_livenessprobe.yaml: Added arguments [--probe-timeout=3s]
+# Applied strategic merge patch host_network_livenessprobe.yaml
 #
 #
 
@@ -46,6 +46,7 @@ spec:
         livenessProbe:
           failureThreshold: 5
           httpGet:
+            host: 127.0.0.1
             path: /healthz
             port: healthz
           initialDelaySeconds: 30
@@ -74,7 +75,7 @@ spec:
       - args:
         - --csi-address=/csi/csi.sock
         - --kubelet-registration-path=/var/lib/kubelet/plugins/smb.csi.k8s.io/csi.sock
-        - --http-endpoint=:10308
+        - --http-endpoint=127.0.0.1:10308
         - --v=${LOG_LEVEL}
         env: []
         image: ${NODE_DRIVER_REGISTRAR_IMAGE}
@@ -89,6 +90,7 @@ spec:
         livenessProbe:
           failureThreshold: 5
           httpGet:
+            host: 127.0.0.1
             path: /healthz
             port: rhealthz
           initialDelaySeconds: 10
@@ -113,7 +115,7 @@ spec:
           name: registration-dir
       - args:
         - --csi-address=/csi/csi.sock
-        - --health-port=10306
+        - --http-endpoint=127.0.0.1:10306
         - --v=${LOG_LEVEL}
         - --probe-timeout=3s
         env: []

--- a/assets/overlays/samba/patches/node_add_driver.yaml
+++ b/assets/overlays/samba/patches/node_add_driver.yaml
@@ -20,6 +20,7 @@ spec:
           livenessProbe:
             failureThreshold: 5
             httpGet:
+              host: 127.0.0.1
               path: /healthz
               port: healthz
             initialDelaySeconds: 30

--- a/pkg/driver/aws-ebs/aws_ebs.go
+++ b/pkg/driver/aws-ebs/aws_ebs.go
@@ -99,7 +99,7 @@ func GetAWSEBSGeneratorConfig() *generator.CSIDriverGeneratorConfig {
 					"--kube-api-burst=100",
 					"--worker-threads=100",
 				),
-				commongenerator.DefaultLivenessProbe.WithExtraArguments(
+				commongenerator.DefaultPodNetworkLivenessProbe.WithExtraArguments(
 					"--probe-timeout=3s",
 				),
 			},
@@ -116,7 +116,7 @@ func GetAWSEBSGeneratorConfig() *generator.CSIDriverGeneratorConfig {
 			NodeRegistrarHealthCheckPort: 10309,
 			Sidecars: []generator.SidecarConfig{
 				commongenerator.DefaultNodeDriverRegistrar,
-				commongenerator.DefaultLivenessProbe.WithExtraArguments(
+				commongenerator.DefaultHostNetworkLivenessProbe.WithExtraArguments(
 					"--probe-timeout=3s",
 				),
 			},

--- a/pkg/driver/aws-efs/aws_efs.go
+++ b/pkg/driver/aws-efs/aws_efs.go
@@ -54,7 +54,7 @@ func GetAWSEFSGeneratorConfig() *generator.CSIDriverGeneratorConfig {
 					"--timeout=5m",
 					"--worker-threads=1",
 				),
-				commongenerator.DefaultLivenessProbe.WithExtraArguments(
+				commongenerator.DefaultPodNetworkLivenessProbe.WithExtraArguments(
 					"--probe-timeout=3s",
 				),
 			},
@@ -71,7 +71,7 @@ func GetAWSEFSGeneratorConfig() *generator.CSIDriverGeneratorConfig {
 			NodeRegistrarHealthCheckPort: 10305,
 			Sidecars: []generator.SidecarConfig{
 				commongenerator.DefaultNodeDriverRegistrar,
-				commongenerator.DefaultLivenessProbe.WithExtraArguments(
+				commongenerator.DefaultHostNetworkLivenessProbe.WithExtraArguments(
 					"--probe-timeout=3s",
 				),
 			},

--- a/pkg/driver/azure-disk/azure_disk.go
+++ b/pkg/driver/azure-disk/azure_disk.go
@@ -108,7 +108,7 @@ func GetAzureDiskGeneratorConfig() *generator.CSIDriverGeneratorConfig {
 				commongenerator.DefaultSnapshotter.WithExtraArguments(
 					"--timeout=600s",
 				),
-				commongenerator.DefaultLivenessProbe.WithExtraArguments(
+				commongenerator.DefaultPodNetworkLivenessProbe.WithExtraArguments(
 					"--probe-timeout=3s",
 				),
 			},
@@ -135,7 +135,7 @@ func GetAzureDiskGeneratorConfig() *generator.CSIDriverGeneratorConfig {
 			NodeRegistrarHealthCheckPort: 10304,
 			Sidecars: []generator.SidecarConfig{
 				commongenerator.DefaultNodeDriverRegistrar,
-				commongenerator.DefaultLivenessProbe.WithExtraArguments(
+				commongenerator.DefaultHostNetworkLivenessProbe.WithExtraArguments(
 					"--probe-timeout=3s",
 				),
 			},

--- a/pkg/driver/azure-file/azure_file.go
+++ b/pkg/driver/azure-file/azure_file.go
@@ -85,7 +85,7 @@ func GetAzureFileGeneratorConfig() *generator.CSIDriverGeneratorConfig {
 				commongenerator.DefaultSnapshotter.WithExtraArguments(
 					"--timeout=600s",
 				),
-				commongenerator.DefaultLivenessProbe.WithExtraArguments(
+				commongenerator.DefaultPodNetworkLivenessProbe.WithExtraArguments(
 					"--probe-timeout=3s",
 				),
 			},
@@ -105,7 +105,7 @@ func GetAzureFileGeneratorConfig() *generator.CSIDriverGeneratorConfig {
 			NodeRegistrarHealthCheckPort: 10305,
 			Sidecars: []generator.SidecarConfig{
 				commongenerator.DefaultNodeDriverRegistrar,
-				commongenerator.DefaultLivenessProbe.WithExtraArguments(
+				commongenerator.DefaultHostNetworkLivenessProbe.WithExtraArguments(
 					"--probe-timeout=3s",
 				),
 			},

--- a/pkg/driver/common/generator/base_assets.go
+++ b/pkg/driver/common/generator/base_assets.go
@@ -5,12 +5,13 @@ import (
 )
 
 const (
-	ProvisionerAssetName         = "common/sidecars/provisioner.yaml"
-	AttacherAssetName            = "common/sidecars/attacher.yaml"
-	SnapshotterAssetName         = "common/sidecars/snapshotter.yaml"
-	ResizerAssetName             = "common/sidecars/resizer.yaml"
-	LivenessProbeAssetName       = "common/sidecars/livenessprobe.yaml"
-	NodeDriverRegistrarAssetName = "common/sidecars/node_driver_registrar.yaml"
+	ProvisionerAssetName              = "common/sidecars/provisioner.yaml"
+	AttacherAssetName                 = "common/sidecars/attacher.yaml"
+	SnapshotterAssetName              = "common/sidecars/snapshotter.yaml"
+	ResizerAssetName                  = "common/sidecars/resizer.yaml"
+	PodNetworkLivenessProbeAssetName  = "common/sidecars/pod_network_livenessprobe.yaml"
+	HostNetworkLivenessProbeAssetName = "common/sidecars/host_network_livenessprobe.yaml"
+	NodeDriverRegistrarAssetName      = "common/sidecars/node_driver_registrar.yaml"
 )
 
 var (
@@ -111,9 +112,15 @@ var (
 			"sidecar.yaml", "common/hypershift/sidecar_add_kubeconfig.yaml.patch",
 		),
 	}
-	// DefaultLivenessProbe is definition of the default livenessprobe sidecar.
-	DefaultLivenessProbe = generator.SidecarConfig{
-		TemplateAssetName: LivenessProbeAssetName,
+	// DefaultPodNetworkLivenessProbe is definition of the default livenessprobe sidecar using pod network.
+	DefaultPodNetworkLivenessProbe = generator.SidecarConfig{
+		TemplateAssetName: PodNetworkLivenessProbeAssetName,
+		ExtraArguments:    nil,
+		HasMetricsPort:    false,
+	}
+	// DefaultHostNetworkLivenessProbe is definition of the default livenessprobe sidecar using host network .
+	DefaultHostNetworkLivenessProbe = generator.SidecarConfig{
+		TemplateAssetName: HostNetworkLivenessProbeAssetName,
 		ExtraArguments:    nil,
 		HasMetricsPort:    false,
 	}

--- a/pkg/driver/openstack-cinder/openstack_cinder.go
+++ b/pkg/driver/openstack-cinder/openstack_cinder.go
@@ -62,7 +62,7 @@ func GetOpenStackCinderGeneratorConfig() *generator.CSIDriverGeneratorConfig {
 				commongenerator.DefaultResizer.WithExtraArguments(),
 				// FIXME(stephenfin): Unlike other sidecars, this one doesn't (and didn't) set a timeout. Should it?
 				commongenerator.DefaultSnapshotter.WithExtraArguments(),
-				commongenerator.DefaultLivenessProbe.WithExtraArguments(
+				commongenerator.DefaultPodNetworkLivenessProbe.WithExtraArguments(
 					"--probe-timeout=10s",
 				),
 			},
@@ -77,7 +77,7 @@ func GetOpenStackCinderGeneratorConfig() *generator.CSIDriverGeneratorConfig {
 			LivenessProbePort:            10300,
 			NodeRegistrarHealthCheckPort: 10304,
 			Sidecars: []generator.SidecarConfig{
-				commongenerator.DefaultLivenessProbe.WithExtraArguments(
+				commongenerator.DefaultHostNetworkLivenessProbe.WithExtraArguments(
 					"--probe-timeout=10s",
 				),
 				commongenerator.DefaultNodeDriverRegistrar,

--- a/pkg/driver/openstack-manila/openstack_manila.go
+++ b/pkg/driver/openstack-manila/openstack_manila.go
@@ -76,7 +76,7 @@ func GetOpenStackManilaGeneratorConfig() *generator.CSIDriverGeneratorConfig {
 					"--handle-volume-inuse-error=false",
 				),
 				commongenerator.DefaultSnapshotter.WithExtraArguments(),
-				commongenerator.DefaultLivenessProbe.WithExtraArguments(
+				commongenerator.DefaultPodNetworkLivenessProbe.WithExtraArguments(
 					"--probe-timeout=10s",
 				),
 			},
@@ -96,7 +96,7 @@ func GetOpenStackManilaGeneratorConfig() *generator.CSIDriverGeneratorConfig {
 			LivenessProbePort:            10305,
 			NodeRegistrarHealthCheckPort: 10307,
 			Sidecars: []generator.SidecarConfig{
-				commongenerator.DefaultLivenessProbe.WithExtraArguments(
+				commongenerator.DefaultHostNetworkLivenessProbe.WithExtraArguments(
 					"--probe-timeout=10s",
 				),
 				commongenerator.DefaultNodeDriverRegistrar,

--- a/pkg/driver/samba/samba.go
+++ b/pkg/driver/samba/samba.go
@@ -48,7 +48,7 @@ func GetSambaGeneratorConfig() *generator.CSIDriverGeneratorConfig {
 					"--timeout=120s",
 					"-handle-volume-inuse-error=false",
 				),
-				commongenerator.DefaultLivenessProbe.WithExtraArguments(
+				commongenerator.DefaultPodNetworkLivenessProbe.WithExtraArguments(
 					"--probe-timeout=3s",
 				),
 			},
@@ -72,7 +72,7 @@ func GetSambaGeneratorConfig() *generator.CSIDriverGeneratorConfig {
 			NodeRegistrarHealthCheckPort: 10308,
 			Sidecars: []generator.SidecarConfig{
 				commongenerator.DefaultNodeDriverRegistrar,
-				commongenerator.DefaultLivenessProbe.WithExtraArguments(
+				commongenerator.DefaultHostNetworkLivenessProbe.WithExtraArguments(
 					"--probe-timeout=3s",
 				),
 			},


### PR DESCRIPTION
Those ports are used only for internal communication inside CSI driver pods. No need to expose them for the world.