### PR TITLE
OCPBUGS-54382: Correct ASH driver inject env config

### DIFF
--- a/pkg/driver/azure-disk/azure_disk.go
+++ b/pkg/driver/azure-disk/azure_disk.go
@@ -54,7 +54,7 @@ const (
 	configEnvName         = "AZURE_ENVIRONMENT_FILEPATH"
 	azureStackCloudConfig = "/etc/azure/azurestackcloud.json"
 	// name of volume that contains cloud-config in actual deployment or daemonset
-	podAzureCfgVolumeName = "cloud-config"
+	podAzureCfgVolumeName = "src-cloud-config"
 
 	diskEncryptionSetID = "diskEncryptionSetID"
 


### PR DESCRIPTION
### Correct ASH driver inject env config
- We made a mistake when migrate the azure disk driver operator from `azure-disk-csi-driver-operator` to `csi-operator`, the  `injectEnvAndMounts` which used for ASH the `endpoints` Subpath expected read the `endpoints` value from the cloud configmap key `endpoints` while we use the incorrect volume name for injecting.
 ref -> https://github.com/openshift/azure-disk-csi-driver-operator/blob/release-4.15/pkg/azurestackhub/azure_stack_hub.go#L48-L76
```console
...
2025-03-27T21:07:32.105160383Z W0327 21:07:32.105102       1 azure_disk_utils.go:236] InitializeCloudFromConfig failed with error: read /etc/azure/azurestackcloud.json: is a directory 
...
```