### PR TITLE
OCPBUGS-54975: Fix Cinder, Manila driver metrics

### DIFF
--- a/assets/overlays/openstack-cinder/generated/hypershift/controller.yaml
+++ b/assets/overlays/openstack-cinder/generated/hypershift/controller.yaml
@@ -91,6 +91,7 @@ spec:
         - --provide-controller-service=true
         - --provide-node-service=false
         - --endpoint=$(CSI_ENDPOINT)
+        - --http-endpoint=localhost:8202
         - --cloud-config=$(CLOUD_CONFIG)
         - --cluster=${CLUSTER_ID}
         - --with-topology=$(ENABLE_TOPOLOGY)

--- a/assets/overlays/openstack-cinder/generated/standalone/controller.yaml
+++ b/assets/overlays/openstack-cinder/generated/standalone/controller.yaml
@@ -61,6 +61,7 @@ spec:
         - --provide-controller-service=true
         - --provide-node-service=false
         - --endpoint=$(CSI_ENDPOINT)
+        - --http-endpoint=localhost:8202
         - --cloud-config=$(CLOUD_CONFIG)
         - --cluster=${CLUSTER_ID}
         - --with-topology=$(ENABLE_TOPOLOGY)

--- a/assets/overlays/openstack-cinder/patches/controller_add_driver.yaml
+++ b/assets/overlays/openstack-cinder/patches/controller_add_driver.yaml
@@ -38,6 +38,9 @@ spec:
             - "--provide-controller-service=true"
             - "--provide-node-service=false"
             - "--endpoint=$(CSI_ENDPOINT)"
+            # this is the generated value of the LOCAL_METRICS_PORT variable
+            # we hardcode it because we don't currently support substitution
+            - "--http-endpoint=localhost:8202"
             - "--cloud-config=$(CLOUD_CONFIG)"
             - "--cluster=${CLUSTER_ID}"
             - "--with-topology=$(ENABLE_TOPOLOGY)"

--- a/assets/overlays/openstack-manila/generated/hypershift/controller.yaml
+++ b/assets/overlays/openstack-manila/generated/hypershift/controller.yaml
@@ -2,7 +2,6 @@
 #
 # Loaded from base/controller.yaml
 # Applied strategic merge patch overlays/openstack-manila/patches/controller_add_driver.yaml
-# Applied strategic merge patch common/sidecars/controller_driver_kube_rbac_proxy.yaml
 # provisioner.yaml: Loaded from common/sidecars/provisioner.yaml
 # provisioner.yaml: Added arguments [--timeout=120s --feature-gates=Topology=true]
 # provisioner.yaml: Applied JSON patch common/hypershift/sidecar_add_kubeconfig.yaml.patch
@@ -156,29 +155,6 @@ spec:
         volumeMounts:
         - mountPath: /plugin
           name: socket-dir
-      - args:
-        - --secure-listen-address=0.0.0.0:9202
-        - --upstream=http://127.0.0.1:8202/
-        - --tls-cert-file=/etc/tls/private/tls.crt
-        - --tls-private-key-file=/etc/tls/private/tls.key
-        - --tls-cipher-suites=${TLS_CIPHER_SUITES}
-        - --tls-min-version=${TLS_MIN_VERSION}
-        - --logtostderr=true
-        image: ${KUBE_RBAC_PROXY_IMAGE}
-        imagePullPolicy: IfNotPresent
-        name: kube-rbac-proxy-8202
-        ports:
-        - containerPort: 9202
-          name: driver-m
-          protocol: TCP
-        resources:
-          requests:
-            cpu: 10m
-            memory: 20Mi
-        terminationMessagePolicy: FallbackToLogsOnError
-        volumeMounts:
-        - mountPath: /etc/tls/private
-          name: metrics-serving-cert
       - args:
         - --csi-address=/var/lib/csi/sockets/pluginproxy/csi.sock
         - --http-endpoint=localhost:8203

--- a/assets/overlays/openstack-manila/generated/hypershift/service.yaml
+++ b/assets/overlays/openstack-manila/generated/hypershift/service.yaml
@@ -4,7 +4,6 @@
 # Applied strategic merge patch common/metrics/service_add_port.yaml
 # Applied strategic merge patch common/metrics/service_add_port.yaml
 # Applied strategic merge patch common/metrics/service_add_port.yaml
-# Applied strategic merge patch common/metrics/service_add_port.yaml
 # Applied strategic merge patch overlays/openstack-manila/patches/modify_service_selector.yaml
 #
 #
@@ -32,10 +31,6 @@ spec:
     port: 9205
     protocol: TCP
     targetPort: snapshotter-m
-  - name: driver-m
-    port: 9202
-    protocol: TCP
-    targetPort: driver-m
   selector:
     app: openstack-manila-csi
     component: controllerplugin

--- a/assets/overlays/openstack-manila/generated/standalone/controller.yaml
+++ b/assets/overlays/openstack-manila/generated/standalone/controller.yaml
@@ -2,7 +2,6 @@
 #
 # Loaded from base/controller.yaml
 # Applied strategic merge patch overlays/openstack-manila/patches/controller_add_driver.yaml
