### PR TITLE
NO-JIRA: Normalize generation of driver metrics RBAC proxy sidecar

### DIFF
--- a/assets/common/sidecars/controller_driver_kube_rbac_proxy.yaml
+++ b/assets/common/sidecars/controller_driver_kube_rbac_proxy.yaml
@@ -19,7 +19,7 @@ spec:
           imagePullPolicy: IfNotPresent
           ports:
           - containerPort: ${EXPOSED_METRICS_PORT}
-            name: ${PORT_NAME}
+            name: driver-m
             protocol: TCP
           resources:
             requests:

--- a/assets/common/sidecars/controller_driver_kube_rbac_proxy.yaml
+++ b/assets/common/sidecars/controller_driver_kube_rbac_proxy.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     spec:
       containers:
-        - name: kube-rbac-proxy-${LOCAL_METRICS_PORT}
+        - name: driver-kube-rbac-proxy
           args:
           - --secure-listen-address=0.0.0.0:${EXPOSED_METRICS_PORT}
           - --upstream=http://127.0.0.1:${LOCAL_METRICS_PORT}/

--- a/assets/common/sidecars/node_driver_kube_rbac_proxy.yaml
+++ b/assets/common/sidecars/node_driver_kube_rbac_proxy.yaml
@@ -19,7 +19,7 @@ spec:
           imagePullPolicy: IfNotPresent
           ports:
           - containerPort: ${EXPOSED_METRICS_PORT}
-            name: ${PORT_NAME}
+            name: driver-m
             protocol: TCP
           resources:
             requests:

--- a/assets/common/sidecars/node_driver_kube_rbac_proxy.yaml
+++ b/assets/common/sidecars/node_driver_kube_rbac_proxy.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     spec:
       containers:
-        - name: kube-rbac-proxy-${LOCAL_METRICS_PORT}
+        - name: driver-kube-rbac-proxy
           args:
           - --secure-listen-address=0.0.0.0:${EXPOSED_METRICS_PORT}
           - --upstream=http://127.0.0.1:${LOCAL_METRICS_PORT}/

--- a/assets/overlays/aws-ebs/generated/hypershift/controller.yaml
+++ b/assets/overlays/aws-ebs/generated/hypershift/controller.yaml
@@ -145,7 +145,7 @@ spec:
         - --logtostderr=true
         image: ${KUBE_RBAC_PROXY_IMAGE}
         imagePullPolicy: IfNotPresent
-        name: kube-rbac-proxy-8201
+        name: driver-kube-rbac-proxy
         ports:
         - containerPort: 9201
           name: driver-m

--- a/assets/overlays/aws-ebs/generated/standalone/controller.yaml
+++ b/assets/overlays/aws-ebs/generated/standalone/controller.yaml
@@ -115,7 +115,7 @@ spec:
         - --logtostderr=true
         image: ${KUBE_RBAC_PROXY_IMAGE}
         imagePullPolicy: IfNotPresent
-        name: kube-rbac-proxy-8201
+        name: driver-kube-rbac-proxy
         ports:
         - containerPort: 9201
           name: driver-m

--- a/assets/overlays/aws-ebs/patches/controller_add_driver.yaml
+++ b/assets/overlays/aws-ebs/patches/controller_add_driver.yaml
@@ -60,7 +60,7 @@ spec:
             - --endpoint=$(CSI_ENDPOINT)
             - --k8s-tag-cluster-id=${CLUSTER_ID}
             - --logtostderr
-            - --http-endpoint=localhost:8201
+            - --http-endpoint=localhost:${DRIVER_METRICS_PORT}
             - --v=${LOG_LEVEL}
             - --batching=true
           env:

--- a/assets/overlays/azure-disk/generated/hypershift/controller.yaml
+++ b/assets/overlays/azure-disk/generated/hypershift/controller.yaml
@@ -139,7 +139,7 @@ spec:
         - --logtostderr=true
         image: ${KUBE_RBAC_PROXY_IMAGE}
         imagePullPolicy: IfNotPresent
-        name: kube-rbac-proxy-8201
+        name: driver-kube-rbac-proxy
         ports:
         - containerPort: 9201
           name: driver-m

--- a/assets/overlays/azure-disk/generated/hypershift/node.yaml
+++ b/assets/overlays/azure-disk/generated/hypershift/node.yaml
@@ -103,7 +103,7 @@ spec:
         - --logtostderr=true
         image: ${KUBE_RBAC_PROXY_IMAGE}
         imagePullPolicy: IfNotPresent
-        name: kube-rbac-proxy-8206
+        name: driver-kube-rbac-proxy
         ports:
         - containerPort: 9206
           name: driver-m

--- a/assets/overlays/azure-disk/generated/standalone/controller.yaml
+++ b/assets/overlays/azure-disk/generated/standalone/controller.yaml
@@ -110,7 +110,7 @@ spec:
         - --logtostderr=true
         image: ${KUBE_RBAC_PROXY_IMAGE}
         imagePullPolicy: IfNotPresent
-        name: kube-rbac-proxy-8201
+        name: driver-kube-rbac-proxy
         ports:
         - containerPort: 9201
           name: driver-m

--- a/assets/overlays/azure-disk/generated/standalone/node.yaml
+++ b/assets/overlays/azure-disk/generated/standalone/node.yaml
@@ -103,7 +103,7 @@ spec:
         - --logtostderr=true
         image: ${KUBE_RBAC_PROXY_IMAGE}
         imagePullPolicy: IfNotPresent
-        name: kube-rbac-proxy-8206
+        name: driver-kube-rbac-proxy
         ports:
         - containerPort: 9206
           name: driver-m

--- a/assets/overlays/azure-disk/patches/controller_add_driver.yaml
+++ b/assets/overlays/azure-disk/patches/controller_add_driver.yaml
@@ -17,7 +17,7 @@ spec:
           args:
             - --endpoint=$(CSI_ENDPOINT)
             - --logtostderr
-            - --metrics-address=localhost:8201
+            - --metrics-address=localhost:${DRIVER_METRICS_PORT}
             - --v=${LOG_LEVEL}
             # Use credentials provided by the azure-inject-credentials container
             - --cloud-config-secret-name=""

--- a/assets/overlays/azure-disk/patches/node_add_driver.yaml
+++ b/assets/overlays/azure-disk/patches/node_add_driver.yaml
@@ -19,7 +19,7 @@ spec:
             - --logtostderr
             - --v=${LOG_LEVEL}
             - --nodeid=$(KUBE_NODE_NAME)
