### PR TITLE
WIP: OCPBUGS-50493: Use 127.0.0.1 for healtz http-endpoints (2)

### DIFF
--- a/assets/common/sidecars/livenessprobe.yaml
+++ b/assets/common/sidecars/livenessprobe.yaml
@@ -9,7 +9,7 @@ spec:
           terminationMessagePolicy: FallbackToLogsOnError
           args:
             - --csi-address=/csi/csi.sock
-            - --health-port=${LIVENESS_PROBE_PORT}
+            - --http-endpoint=127.0.0.1:${LIVENESS_PROBE_PORT}
             - --v=${LOG_LEVEL}
           # Empty env. instead of nil for json patch to append new env. vars there
           env: []

--- a/assets/overlays/aws-ebs/generated/hypershift/controller.yaml
+++ b/assets/overlays/aws-ebs/generated/hypershift/controller.yaml
@@ -379,7 +379,7 @@ spec:
           name: metrics-serving-cert
       - args:
         - --csi-address=/csi/csi.sock
-        - --health-port=10301
+        - --http-endpoint=127.0.0.1:10301
         - --v=${LOG_LEVEL}
         - --probe-timeout=3s
         env: []

--- a/assets/overlays/aws-ebs/generated/hypershift/node.yaml
+++ b/assets/overlays/aws-ebs/generated/hypershift/node.yaml
@@ -116,7 +116,7 @@ spec:
           name: registration-dir
       - args:
         - --csi-address=/csi/csi.sock
-        - --health-port=10300
+        - --http-endpoint=127.0.0.1:10300
         - --v=${LOG_LEVEL}
         - --probe-timeout=3s
         env: []

--- a/assets/overlays/aws-ebs/generated/standalone/controller.yaml
+++ b/assets/overlays/aws-ebs/generated/standalone/controller.yaml
@@ -325,7 +325,7 @@ spec:
           name: metrics-serving-cert
       - args:
         - --csi-address=/csi/csi.sock
-        - --health-port=10301
+        - --http-endpoint=127.0.0.1:10301
         - --v=${LOG_LEVEL}
         - --probe-timeout=3s
         env: []

--- a/assets/overlays/aws-ebs/generated/standalone/node.yaml
+++ b/assets/overlays/aws-ebs/generated/standalone/node.yaml
@@ -116,7 +116,7 @@ spec:
           name: registration-dir
       - args:
         - --csi-address=/csi/csi.sock
-        - --health-port=10300
+        - --http-endpoint=127.0.0.1:10300
         - --v=${LOG_LEVEL}
         - --probe-timeout=3s
         env: []

--- a/assets/overlays/aws-efs/generated/standalone/controller.yaml
+++ b/assets/overlays/aws-efs/generated/standalone/controller.yaml
@@ -147,7 +147,7 @@ spec:
           name: metrics-serving-cert
       - args:
         - --csi-address=/csi/csi.sock
-        - --health-port=10302
+        - --http-endpoint=127.0.0.1:10302
         - --v=${LOG_LEVEL}
         - --probe-timeout=3s
         env: []

--- a/assets/overlays/aws-efs/generated/standalone/node.yaml
+++ b/assets/overlays/aws-efs/generated/standalone/node.yaml
@@ -119,7 +119,7 @@ spec:
           name: registration-dir
       - args:
         - --csi-address=/csi/csi.sock
-        - --health-port=10303
+        - --http-endpoint=127.0.0.1:10303
         - --v=${LOG_LEVEL}
         - --probe-timeout=3s
         env: []

--- a/assets/overlays/azure-disk/generated/hypershift/controller.yaml
+++ b/assets/overlays/azure-disk/generated/hypershift/controller.yaml
@@ -369,7 +369,7 @@ spec:
           name: metrics-serving-cert
       - args:
         - --csi-address=/csi/csi.sock
-        - --health-port=10301
+        - --http-endpoint=127.0.0.1:10301
         - --v=${LOG_LEVEL}
         - --probe-timeout=3s
         env: []