-# Applied strategic merge patch common/sidecars/controller_driver_kube_rbac_proxy.yaml
 # provisioner.yaml: Loaded from common/sidecars/provisioner.yaml
 # provisioner.yaml: Added arguments [--timeout=120s --feature-gates=Topology=true]
 # Applied strategic merge patch provisioner.yaml
@@ -126,29 +125,6 @@ spec:
         volumeMounts:
         - mountPath: /plugin
           name: socket-dir
-      - args:
-        - --secure-listen-address=0.0.0.0:9202
-        - --upstream=http://127.0.0.1:8202/
-        - --tls-cert-file=/etc/tls/private/tls.crt
-        - --tls-private-key-file=/etc/tls/private/tls.key
-        - --tls-cipher-suites=${TLS_CIPHER_SUITES}
-        - --tls-min-version=${TLS_MIN_VERSION}
-        - --logtostderr=true
-        image: ${KUBE_RBAC_PROXY_IMAGE}
-        imagePullPolicy: IfNotPresent
-        name: kube-rbac-proxy-8202
-        ports:
-        - containerPort: 9202
-          name: driver-m
-          protocol: TCP
-        resources:
-          requests:
-            cpu: 10m
-            memory: 20Mi
-        terminationMessagePolicy: FallbackToLogsOnError
-        volumeMounts:
-        - mountPath: /etc/tls/private
-          name: metrics-serving-cert
       - args:
         - --csi-address=/var/lib/csi/sockets/pluginproxy/csi.sock
         - --http-endpoint=localhost:8203

--- a/assets/overlays/openstack-manila/generated/standalone/service.yaml
+++ b/assets/overlays/openstack-manila/generated/standalone/service.yaml
@@ -4,7 +4,6 @@
 # Applied strategic merge patch common/metrics/service_add_port.yaml
 # Applied strategic merge patch common/metrics/service_add_port.yaml
 # Applied strategic merge patch common/metrics/service_add_port.yaml
-# Applied strategic merge patch common/metrics/service_add_port.yaml
 # Applied strategic merge patch overlays/openstack-manila/patches/modify_service_selector.yaml
 #
 #
@@ -32,10 +31,6 @@ spec:
     port: 9205
     protocol: TCP
     targetPort: snapshotter-m
-  - name: driver-m
-    port: 9202
-    protocol: TCP
-    targetPort: driver-m
   selector:
     app: openstack-manila-csi
     component: controllerplugin

--- a/assets/overlays/openstack-manila/generated/standalone/servicemonitor.yaml
+++ b/assets/overlays/openstack-manila/generated/standalone/servicemonitor.yaml
@@ -4,7 +4,6 @@
 # Applied JSON patch common/metrics/service_monitor_add_port.yaml.patch
 # Applied JSON patch common/metrics/service_monitor_add_port.yaml.patch
 # Applied JSON patch common/metrics/service_monitor_add_port.yaml.patch
-# Applied JSON patch common/metrics/service_monitor_add_port.yaml.patch
 #
 #
 
@@ -35,14 +34,6 @@ spec:
     interval: 30s
     path: /metrics
     port: snapshotter-m
-    scheme: https
-    tlsConfig:
-      caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
-      serverName: manila-csi-driver-controller-metrics.${NAMESPACE}.svc
-  - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
-    interval: 30s
-    path: /metrics
-    port: driver-m
     scheme: https
     tlsConfig:
       caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt

--- a/assets/overlays/openstack-manila/patches/controller_add_driver.yaml
+++ b/assets/overlays/openstack-manila/patches/controller_add_driver.yaml
@@ -38,8 +38,8 @@ spec:
           image: ${DRIVER_IMAGE}
           imagePullPolicy: IfNotPresent
           args:
-            - "--provide-controller-service=true"
-            - "--provide-node-service=false"
+            - --provide-controller-service=true
+            - --provide-node-service=false
             - --v=${LOG_LEVEL}
             - --cluster-id=${CLUSTER_ID}
             - --nodeid=$(NODE_ID)

--- a/pkg/driver/openstack-manila/openstack_manila.go
+++ b/pkg/driver/openstack-manila/openstack_manila.go
@@ -56,14 +56,7 @@ func GetOpenStackManilaGeneratorConfig() *generator.CSIDriverGeneratorConfig {
 		ControllerConfig: &generator.ControlPlaneConfig{
 			DeploymentTemplateAssetName: "overlays/openstack-manila/patches/controller_add_driver.yaml",
 			LivenessProbePort:           10306,
-			MetricsPorts: []generator.MetricsPort{
-				{
-					LocalPort:           commongenerator.OpenStackManilaLoopbackMetricsPortStart,
-					InjectKubeRBACProxy: true,
-					ExposedPort:         commongenerator.OpenStackManilaExposedMetricsPortStart,
-					Name:                "driver-m",
-				},
-			},
+			// TODO(stephenfin): Expose metrics port once the driver supports it
 			SidecarLocalMetricsPortStart:   commongenerator.OpenStackManilaLoopbackMetricsPortStart + 1,
 			SidecarExposedMetricsPortStart: commongenerator.OpenStackManilaExposedMetricsPortStart + 1,
 			Sidecars: []generator.SidecarConfig{


### PR DESCRIPTION
Modify the Cinder operator so that it starts reporting controller driver metrics correctly.

Modify the Manila operator so that we stop creating a controller driver metrics proxy container, since the controller driver does not currently support reporting metrics.