-            - --metrics-address=localhost:8206
+            - --metrics-address=localhost:${DRIVER_METRICS_PORT}
             # Use credentials provided by the azure-inject-credentials container
             - --cloud-config-secret-name=""
             - --cloud-config-secret-namespace=""

--- a/assets/overlays/azure-file/generated/hypershift/controller.yaml
+++ b/assets/overlays/azure-file/generated/hypershift/controller.yaml
@@ -152,7 +152,7 @@ spec:
         - --logtostderr=true
         image: ${KUBE_RBAC_PROXY_IMAGE}
         imagePullPolicy: IfNotPresent
-        name: kube-rbac-proxy-8211
+        name: driver-kube-rbac-proxy
         ports:
         - containerPort: 9211
           name: driver-m

--- a/assets/overlays/azure-file/generated/standalone/controller.yaml
+++ b/assets/overlays/azure-file/generated/standalone/controller.yaml
@@ -116,7 +116,7 @@ spec:
         - --logtostderr=true
         image: ${KUBE_RBAC_PROXY_IMAGE}
         imagePullPolicy: IfNotPresent
-        name: kube-rbac-proxy-8211
+        name: driver-kube-rbac-proxy
         ports:
         - containerPort: 9211
           name: driver-m

--- a/assets/overlays/azure-file/patches/controller_add_driver.yaml
+++ b/assets/overlays/azure-file/patches/controller_add_driver.yaml
@@ -20,7 +20,7 @@ spec:
             - --enable-vhd=false
             - --endpoint=$(CSI_ENDPOINT)
             - --logtostderr
-            - --metrics-address=localhost:8211
+            - --metrics-address=localhost:${DRIVER_METRICS_PORT}
             - --v=${LOG_LEVEL}
             # Use credentials provided by the azure-inject-credentials container
             - --cloud-config-secret-name=""

--- a/assets/overlays/openstack-cinder/generated/hypershift/controller.yaml
+++ b/assets/overlays/openstack-cinder/generated/hypershift/controller.yaml
@@ -91,6 +91,7 @@ spec:
         - --provide-controller-service=true
         - --provide-node-service=false
         - --endpoint=$(CSI_ENDPOINT)
+        - --http-endpoint=localhost:8202
         - --cloud-config=$(CLOUD_CONFIG)
         - --cluster=${CLUSTER_ID}
         - --with-topology=$(ENABLE_TOPOLOGY)

--- a/assets/overlays/openstack-cinder/generated/hypershift/controller.yaml
+++ b/assets/overlays/openstack-cinder/generated/hypershift/controller.yaml
@@ -147,7 +147,7 @@ spec:
         - --logtostderr=true
         image: ${KUBE_RBAC_PROXY_IMAGE}
         imagePullPolicy: IfNotPresent
-        name: kube-rbac-proxy-8202
+        name: driver-kube-rbac-proxy
         ports:
         - containerPort: 9202
           name: driver-m

--- a/assets/overlays/openstack-cinder/generated/standalone/controller.yaml
+++ b/assets/overlays/openstack-cinder/generated/standalone/controller.yaml
@@ -61,6 +61,7 @@ spec:
         - --provide-controller-service=true
         - --provide-node-service=false
         - --endpoint=$(CSI_ENDPOINT)
+        - --http-endpoint=localhost:8202
         - --cloud-config=$(CLOUD_CONFIG)
         - --cluster=${CLUSTER_ID}
         - --with-topology=$(ENABLE_TOPOLOGY)

--- a/assets/overlays/openstack-cinder/generated/standalone/controller.yaml
+++ b/assets/overlays/openstack-cinder/generated/standalone/controller.yaml
@@ -117,7 +117,7 @@ spec:
         - --logtostderr=true
         image: ${KUBE_RBAC_PROXY_IMAGE}
         imagePullPolicy: IfNotPresent
-        name: kube-rbac-proxy-8202
+        name: driver-kube-rbac-proxy
         ports:
         - containerPort: 9202
           name: driver-m

--- a/assets/overlays/openstack-cinder/patches/controller_add_driver.yaml
+++ b/assets/overlays/openstack-cinder/patches/controller_add_driver.yaml
@@ -38,6 +38,9 @@ spec:
             - "--provide-controller-service=true"
             - "--provide-node-service=false"
             - "--endpoint=$(CSI_ENDPOINT)"
+            # this is the generated value of the LOCAL_METRICS_PORT variable
+            # we hardcode it because we don't currently support substitution
+            - "--http-endpoint=localhost:8202"
             - "--cloud-config=$(CLOUD_CONFIG)"
             - "--cluster=${CLUSTER_ID}"
             - "--with-topology=$(ENABLE_TOPOLOGY)"

--- a/assets/overlays/openstack-cinder/patches/controller_add_driver.yaml
+++ b/assets/overlays/openstack-cinder/patches/controller_add_driver.yaml
@@ -35,16 +35,14 @@ spec:
           imagePullPolicy: IfNotPresent
           args:
             - /bin/cinder-csi-plugin
-            - "--provide-controller-service=true"
-            - "--provide-node-service=false"
-            - "--endpoint=$(CSI_ENDPOINT)"
-            # this is the generated value of the LOCAL_METRICS_PORT variable
-            # we hardcode it because we don't currently support substitution
-            - "--http-endpoint=localhost:8202"
-            - "--cloud-config=$(CLOUD_CONFIG)"
-            - "--cluster=${CLUSTER_ID}"
-            - "--with-topology=$(ENABLE_TOPOLOGY)"
-            - "--v=${LOG_LEVEL}"
+            - --provide-controller-service=true
+            - --provide-node-service=false
+            - --endpoint=$(CSI_ENDPOINT)
+            - --http-endpoint=localhost:${DRIVER_METRICS_PORT}
+            - --cloud-config=$(CLOUD_CONFIG)
+            - --cluster=${CLUSTER_ID}
+            - --with-topology=$(ENABLE_TOPOLOGY)
+            - --v=${LOG_LEVEL}
           env:
             - name: CSI_ENDPOINT
               value: unix://csi/csi.sock

--- a/assets/overlays/openstack-manila/generated/hypershift/controller.yaml
+++ b/assets/overlays/openstack-manila/generated/hypershift/controller.yaml
@@ -2,7 +2,6 @@
 #
 # Loaded from base/controller.yaml
 # Applied strategic merge patch overlays/openstack-manila/patches/controller_add_driver.yaml