--- a/assets/overlays/azure-disk/generated/hypershift/node.yaml
+++ b/assets/overlays/azure-disk/generated/hypershift/node.yaml
@@ -157,7 +157,7 @@ spec:
           name: registration-dir
       - args:
         - --csi-address=/csi/csi.sock
-        - --health-port=10300
+        - --http-endpoint=127.0.0.1:10300
         - --v=${LOG_LEVEL}
         - --probe-timeout=3s
         env: []

--- a/assets/overlays/azure-disk/generated/standalone/controller.yaml
+++ b/assets/overlays/azure-disk/generated/standalone/controller.yaml
@@ -316,7 +316,7 @@ spec:
           name: metrics-serving-cert
       - args:
         - --csi-address=/csi/csi.sock
-        - --health-port=10301
+        - --http-endpoint=127.0.0.1:10301
         - --v=${LOG_LEVEL}
         - --probe-timeout=3s
         env: []

--- a/assets/overlays/azure-disk/generated/standalone/node.yaml
+++ b/assets/overlays/azure-disk/generated/standalone/node.yaml
@@ -157,7 +157,7 @@ spec:
           name: registration-dir
       - args:
         - --csi-address=/csi/csi.sock
-        - --health-port=10300
+        - --http-endpoint=127.0.0.1:10300
         - --v=${LOG_LEVEL}
         - --probe-timeout=3s
         env: []

--- a/assets/overlays/azure-file/generated/hypershift/controller.yaml
+++ b/assets/overlays/azure-file/generated/hypershift/controller.yaml
@@ -375,7 +375,7 @@ spec:
           name: metrics-serving-cert
       - args:
         - --csi-address=/csi/csi.sock
-        - --health-port=10303
+        - --http-endpoint=127.0.0.1:10303
         - --v=${LOG_LEVEL}
         - --probe-timeout=3s
         env: []

--- a/assets/overlays/azure-file/generated/hypershift/node.yaml
+++ b/assets/overlays/azure-file/generated/hypershift/node.yaml
@@ -136,7 +136,7 @@ spec:
           name: registration-dir
       - args:
         - --csi-address=/csi/csi.sock
-        - --health-port=10302
+        - --http-endpoint=127.0.0.1:10302
         - --v=${LOG_LEVEL}
         - --probe-timeout=3s
         env: []

--- a/assets/overlays/azure-file/generated/standalone/controller.yaml
+++ b/assets/overlays/azure-file/generated/standalone/controller.yaml
@@ -315,7 +315,7 @@ spec:
           name: metrics-serving-cert
       - args:
         - --csi-address=/csi/csi.sock
-        - --health-port=10303
+        - --http-endpoint=127.0.0.1:10303
         - --v=${LOG_LEVEL}
         - --probe-timeout=3s
         env: []

--- a/assets/overlays/azure-file/generated/standalone/node.yaml
+++ b/assets/overlays/azure-file/generated/standalone/node.yaml
@@ -136,7 +136,7 @@ spec:
           name: registration-dir
       - args:
         - --csi-address=/csi/csi.sock
-        - --health-port=10302
+        - --http-endpoint=127.0.0.1:10302
         - --v=${LOG_LEVEL}
         - --probe-timeout=3s
         env: []

--- a/assets/overlays/openstack-cinder/generated/hypershift/controller.yaml
+++ b/assets/overlays/openstack-cinder/generated/hypershift/controller.yaml
@@ -365,7 +365,7 @@ spec:
           name: metrics-serving-cert
       - args:
         - --csi-address=/csi/csi.sock
-        - --health-port=10301
+        - --http-endpoint=127.0.0.1:10301
         - --v=${LOG_LEVEL}
         - --probe-timeout=10s
         env: []

--- a/assets/overlays/openstack-cinder/generated/hypershift/node.yaml
+++ b/assets/overlays/openstack-cinder/generated/hypershift/node.yaml
@@ -93,7 +93,7 @@ spec:
           readOnly: true
       - args:
         - --csi-address=/csi/csi.sock
