### PR TITLE
OCPBUGS-54760: Replace deprecated `node-role` toleration/nodeSelector

### DIFF
--- a/assets/common/standalone/controller_add_affinity.yaml
+++ b/assets/common/standalone/controller_add_affinity.yaml
@@ -13,15 +13,15 @@ spec:
                   app: ${ASSET_PREFIX}-controller
               topologyKey: kubernetes.io/hostname
             weight: 100
-
       nodeSelector:
         node-role.kubernetes.io/master: ""
-
       priorityClassName: system-cluster-critical
-
       tolerations:
       - key: CriticalAddonsOnly
         operator: Exists
+      - key: node-role.kubernetes.io/control-plane
+        operator: Exists
+        effect: "NoSchedule"
       - effect: NoSchedule
         key: node-role.kubernetes.io/master
         operator: Exists

--- a/assets/overlays/aws-ebs/generated/standalone/controller.yaml
+++ b/assets/overlays/aws-ebs/generated/standalone/controller.yaml
@@ -388,6 +388,9 @@ spec:
       - key: CriticalAddonsOnly
         operator: Exists
       - effect: NoSchedule
+        key: node-role.kubernetes.io/control-plane
+        operator: Exists
+      - effect: NoSchedule
         key: node-role.kubernetes.io/master
         operator: Exists
       volumes:

--- a/assets/overlays/aws-efs/generated/standalone/controller.yaml
+++ b/assets/overlays/aws-efs/generated/standalone/controller.yaml
@@ -213,6 +213,9 @@ spec:
       - key: CriticalAddonsOnly
         operator: Exists
       - effect: NoSchedule
+        key: node-role.kubernetes.io/control-plane
+        operator: Exists
+      - effect: NoSchedule
         key: node-role.kubernetes.io/master
         operator: Exists
       volumes:

--- a/assets/overlays/aws-efs/patches/controller_add_driver.yaml
+++ b/assets/overlays/aws-efs/patches/controller_add_driver.yaml
@@ -31,6 +31,9 @@ spec:
       tolerations:
         - key: CriticalAddonsOnly
           operator: Exists
+        - key: node-role.kubernetes.io/control-plane
+          operator: Exists
+          effect: "NoSchedule"
         - key: node-role.kubernetes.io/master
           operator: Exists
           effect: "NoSchedule"

--- a/assets/overlays/azure-disk/generated/standalone/controller.yaml
+++ b/assets/overlays/azure-disk/generated/standalone/controller.yaml
@@ -360,6 +360,9 @@ spec:
       - key: CriticalAddonsOnly
         operator: Exists
       - effect: NoSchedule
+        key: node-role.kubernetes.io/control-plane
+        operator: Exists
+      - effect: NoSchedule
         key: node-role.kubernetes.io/master
         operator: Exists
       volumes:

--- a/assets/overlays/azure-file/generated/standalone/controller.yaml
+++ b/assets/overlays/azure-file/generated/standalone/controller.yaml
@@ -359,6 +359,9 @@ spec:
       - key: CriticalAddonsOnly
         operator: Exists
       - effect: NoSchedule
+        key: node-role.kubernetes.io/control-plane
+        operator: Exists
+      - effect: NoSchedule
         key: node-role.kubernetes.io/master
         operator: Exists
       volumes:

--- a/assets/overlays/openstack-cinder/generated/standalone/controller.yaml
+++ b/assets/overlays/openstack-cinder/generated/standalone/controller.yaml
@@ -333,6 +333,9 @@ spec:
       - key: CriticalAddonsOnly
         operator: Exists
       - effect: NoSchedule
+        key: node-role.kubernetes.io/control-plane
+        operator: Exists
+      - effect: NoSchedule
         key: node-role.kubernetes.io/master
         operator: Exists
       volumes:

--- a/assets/overlays/openstack-cinder/patches/controller_add_driver.yaml
+++ b/assets/overlays/openstack-cinder/patches/controller_add_driver.yaml
@@ -17,6 +17,9 @@ spec:
       tolerations:
         - key: CriticalAddonsOnly
           operator: Exists
+        - key: node-role.kubernetes.io/control-plane
+          operator: Exists
+          effect: "NoSchedule"
         - key: node-role.kubernetes.io/master
           operator: Exists
           effect: "NoSchedule"

