### PR TITLE
OCPBUGS-54180: Disable remove-not-ready-taint for azure disk csi driver

### DIFF
--- a/assets/overlays/azure-disk/generated/hypershift/node.yaml
+++ b/assets/overlays/azure-disk/generated/hypershift/node.yaml
@@ -41,6 +41,7 @@ spec:
         - --metrics-address=localhost:8206
         - --cloud-config-secret-name=""
         - --cloud-config-secret-namespace=""
+        - --remove-not-ready-taint=false
         env:
         - name: AZURE_CREDENTIAL_FILE
           value: /etc/kubernetes/cloud.conf

--- a/assets/overlays/azure-disk/generated/standalone/node.yaml
+++ b/assets/overlays/azure-disk/generated/standalone/node.yaml
@@ -41,6 +41,7 @@ spec:
         - --metrics-address=localhost:8206
         - --cloud-config-secret-name=""
         - --cloud-config-secret-namespace=""
+        - --remove-not-ready-taint=false
         env:
         - name: AZURE_CREDENTIAL_FILE
           value: /etc/kubernetes/cloud.conf

--- a/assets/overlays/azure-disk/patches/node_add_driver.yaml
+++ b/assets/overlays/azure-disk/patches/node_add_driver.yaml
@@ -23,6 +23,9 @@ spec:
             # Use credentials provided by the azure-inject-credentials container
             - --cloud-config-secret-name=""
             - --cloud-config-secret-namespace=""
+            # Disable the remove-not-ready-taint, as it is not implemented in ocp
+            # https://github.com/kubernetes-sigs/azuredisk-csi-driver/pull/2309
+            - --remove-not-ready-taint=false
           env:
             - name: AZURE_CREDENTIAL_FILE
               value: "/etc/kubernetes/cloud.conf"


### PR DESCRIPTION
- Disable the remove-not-ready-taint feature, as it is not implemented in ocp, avoid the unnecessary remove taint actions and logs. (Try to make it opt-in on upstream but unfortunately the maintainer is not happy with it, so we could go head disable it from our operator side. https://redhat-internal.slack.com/archives/GK0DA0JR5/p1743062502904419?thread_ts=1742823634.580139&cid=GK0DA0JR5)