-# Applied strategic merge patch common/sidecars/controller_driver_kube_rbac_proxy.yaml
 # provisioner.yaml: Loaded from common/sidecars/provisioner.yaml
 # provisioner.yaml: Added arguments [--timeout=120s --feature-gates=Topology=true]
 # provisioner.yaml: Applied JSON patch common/hypershift/sidecar_add_kubeconfig.yaml.patch
@@ -156,29 +155,6 @@ spec:
         volumeMounts:
         - mountPath: /plugin
           name: socket-dir
-      - args:
-        - --secure-listen-address=0.0.0.0:9202
-        - --upstream=http://127.0.0.1:8202/
-        - --tls-cert-file=/etc/tls/private/tls.crt
-        - --tls-private-key-file=/etc/tls/private/tls.key
-        - --tls-cipher-suites=${TLS_CIPHER_SUITES}
-        - --tls-min-version=${TLS_MIN_VERSION}
-        - --logtostderr=true
-        image: ${KUBE_RBAC_PROXY_IMAGE}
-        imagePullPolicy: IfNotPresent
-        name: kube-rbac-proxy-8202
-        ports:
-        - containerPort: 9202
-          name: driver-m
-          protocol: TCP
-        resources:
-          requests:
-            cpu: 10m
-            memory: 20Mi
-        terminationMessagePolicy: FallbackToLogsOnError
-        volumeMounts:
-        - mountPath: /etc/tls/private
-          name: metrics-serving-cert
       - args:
         - --csi-address=/var/lib/csi/sockets/pluginproxy/csi.sock
         - --http-endpoint=localhost:8203

--- a/assets/overlays/openstack-manila/generated/hypershift/service.yaml
+++ b/assets/overlays/openstack-manila/generated/hypershift/service.yaml
@@ -4,7 +4,6 @@
 # Applied strategic merge patch common/metrics/service_add_port.yaml
 # Applied strategic merge patch common/metrics/service_add_port.yaml
 # Applied strategic merge patch common/metrics/service_add_port.yaml
-# Applied strategic merge patch common/metrics/service_add_port.yaml
 # Applied strategic merge patch overlays/openstack-manila/patches/modify_service_selector.yaml
 #
 #
@@ -32,10 +31,6 @@ spec:
     port: 9205
     protocol: TCP
     targetPort: snapshotter-m
-  - name: driver-m
-    port: 9202
-    protocol: TCP
-    targetPort: driver-m
   selector:
     app: openstack-manila-csi
     component: controllerplugin

--- a/assets/overlays/openstack-manila/generated/standalone/controller.yaml
+++ b/assets/overlays/openstack-manila/generated/standalone/controller.yaml
@@ -2,7 +2,6 @@
 #
 # Loaded from base/controller.yaml
 # Applied strategic merge patch overlays/openstack-manila/patches/controller_add_driver.yaml
-# Applied strategic merge patch common/sidecars/controller_driver_kube_rbac_proxy.yaml
 # provisioner.yaml: Loaded from common/sidecars/provisioner.yaml
 # provisioner.yaml: Added arguments [--timeout=120s --feature-gates=Topology=true]
 # Applied strategic merge patch provisioner.yaml
@@ -126,29 +125,6 @@ spec:
         volumeMounts:
         - mountPath: /plugin
           name: socket-dir
-      - args:
-        - --secure-listen-address=0.0.0.0:9202
-        - --upstream=http://127.0.0.1:8202/
-        - --tls-cert-file=/etc/tls/private/tls.crt
-        - --tls-private-key-file=/etc/tls/private/tls.key
-        - --tls-cipher-suites=${TLS_CIPHER_SUITES}
-        - --tls-min-version=${TLS_MIN_VERSION}
-        - --logtostderr=true
-        image: ${KUBE_RBAC_PROXY_IMAGE}
-        imagePullPolicy: IfNotPresent
-        name: kube-rbac-proxy-8202
-        ports:
-        - containerPort: 9202
-          name: driver-m
-          protocol: TCP
-        resources:
-          requests:
-            cpu: 10m
-            memory: 20Mi
-        terminationMessagePolicy: FallbackToLogsOnError
-        volumeMounts:
-        - mountPath: /etc/tls/private
-          name: metrics-serving-cert
       - args:
         - --csi-address=/var/lib/csi/sockets/pluginproxy/csi.sock
         - --http-endpoint=localhost:8203

--- a/assets/overlays/openstack-manila/generated/standalone/service.yaml
+++ b/assets/overlays/openstack-manila/generated/standalone/service.yaml
@@ -4,7 +4,6 @@
 # Applied strategic merge patch common/metrics/service_add_port.yaml
 # Applied strategic merge patch common/metrics/service_add_port.yaml
 # Applied strategic merge patch common/metrics/service_add_port.yaml
-# Applied strategic merge patch common/metrics/service_add_port.yaml
 # Applied strategic merge patch overlays/openstack-manila/patches/modify_service_selector.yaml
 #
 #
@@ -32,10 +31,6 @@ spec:
     port: 9205
     protocol: TCP
     targetPort: snapshotter-m
-  - name: driver-m
-    port: 9202
-    protocol: TCP
-    targetPort: driver-m
   selector:
     app: openstack-manila-csi
     component: controllerplugin

--- a/assets/overlays/openstack-manila/generated/standalone/servicemonitor.yaml
+++ b/assets/overlays/openstack-manila/generated/standalone/servicemonitor.yaml
@@ -4,7 +4,6 @@
 # Applied JSON patch common/metrics/service_monitor_add_port.yaml.patch
 # Applied JSON patch common/metrics/service_monitor_add_port.yaml.patch
 # Applied JSON patch common/metrics/service_monitor_add_port.yaml.patch
-# Applied JSON patch common/metrics/service_monitor_add_port.yaml.patch
 #
 #
 
@@ -35,14 +34,6 @@ spec:
     interval: 30s
     path: /metrics
     port: snapshotter-m
-    scheme: https
-    tlsConfig:
-      caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
-      serverName: manila-csi-driver-controller-metrics.${NAMESPACE}.svc
-  - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
-    interval: 30s
-    path: /metrics
-    port: driver-m
     scheme: https
     tlsConfig:
       caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt

--- a/assets/overlays/openstack-manila/patches/controller_add_driver.yaml
+++ b/assets/overlays/openstack-manila/patches/controller_add_driver.yaml
@@ -38,8 +38,8 @@ spec:
           image: ${DRIVER_IMAGE}
           imagePullPolicy: IfNotPresent
           args:
-            - "--provide-controller-service=true"
-            - "--provide-node-service=false"
+            - --provide-controller-service=true
+            - --provide-node-service=false
             - --v=${LOG_LEVEL}
             - --cluster-id=${CLUSTER_ID}
             - --nodeid=$(NODE_ID)

--- a/assets/overlays/samba/generated/standalone/controller.yaml
+++ b/assets/overlays/samba/generated/standalone/controller.yaml
@@ -93,7 +93,7 @@ spec:
         - --logtostderr=true
         image: ${KUBE_RBAC_PROXY_IMAGE}
         imagePullPolicy: IfNotPresent
-        name: kube-rbac-proxy-8221
+        name: driver-kube-rbac-proxy
         ports:
         - containerPort: 9221
           name: driver-m

--- a/assets/overlays/samba/patches/controller_add_driver.yaml
+++ b/assets/overlays/samba/patches/controller_add_driver.yaml
@@ -12,7 +12,7 @@ spec:
           imagePullPolicy: IfNotPresent
           args:
             - --endpoint=$(CSI_ENDPOINT)
-            - --metrics-address=localhost:8221
+            - --metrics-address=localhost:${DRIVER_METRICS_PORT}
             - --v=${LOG_LEVEL}
           ports:
             - containerPort: 10307