--- a/assets/overlays/openstack-manila/generated/standalone/controller.yaml
+++ b/assets/overlays/openstack-manila/generated/standalone/controller.yaml
@@ -310,6 +310,9 @@ spec:
       - key: CriticalAddonsOnly
         operator: Exists
       - effect: NoSchedule
+        key: node-role.kubernetes.io/control-plane
+        operator: Exists
+      - effect: NoSchedule
         key: node-role.kubernetes.io/master
         operator: Exists
       volumes:

--- a/assets/overlays/openstack-manila/patches/controller_add_driver.yaml
+++ b/assets/overlays/openstack-manila/patches/controller_add_driver.yaml
@@ -30,6 +30,9 @@ spec:
       tolerations:
         - key: CriticalAddonsOnly
           operator: Exists
+        - key: node-role.kubernetes.io/control-plane
+          operator: Exists
+          effect: "NoSchedule"
         - key: node-role.kubernetes.io/master
           operator: Exists
           effect: "NoSchedule"

--- a/assets/overlays/samba/generated/standalone/controller.yaml
+++ b/assets/overlays/samba/generated/standalone/controller.yaml
@@ -222,6 +222,9 @@ spec:
       - key: CriticalAddonsOnly
         operator: Exists
       - effect: NoSchedule
+        key: node-role.kubernetes.io/control-plane
+        operator: Exists
+      - effect: NoSchedule
         key: node-role.kubernetes.io/master
         operator: Exists
       volumes:

--- a/config/aws-efs/manifests/stable/aws-efs-csi-driver-operator.clusterserviceversion.yaml
+++ b/config/aws-efs/manifests/stable/aws-efs-csi-driver-operator.clusterserviceversion.yaml
@@ -418,6 +418,13 @@ spec:
                     - weight: 100
                       preference:
                         matchExpressions:
+                        - key: node-role.kubernetes.io/control-plane
+                          operator: In
+                          values:
+                          - ""
+                    - weight: 100
+                      preference:
+                        matchExpressions:
                         - key: node-role.kubernetes.io/master
                           operator: In
                           values:
@@ -425,6 +432,9 @@ spec:
                 tolerations:
                   - key: CriticalAddonsOnly
                     operator: Exists
+                  - key: node-role.kubernetes.io/control-plane
+                    operator: Exists
+                    effect: "NoSchedule"
                   - key: node-role.kubernetes.io/master
                     operator: Exists
                     effect: "NoSchedule"

--- a/config/samba/manifests/stable/smb-csi-driver-operator.clusterserviceversion.yaml
+++ b/config/samba/manifests/stable/smb-csi-driver-operator.clusterserviceversion.yaml
@@ -368,6 +368,13 @@ spec:
                     - weight: 100
                       preference:
                         matchExpressions:
+                        - key: node-role.kubernetes.io/control-plane
+                          operator: In
+                          values:
+                          - ""
+                    - weight: 100
+                      preference:
+                        matchExpressions:
                         - key: node-role.kubernetes.io/master
                           operator: In
                           values:
@@ -375,6 +382,9 @@ spec:
                 tolerations:
                   - key: CriticalAddonsOnly
                     operator: Exists
+                  - key: node-role.kubernetes.io/control-plane
+                    operator: Exists
+                    effect: "NoSchedule"
                   - key: node-role.kubernetes.io/master
                     operator: Exists
                     effect: "NoSchedule"


### PR DESCRIPTION
The `node-role.kubernetes.io/master` annotation is deprecated in favour of `node-role.kubernetes.io/control-plane` [[1][1]] [[2][2]] and currently produces a warning when modifying resources via `oc`/`kubectl`.

```
❯ oc scale -n openshift-cluster-storage-operator deployment cluster-storage-operator --replicas 0
Warning: spec.template.spec.nodeSelector[node-role.kubernetes.io/master]: use "node-role.kubernetes.io/control-plane" instead
deployment.apps/cluster-storage-operator scaled
```

Migrate all `tolerations` and `nodeSelector` instances over. While both labels currently co-exist, we opt to update the existing label rather than append a new one since the new label has been present since 1.26. This is achieved like so:

```
❯ sed -i 's/node-role.kubernetes.io\/master/node-role.kubernetes.io\/control-plane/' \
    $(ag node-role -l --ignore generated --ignore vendor)
❯ make update
```

[1]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-cluster-lifecycle/kubeadm/2067-rename-master-label-taint
[2]: https://kubernetes.io/docs/reference/labels-annotations-taints/#node-role-kubernetes-io-master-taint