-        - --health-port=10300
+        - --http-endpoint=127.0.0.1:10300
         - --v=${LOG_LEVEL}
         - --probe-timeout=10s
         env: []

--- a/assets/overlays/openstack-cinder/generated/standalone/controller.yaml
+++ b/assets/overlays/openstack-cinder/generated/standalone/controller.yaml
@@ -311,7 +311,7 @@ spec:
           name: metrics-serving-cert
       - args:
         - --csi-address=/csi/csi.sock
-        - --health-port=10301
+        - --http-endpoint=127.0.0.1:10301
         - --v=${LOG_LEVEL}
         - --probe-timeout=10s
         env: []

--- a/assets/overlays/openstack-cinder/generated/standalone/node.yaml
+++ b/assets/overlays/openstack-cinder/generated/standalone/node.yaml
@@ -93,7 +93,7 @@ spec:
           readOnly: true
       - args:
         - --csi-address=/csi/csi.sock
-        - --health-port=10300
+        - --http-endpoint=127.0.0.1:10300
         - --v=${LOG_LEVEL}
         - --probe-timeout=10s
         env: []

--- a/assets/overlays/openstack-manila/generated/hypershift/controller.yaml
+++ b/assets/overlays/openstack-manila/generated/hypershift/controller.yaml
@@ -333,7 +333,7 @@ spec:
           name: metrics-serving-cert
       - args:
         - --csi-address=/csi/csi.sock
-        - --health-port=10306
+        - --http-endpoint=127.0.0.1:10306
         - --v=${LOG_LEVEL}
         - --probe-timeout=10s
         env: []

--- a/assets/overlays/openstack-manila/generated/hypershift/node.yaml
+++ b/assets/overlays/openstack-manila/generated/hypershift/node.yaml
@@ -89,7 +89,7 @@ spec:
           name: sys-fs
       - args:
         - --csi-address=/csi/csi.sock
-        - --health-port=10305
+        - --http-endpoint=127.0.0.1:10305
         - --v=${LOG_LEVEL}
         - --probe-timeout=10s
         env: []

--- a/assets/overlays/openstack-manila/generated/standalone/controller.yaml
+++ b/assets/overlays/openstack-manila/generated/standalone/controller.yaml
@@ -285,7 +285,7 @@ spec:
           name: metrics-serving-cert
       - args:
         - --csi-address=/csi/csi.sock
-        - --health-port=10306
+        - --http-endpoint=127.0.0.1:10306
         - --v=${LOG_LEVEL}
         - --probe-timeout=10s
         env: []

--- a/assets/overlays/openstack-manila/generated/standalone/node.yaml
+++ b/assets/overlays/openstack-manila/generated/standalone/node.yaml
@@ -89,7 +89,7 @@ spec:
           name: sys-fs
       - args:
         - --csi-address=/csi/csi.sock
-        - --health-port=10305
+        - --http-endpoint=127.0.0.1:10305
         - --v=${LOG_LEVEL}
         - --probe-timeout=10s
         env: []

--- a/assets/overlays/samba/generated/standalone/controller.yaml
+++ b/assets/overlays/samba/generated/standalone/controller.yaml
@@ -199,7 +199,7 @@ spec:
           name: metrics-serving-cert
       - args:
         - --csi-address=/csi/csi.sock
-        - --health-port=10307
+        - --http-endpoint=127.0.0.1:10307
         - --v=${LOG_LEVEL}
         - --probe-timeout=3s
         env: []

--- a/assets/overlays/samba/generated/standalone/node.yaml
+++ b/assets/overlays/samba/generated/standalone/node.yaml
@@ -113,7 +113,7 @@ spec:
           name: registration-dir
       - args:
         - --csi-address=/csi/csi.sock
-        - --health-port=10306
+        - --http-endpoint=127.0.0.1:10306
         - --v=${LOG_LEVEL}
         - --probe-timeout=3s
         env: []


### PR DESCRIPTION
Debugging why https://github.com/openshift/csi-operator/pull/364 failed CI tests