--- a/pkg/driver/aws-ebs/aws_ebs.go
+++ b/pkg/driver/aws-ebs/aws_ebs.go
@@ -55,14 +55,10 @@ func GetAWSEBSGeneratorConfig() *generator.CSIDriverGeneratorConfig {
 		OutputDir:        generatedAssetBase,
 
 		ControllerConfig: &generator.ControlPlaneConfig{
-			DeploymentTemplateAssetName: "overlays/aws-ebs/patches/controller_add_driver.yaml",
-			LivenessProbePort:           10301,
-			MetricsPort: &generator.MetricsPort{
-				LocalPort:           commongenerator.AWSEBSLoopbackMetricsPortStart,
-				InjectKubeRBACProxy: true,
-				ExposedPort:         commongenerator.AWSEBSExposedMetricsPortStart,
-				Name:                "driver-m",
-			},
+			DeploymentTemplateAssetName:    "overlays/aws-ebs/patches/controller_add_driver.yaml",
+			LivenessProbePort:              10301,
+			LocalMetricsPort:               commongenerator.AWSEBSLoopbackMetricsPortStart,
+			ExposedMetricsPort:             commongenerator.AWSEBSExposedMetricsPortStart,
 			SidecarLocalMetricsPortStart:   commongenerator.AWSEBSLoopbackMetricsPortStart + 1,
 			SidecarExposedMetricsPortStart: commongenerator.AWSEBSExposedMetricsPortStart + 1,
 			Sidecars: []generator.SidecarConfig{

--- a/pkg/driver/aws-ebs/aws_ebs.go
+++ b/pkg/driver/aws-ebs/aws_ebs.go
@@ -57,13 +57,11 @@ func GetAWSEBSGeneratorConfig() *generator.CSIDriverGeneratorConfig {
 		ControllerConfig: &generator.ControlPlaneConfig{
 			DeploymentTemplateAssetName: "overlays/aws-ebs/patches/controller_add_driver.yaml",
 			LivenessProbePort:           10301,
-			MetricsPorts: []generator.MetricsPort{
-				{
-					LocalPort:           commongenerator.AWSEBSLoopbackMetricsPortStart,
-					InjectKubeRBACProxy: true,
-					ExposedPort:         commongenerator.AWSEBSExposedMetricsPortStart,
-					Name:                "driver-m",
-				},
+			MetricsPort: &generator.MetricsPort{
+				LocalPort:           commongenerator.AWSEBSLoopbackMetricsPortStart,
+				InjectKubeRBACProxy: true,
+				ExposedPort:         commongenerator.AWSEBSExposedMetricsPortStart,
+				Name:                "driver-m",
 			},
 			SidecarLocalMetricsPortStart:   commongenerator.AWSEBSLoopbackMetricsPortStart + 1,
 			SidecarExposedMetricsPortStart: commongenerator.AWSEBSExposedMetricsPortStart + 1,

--- a/pkg/driver/azure-disk/azure_disk.go
+++ b/pkg/driver/azure-disk/azure_disk.go
@@ -74,13 +74,11 @@ func GetAzureDiskGeneratorConfig() *generator.CSIDriverGeneratorConfig {
 		ControllerConfig: &generator.ControlPlaneConfig{
 			DeploymentTemplateAssetName: "overlays/azure-disk/patches/controller_add_driver.yaml",
 			LivenessProbePort:           10301,
-			MetricsPorts: []generator.MetricsPort{
-				{
-					LocalPort:           commongenerator.AzureDiskControllerLoopbackMetricsPortStart,
-					InjectKubeRBACProxy: true,
-					ExposedPort:         commongenerator.AzureDiskControllerExposedMetricsPortStart,
-					Name:                "driver-m",
-				},
+			MetricsPort: &generator.MetricsPort{
+				LocalPort:           commongenerator.AzureDiskControllerLoopbackMetricsPortStart,
+				InjectKubeRBACProxy: true,
+				ExposedPort:         commongenerator.AzureDiskControllerExposedMetricsPortStart,
+				Name:                "driver-m",
 			},
 			SidecarLocalMetricsPortStart:   commongenerator.AzureDiskControllerLoopbackMetricsPortStart + 1,
 			SidecarExposedMetricsPortStart: commongenerator.AzureDiskControllerExposedMetricsPortStart + 1,
@@ -122,13 +120,11 @@ func GetAzureDiskGeneratorConfig() *generator.CSIDriverGeneratorConfig {
 
 		GuestConfig: &generator.GuestConfig{
 			DaemonSetTemplateAssetName: "overlays/azure-disk/patches/node_add_driver.yaml",
-			MetricsPorts: []generator.MetricsPort{
-				{
-					LocalPort:           commongenerator.AzureDiskNodeLoopbackMetricsPortStart,
-					ExposedPort:         commongenerator.AzureDiskNodeExposedMetricsPortStart,
-					Name:                "driver-m",
-					InjectKubeRBACProxy: true,
-				},
+			MetricsPort: &generator.MetricsPort{
+				LocalPort:           commongenerator.AzureDiskNodeLoopbackMetricsPortStart,
+				InjectKubeRBACProxy: true,
+				ExposedPort:         commongenerator.AzureDiskNodeExposedMetricsPortStart,
+				Name:                "driver-m",
 			},
 			LivenessProbePort: 10300,
 			// 10303 port is taken by azurefile stuff and hence we must use 10304 here

--- a/pkg/driver/azure-disk/azure_disk.go
+++ b/pkg/driver/azure-disk/azure_disk.go
@@ -72,14 +72,10 @@ func GetAzureDiskGeneratorConfig() *generator.CSIDriverGeneratorConfig {
 		OutputDir:        generatedAssetBase,
 
 		ControllerConfig: &generator.ControlPlaneConfig{
-			DeploymentTemplateAssetName: "overlays/azure-disk/patches/controller_add_driver.yaml",
-			LivenessProbePort:           10301,
-			MetricsPort: &generator.MetricsPort{
-				LocalPort:           commongenerator.AzureDiskControllerLoopbackMetricsPortStart,
-				InjectKubeRBACProxy: true,
-				ExposedPort:         commongenerator.AzureDiskControllerExposedMetricsPortStart,
-				Name:                "driver-m",
-			},
+			DeploymentTemplateAssetName:    "overlays/azure-disk/patches/controller_add_driver.yaml",
+			LivenessProbePort:              10301,
+			LocalMetricsPort:               commongenerator.AzureDiskControllerLoopbackMetricsPortStart,
+			ExposedMetricsPort:             commongenerator.AzureDiskControllerExposedMetricsPortStart,
 			SidecarLocalMetricsPortStart:   commongenerator.AzureDiskControllerLoopbackMetricsPortStart + 1,
 			SidecarExposedMetricsPortStart: commongenerator.AzureDiskControllerExposedMetricsPortStart + 1,
 			Sidecars: []generator.SidecarConfig{
@@ -120,13 +116,9 @@ func GetAzureDiskGeneratorConfig() *generator.CSIDriverGeneratorConfig {
 
 		GuestConfig: &generator.GuestConfig{
 			DaemonSetTemplateAssetName: "overlays/azure-disk/patches/node_add_driver.yaml",
-			MetricsPort: &generator.MetricsPort{
-				LocalPort:           commongenerator.AzureDiskNodeLoopbackMetricsPortStart,
-				InjectKubeRBACProxy: true,
-				ExposedPort:         commongenerator.AzureDiskNodeExposedMetricsPortStart,
-				Name:                "driver-m",
-			},
-			LivenessProbePort: 10300,
+			LocalMetricsPort:           commongenerator.AzureDiskNodeLoopbackMetricsPortStart,
+			ExposedMetricsPort:         commongenerator.AzureDiskNodeExposedMetricsPortStart,
+			LivenessProbePort:          10300,
 			// 10303 port is taken by azurefile stuff and hence we must use 10304 here
 			NodeRegistrarHealthCheckPort: 10304,
 			Sidecars: []generator.SidecarConfig{

--- a/pkg/driver/azure-file/azure_file.go
+++ b/pkg/driver/azure-file/azure_file.go
@@ -58,13 +58,11 @@ func GetAzureFileGeneratorConfig() *generator.CSIDriverGeneratorConfig {
 		ControllerConfig: &generator.ControlPlaneConfig{
 			DeploymentTemplateAssetName: "overlays/azure-file/patches/controller_add_driver.yaml",
 			LivenessProbePort:           10303,
-			MetricsPorts: []generator.MetricsPort{
-				{
-					LocalPort:           commongenerator.AzureFileLoopbackMetricsPortStart,
-					InjectKubeRBACProxy: true,
-					ExposedPort:         commongenerator.AzureFileExposedMetricsPortStart,
-					Name:                "driver-m",
-				},
+			MetricsPort: &generator.MetricsPort{
+				LocalPort:           commongenerator.AzureFileLoopbackMetricsPortStart,
+				InjectKubeRBACProxy: true,
+				ExposedPort:         commongenerator.AzureFileExposedMetricsPortStart,
+				Name:                "driver-m",
 			},
 			SidecarLocalMetricsPortStart:   commongenerator.AzureFileLoopbackMetricsPortStart + 1,
 			SidecarExposedMetricsPortStart: commongenerator.AzureFileExposedMetricsPortStart + 1,

--- a/pkg/driver/azure-file/azure_file.go
+++ b/pkg/driver/azure-file/azure_file.go
@@ -56,14 +56,10 @@ func GetAzureFileGeneratorConfig() *generator.CSIDriverGeneratorConfig {
 		OutputDir:        generatedAssetBase,
 
 		ControllerConfig: &generator.ControlPlaneConfig{
-			DeploymentTemplateAssetName: "overlays/azure-file/patches/controller_add_driver.yaml",
-			LivenessProbePort:           10303,
-			MetricsPort: &generator.MetricsPort{
-				LocalPort:           commongenerator.AzureFileLoopbackMetricsPortStart,
-				InjectKubeRBACProxy: true,
-				ExposedPort:         commongenerator.AzureFileExposedMetricsPortStart,
-				Name:                "driver-m",
-			},
+			DeploymentTemplateAssetName:    "overlays/azure-file/patches/controller_add_driver.yaml",
+			LivenessProbePort:              10303,
+			LocalMetricsPort:               commongenerator.AzureFileLoopbackMetricsPortStart,
+			ExposedMetricsPort:             commongenerator.AzureFileExposedMetricsPortStart,
 			SidecarLocalMetricsPortStart:   commongenerator.AzureFileLoopbackMetricsPortStart + 1,
 			SidecarExposedMetricsPortStart: commongenerator.AzureFileExposedMetricsPortStart + 1,
 			Sidecars: []generator.SidecarConfig{

--- a/pkg/driver/common/operator/test_manifests/aws_ebs_controller_hypershift.yaml
+++ b/pkg/driver/common/operator/test_manifests/aws_ebs_controller_hypershift.yaml
@@ -273,7 +273,7 @@ spec:
           name: metrics-serving-cert
       - args:
         - --csi-address=/var/lib/csi/sockets/pluginproxy/csi.sock
-        - --metrics-address=localhost:8206
+        - --metrics-address=localhost:${DRIVER_METRICS_PORT}
         - --leader-election
         - --leader-election-lease-duration=${LEADER_ELECTION_LEASE_DURATION}
         - --leader-election-renew-deadline=${LEADER_ELECTION_RENEW_DEADLINE}

--- a/pkg/driver/openstack-cinder/openstack_cinder.go
+++ b/pkg/driver/openstack-cinder/openstack_cinder.go
@@ -38,14 +38,10 @@ func GetOpenStackCinderGeneratorConfig() *generator.CSIDriverGeneratorConfig {
 		OutputDir:        generatedAssetBase,
 
 		ControllerConfig: &generator.ControlPlaneConfig{
-			DeploymentTemplateAssetName: "overlays/openstack-cinder/patches/controller_add_driver.yaml",
-			LivenessProbePort:           10301,
-			MetricsPort: &generator.MetricsPort{
-				LocalPort:           commongenerator.OpenStackCinderLoopbackMetricsPortStart,
-				InjectKubeRBACProxy: true,
-				ExposedPort:         commongenerator.OpenStackCinderExposedMetricsPortStart,
-				Name:                "driver-m",
-			},
+			DeploymentTemplateAssetName:    "overlays/openstack-cinder/patches/controller_add_driver.yaml",
+			LivenessProbePort:              10301,
+			LocalMetricsPort:               commongenerator.OpenStackCinderLoopbackMetricsPortStart,
+			ExposedMetricsPort:             commongenerator.OpenStackCinderExposedMetricsPortStart,
 			SidecarLocalMetricsPortStart:   commongenerator.OpenStackCinderLoopbackMetricsPortStart + 1,
 			SidecarExposedMetricsPortStart: commongenerator.OpenStackCinderExposedMetricsPortStart + 1,
 			Sidecars: []generator.SidecarConfig{

--- a/pkg/driver/openstack-cinder/openstack_cinder.go
+++ b/pkg/driver/openstack-cinder/openstack_cinder.go
@@ -40,13 +40,11 @@ func GetOpenStackCinderGeneratorConfig() *generator.CSIDriverGeneratorConfig {
 		ControllerConfig: &generator.ControlPlaneConfig{
 			DeploymentTemplateAssetName: "overlays/openstack-cinder/patches/controller_add_driver.yaml",
 			LivenessProbePort:           10301,
-			MetricsPorts: []generator.MetricsPort{
-				{
-					LocalPort:           commongenerator.OpenStackCinderLoopbackMetricsPortStart,
-					InjectKubeRBACProxy: true,
-					ExposedPort:         commongenerator.OpenStackCinderExposedMetricsPortStart,
-					Name:                "driver-m",
-				},
+			MetricsPort: &generator.MetricsPort{
+				LocalPort:           commongenerator.OpenStackCinderLoopbackMetricsPortStart,
+				InjectKubeRBACProxy: true,
+				ExposedPort:         commongenerator.OpenStackCinderExposedMetricsPortStart,
+				Name:                "driver-m",
 			},
 			SidecarLocalMetricsPortStart:   commongenerator.OpenStackCinderLoopbackMetricsPortStart + 1,
 			SidecarExposedMetricsPortStart: commongenerator.OpenStackCinderExposedMetricsPortStart + 1,

--- a/pkg/driver/openstack-manila/openstack_manila.go
+++ b/pkg/driver/openstack-manila/openstack_manila.go
@@ -56,14 +56,7 @@ func GetOpenStackManilaGeneratorConfig() *generator.CSIDriverGeneratorConfig {
 		ControllerConfig: &generator.ControlPlaneConfig{
 			DeploymentTemplateAssetName: "overlays/openstack-manila/patches/controller_add_driver.yaml",
 			LivenessProbePort:           10306,
-			MetricsPorts: []generator.MetricsPort{
-				{
-					LocalPort:           commongenerator.OpenStackManilaLoopbackMetricsPortStart,
-					InjectKubeRBACProxy: true,
-					ExposedPort:         commongenerator.OpenStackManilaExposedMetricsPortStart,
-					Name:                "driver-m",
-				},
-			},
+			// TODO(stephenfin): Expose metrics port once the driver supports it
 			SidecarLocalMetricsPortStart:   commongenerator.OpenStackManilaLoopbackMetricsPortStart + 1,
 			SidecarExposedMetricsPortStart: commongenerator.OpenStackManilaExposedMetricsPortStart + 1,
 			Sidecars: []generator.SidecarConfig{

--- a/pkg/driver/samba/samba.go
+++ b/pkg/driver/samba/samba.go
@@ -28,14 +28,10 @@ func GetSambaGeneratorConfig() *generator.CSIDriverGeneratorConfig {
 		OutputDir:        generatedAssetBase,
 
 		ControllerConfig: &generator.ControlPlaneConfig{
-			DeploymentTemplateAssetName: "overlays/samba/patches/controller_add_driver.yaml",
-			LivenessProbePort:           10307,
-			MetricsPort: &generator.MetricsPort{
-				LocalPort:           commongenerator.SambaLoopbackMetricsPortStart,
-				InjectKubeRBACProxy: true,
-				ExposedPort:         commongenerator.SambaExposedMetricsPortStart,
-				Name:                "driver-m",
-			},
+			DeploymentTemplateAssetName:    "overlays/samba/patches/controller_add_driver.yaml",
+			LivenessProbePort:              10307,
+			LocalMetricsPort:               commongenerator.SambaLoopbackMetricsPortStart,
+			ExposedMetricsPort:             commongenerator.SambaExposedMetricsPortStart,
 			SidecarLocalMetricsPortStart:   commongenerator.SambaLoopbackMetricsPortStart + 1,
 			SidecarExposedMetricsPortStart: commongenerator.SambaExposedMetricsPortStart + 1,
 			Sidecars: []generator.SidecarConfig{

--- a/pkg/driver/samba/samba.go
+++ b/pkg/driver/samba/samba.go
@@ -30,13 +30,11 @@ func GetSambaGeneratorConfig() *generator.CSIDriverGeneratorConfig {
 		ControllerConfig: &generator.ControlPlaneConfig{
 			DeploymentTemplateAssetName: "overlays/samba/patches/controller_add_driver.yaml",
 			LivenessProbePort:           10307,
-			MetricsPorts: []generator.MetricsPort{
-				{
-					LocalPort:           commongenerator.SambaLoopbackMetricsPortStart,
-					InjectKubeRBACProxy: true,
-					ExposedPort:         commongenerator.SambaExposedMetricsPortStart,
-					Name:                "driver-m",
-				},
+			MetricsPort: &generator.MetricsPort{
+				LocalPort:           commongenerator.SambaLoopbackMetricsPortStart,
+				InjectKubeRBACProxy: true,
+				ExposedPort:         commongenerator.SambaExposedMetricsPortStart,
+				Name:                "driver-m",
 			},
 			SidecarLocalMetricsPortStart:   commongenerator.SambaLoopbackMetricsPortStart + 1,
 			SidecarExposedMetricsPortStart: commongenerator.SambaExposedMetricsPortStart + 1,

--- a/pkg/generator/asset_generator.go
+++ b/pkg/generator/asset_generator.go
@@ -102,26 +102,25 @@ func (gen *AssetGenerator) patchController() error {
 	return nil
 }
 
-// Inject kube-rbac-proxy container for all metrics ports into yamlFile. The yamlFile can be a Deployment or a
+// Inject kube-rbac-proxy container for the metrics port into yamlFile. The yamlFile can be a Deployment or a
 // DaemonSet. proxyPatchFile is the path to Deployment / DaemonSet patch file that adds the proxy container.
-func (gen *AssetGenerator) addDriverRBACProxyContainers(yamlFile *YAMLWithHistory, proxyPatchFile string, metricPorts []MetricsPort, baseExtraReplacements []string) error {
-	for i := 0; i < len(metricPorts); i++ {
-		port := metricPorts[i]
-		if !port.InjectKubeRBACProxy {
-			continue
-		}
-		extraReplacements := append([]string{}, baseExtraReplacements...) // Poor man's copy of the array.
-		extraReplacements = append(extraReplacements,
-			"${LOCAL_METRICS_PORT}", strconv.Itoa(int(port.LocalPort)),
-			"${EXPOSED_METRICS_PORT}", strconv.Itoa(int(port.ExposedPort)),
-			"${PORT_NAME}", port.Name,
-		)
-		port.LocalPort++
-		port.ExposedPort++
-		err := gen.applyAssetPatch(yamlFile, proxyPatchFile, extraReplacements)
-		if err != nil {
-			return err
-		}
+func (gen *AssetGenerator) addDriverRBACProxyContainers(yamlFile *YAMLWithHistory, proxyPatchFile string, metricsPort *MetricsPort, baseExtraReplacements []string) error {
+	if metricsPort == nil {
+		return nil
+	}
+
+	if !metricsPort.InjectKubeRBACProxy {
+		return nil
+	}
+	extraReplacements := append([]string{}, baseExtraReplacements...) // Poor man's copy of the array.
+	extraReplacements = append(extraReplacements,
+		"${LOCAL_METRICS_PORT}", strconv.Itoa(int(metricsPort.LocalPort)),
+		"${EXPOSED_METRICS_PORT}", strconv.Itoa(int(metricsPort.ExposedPort)),
+		"${PORT_NAME}", metricsPort.Name,
+	)
+	err := gen.applyAssetPatch(yamlFile, proxyPatchFile, extraReplacements)
+	if err != nil {
+		return err
 	}
 	return nil
 }
@@ -143,7 +142,7 @@ func (gen *AssetGenerator) generateDeployment() error {
 		baseExtraReplacements = append(baseExtraReplacements, "${LIVENESS_PROBE_PORT}", strconv.Itoa(int(ctrlCfg.LivenessProbePort)))
 	}
 
-	err = gen.addDriverRBACProxyContainers(deploymentYAML, "common/sidecars/controller_driver_kube_rbac_proxy.yaml", ctrlCfg.MetricsPorts, baseExtraReplacements)
+	err = gen.addDriverRBACProxyContainers(deploymentYAML, "common/sidecars/controller_driver_kube_rbac_proxy.yaml", ctrlCfg.MetricsPort, baseExtraReplacements)
 	if err != nil {
 		return err
 	}
@@ -170,25 +169,26 @@ func (gen *AssetGenerator) generateDeployment() error {
 	return nil
 }
 
-// Add driver's MetricsPorts to the metrics Service and ServiceMonitor.
-func (gen *AssetGenerator) generateDriverMetricsService(serviceYAML, serviceMonitorYAML *YAMLWithHistory, metricsPorts []MetricsPort, servicePrefix string) error {
-	for i := 0; i < len(metricsPorts); i++ {
-		port := metricsPorts[i]
-		extraReplacements := []string{
-			"${EXPOSED_METRICS_PORT}", strconv.Itoa(int(port.ExposedPort)),
-			"${LOCAL_METRICS_PORT}", strconv.Itoa(int(port.LocalPort)),
-			"${PORT_NAME}", port.Name,
-			"${SERVICE_PREFIX}", servicePrefix,
-		}
-		var err error
-		err = gen.applyAssetPatch(serviceYAML, "common/metrics/service_add_port.yaml", extraReplacements)
-		if err != nil {
-			return err
-		}
-		err = gen.applyAssetPatch(serviceMonitorYAML, "common/metrics/service_monitor_add_port.yaml.patch", extraReplacements)
-		if err != nil {
-			return err
-		}
+// Add driver's MetricsPort to the metrics Service and ServiceMonitor.
+func (gen *AssetGenerator) generateDriverMetricsService(serviceYAML, serviceMonitorYAML *YAMLWithHistory, metricsPort *MetricsPort, servicePrefix string) error {
+	if metricsPort == nil {
+		return nil
+	}
+
+	extraReplacements := []string{
+		"${EXPOSED_METRICS_PORT}", strconv.Itoa(int(metricsPort.ExposedPort)),
+		"${LOCAL_METRICS_PORT}", strconv.Itoa(int(metricsPort.LocalPort)),
+		"${PORT_NAME}", metricsPort.Name,
+		"${SERVICE_PREFIX}", servicePrefix,
+	}
+	var err error
+	err = gen.applyAssetPatch(serviceYAML, "common/metrics/service_add_port.yaml", extraReplacements)
+	if err != nil {
+		return err
+	}
+	err = gen.applyAssetPatch(serviceMonitorYAML, "common/metrics/service_monitor_add_port.yaml.patch", extraReplacements)
+	if err != nil {
+		return err
 	}
 	return nil
 }
@@ -232,7 +232,7 @@ func (gen *AssetGenerator) generateControllerMonitoringService() error {
 	if err := gen.generateSidecarMetricsServices(serviceYAML, serviceMonitorYAML, int(ctrlCfg.SidecarLocalMetricsPortStart), int(ctrlCfg.SidecarExposedMetricsPortStart), ctrlCfg.Sidecars, "controller"); err != nil {
 		return err
 	}
-	if err := gen.generateDriverMetricsService(serviceYAML, serviceMonitorYAML, ctrlCfg.MetricsPorts, "controller"); err != nil {
+	if err := gen.generateDriverMetricsService(serviceYAML, serviceMonitorYAML, ctrlCfg.MetricsPort, "controller"); err != nil {
 		return err
 	}
 
@@ -292,7 +292,7 @@ func (gen *AssetGenerator) generateDaemonSet() error {
 		return err
 	}
 
-	err = gen.addDriverRBACProxyContainers(dsYAML, "common/sidecars/node_driver_kube_rbac_proxy.yaml", cfg.MetricsPorts, extraReplacements)
+	err = gen.addDriverRBACProxyContainers(dsYAML, "common/sidecars/node_driver_kube_rbac_proxy.yaml", cfg.MetricsPort, extraReplacements)
 	if err != nil {
 		return err
 	}
@@ -311,7 +311,7 @@ func (gen *AssetGenerator) generateDaemonSet() error {
 func (gen *AssetGenerator) generateGuestMonitoringService() error {
 	cfg := gen.operatorConfig.GuestConfig
 
-	if len(cfg.MetricsPorts) == 0 {
+	if cfg.MetricsPort == nil {
 		// Do not add metrics service if driver does not expose any metrics.
 		// There is no node-level sidecar that would export one.
 		return nil
@@ -319,7 +319,7 @@ func (gen *AssetGenerator) generateGuestMonitoringService() error {
 	serviceYAML := gen.mustReadBaseAsset("base/node_metrics_service.yaml", nil)
 	serviceMonitorYAML := gen.mustReadBaseAsset("base/node_metrics_servicemonitor.yaml", nil)
 
-	err := gen.generateDriverMetricsService(serviceYAML, serviceMonitorYAML, cfg.MetricsPorts, "node")
+	err := gen.generateDriverMetricsService(serviceYAML, serviceMonitorYAML, cfg.MetricsPort, "node")
 	if err != nil {
 		return err
 	}

--- a/pkg/generator/types.go
+++ b/pkg/generator/types.go
@@ -55,9 +55,9 @@ type ControlPlaneConfig struct {
 	// The Deployment will be available as "controller.yaml" in the generated assets and can be patched
 	// by
 	DeploymentTemplateAssetName string
-	// List of metric ports exposed by the driver itself and any containers defined in DeploymentTemplateAssetName.
+	// Metric port exposed by the driver itself.
 	// Sidecar metrics ports are not included here, they will be added dynamically from sidecar config below.
-	MetricsPorts []MetricsPort
+	MetricsPort *MetricsPort
 	// Liveness probe TCP port number exposed by the driver itself, i.e. by DeploymentTemplateAssetName.
 	// It will be injected to liveness probe sidecar automatically.
 	LivenessProbePort uint16
@@ -114,8 +114,8 @@ type SidecarConfig struct {
 type GuestConfig struct {
 	// Name of the template asset that contains DaemonSet of the guest components.
 	DaemonSetTemplateAssetName string
-	// List of metric ports exposed by the driver itself and any containers defined in DeploymentTemplateAssetName.
-	MetricsPorts []MetricsPort
+	// Metric ports exposed by the driver itself.
+	MetricsPort *MetricsPort
 	// Liveness probe TCP port number exposed by the driver itself, i.e. by DaemonSetTemplateAssetName.
 	LivenessProbePort uint16
 	// port where node-registrar will expose health check endpoint

--- a/pkg/generator/types.go
+++ b/pkg/generator/types.go
@@ -55,14 +55,15 @@ type ControlPlaneConfig struct {
 	// The Deployment will be available as "controller.yaml" in the generated assets and can be patched
 	// by
 	DeploymentTemplateAssetName string
-	// Metric port exposed by the driver itself.
-	// Sidecar metrics ports are not included here, they will be added dynamically from sidecar config below.
-	MetricsPort *MetricsPort
+	// Metrics TCP port exposed by the driver itself on loopback interface.
+	LocalMetricsPort uint16
+	// Metrics TCP port number that should be exposed by kube-rbac-proxy on the container interface.
+	ExposedMetricsPort uint16
 	// Liveness probe TCP port number exposed by the driver itself, i.e. by DeploymentTemplateAssetName.
 	// It will be injected to liveness probe sidecar automatically.
 	LivenessProbePort uint16
 
-	// Start of TCP port number range to be used by sidecar to expose metrics on loopback interface.
+	// Start of TCP port number range to be used by sidecars to expose metrics on loopback interface.
 	// The generator will allocate a port for each sidecar and add kube-rbac-proxy in front of it.
 	SidecarLocalMetricsPortStart uint16
 	// Start of TCP port number range to be used by sidecar to expose metrics via kube-rbac-proxy on the container
@@ -77,18 +78,6 @@ type ControlPlaneConfig struct {
 	// Patches to apply to any assets in the control plane namespace, not necessarily to the ones defined in
 	// Assets. The controller Deployment can be patched too.
 	AssetPatches AssetPatches
-}
-
-// Configuration of metric ports exposed by the CSI driver itself.
-type MetricsPort struct {
-	// TCP port number exposed by the driver itself on loopback interface.
-	LocalPort uint16
-	// TCP port number that should be exposed by kube-rbac-proxy on the container interface.
-	ExposedPort uint16
-	// Name of the port. It is used in metrics Service and ServiceMonitor.
-	Name string
-	// If true, kube-rbac-proxy will be injected in front of the LocalPort by the generator, exposing ExposedPort.
-	InjectKubeRBACProxy bool
 }
 
 // Configuration of a single CSI sidecar. It usually contains also kube-rbac-proxy sidecar.
@@ -114,8 +103,10 @@ type SidecarConfig struct {
 type GuestConfig struct {
 	// Name of the template asset that contains DaemonSet of the guest components.
 	DaemonSetTemplateAssetName string
-	// Metric ports exposed by the driver itself.
-	MetricsPort *MetricsPort
+	// Metrics TCP port exposed by the driver itself on loopback interface.
+	LocalMetricsPort uint16
+	// Metrics TCP port number that should be exposed by kube-rbac-proxy on the container interface.
+	ExposedMetricsPort uint16
 	// Liveness probe TCP port number exposed by the driver itself, i.e. by DaemonSetTemplateAssetName.
 	LivenessProbePort uint16
 	// port where node-registrar will expose health check endpoint


### PR DESCRIPTION
The generator has the ability to generate kube-rbac-proxy sidecar containers when exposing driver metrics on the controller or node.
In https://github.com/openshift/csi-operator/pull/379, we noted that while the sidecar containers templates used template variables, the actual driver template used hardcoded strings. This allows for the possibility of bugs if the port numbers are changed at any point.
Resolve this by modifying the generator such that the metric port for the drivers is now templated also. Changes are implemented in multiple steps: I'd encourage reviewers to look at the individual commits.

This includes the commits from https://github.com/openshift/csi-operator/pull/379 and that can as such be considered a dependency.

Dependencies:

- [ ] https://github.com/openshift/csi-operator/pull/379
