### PR TITLE
OCPBUGS-54447: Enable required driver services

### DIFF
--- a/assets/overlays/openstack-manila/generated/hypershift/controller.yaml
+++ b/assets/overlays/openstack-manila/generated/hypershift/controller.yaml
@@ -89,6 +89,8 @@ spec:
             weight: 100
       containers:
       - args:
+        - --provide-controller-service=true
+        - --provide-node-service=false
         - --v=${LOG_LEVEL}
         - --cluster-id=${CLUSTER_ID}
         - --nodeid=$(NODE_ID)

--- a/assets/overlays/openstack-manila/generated/hypershift/node.yaml
+++ b/assets/overlays/openstack-manila/generated/hypershift/node.yaml
@@ -35,6 +35,8 @@ spec:
     spec:
       containers:
       - args:
+        - --provide-controller-service=false
+        - --provide-node-service=true
         - --v=${LOG_LEVEL}
         - --nodeid=$(NODE_ID)
         - --endpoint=$(CSI_ENDPOINT)

--- a/assets/overlays/openstack-manila/generated/standalone/controller.yaml
+++ b/assets/overlays/openstack-manila/generated/standalone/controller.yaml
@@ -59,6 +59,8 @@ spec:
             weight: 100
       containers:
       - args:
+        - --provide-controller-service=true
+        - --provide-node-service=false
         - --v=${LOG_LEVEL}
         - --cluster-id=${CLUSTER_ID}
         - --nodeid=$(NODE_ID)

--- a/assets/overlays/openstack-manila/generated/standalone/node.yaml
+++ b/assets/overlays/openstack-manila/generated/standalone/node.yaml
@@ -35,6 +35,8 @@ spec:
     spec:
       containers:
       - args:
+        - --provide-controller-service=false
+        - --provide-node-service=true
         - --v=${LOG_LEVEL}
         - --nodeid=$(NODE_ID)
         - --endpoint=$(CSI_ENDPOINT)

--- a/assets/overlays/openstack-manila/patches/controller_add_driver.yaml
+++ b/assets/overlays/openstack-manila/patches/controller_add_driver.yaml
@@ -38,6 +38,8 @@ spec:
           image: ${DRIVER_IMAGE}
           imagePullPolicy: IfNotPresent
           args:
+            - "--provide-controller-service=true"
+            - "--provide-node-service=false"
             - --v=${LOG_LEVEL}
             - --cluster-id=${CLUSTER_ID}
             - --nodeid=$(NODE_ID)

--- a/assets/overlays/openstack-manila/patches/node_add_driver.yaml
+++ b/assets/overlays/openstack-manila/patches/node_add_driver.yaml
@@ -37,6 +37,8 @@ spec:
           image: ${DRIVER_IMAGE}
           imagePullPolicy: IfNotPresent
           args:
+            - "--provide-controller-service=false"
+            - "--provide-node-service=true"
             - --v=${LOG_LEVEL}
             - "--nodeid=$(NODE_ID)"
             - "--endpoint=$(CSI_ENDPOINT)"


### PR DESCRIPTION
The Manila CSI driver, like Cinder, uses a single binary for both the controller and node (worker) services. This can result in services running on unintended hosts. A similar issue was addressed in Cinder in version 4.18, and we should now apply the same fix to Manila.