### PR TITLE
OCPBUGS-56128: openstack-cinder: Set --with-topology flag for node driver also

### DIFF
--- a/assets/overlays/openstack-cinder/generated/hypershift/node.yaml
+++ b/assets/overlays/openstack-cinder/generated/hypershift/node.yaml
@@ -38,12 +38,18 @@ spec:
         - --provide-node-service=true
         - --endpoint=$(CSI_ENDPOINT)
         - --cloud-config=$(CLOUD_CONFIG)
+        - --with-topology=$(ENABLE_TOPOLOGY)
         - --v=${LOG_LEVEL}
         env:
         - name: CSI_ENDPOINT
           value: unix://csi/csi.sock
         - name: CLOUD_CONFIG
           value: /etc/kubernetes/config/cloud.conf
+        - name: ENABLE_TOPOLOGY
+          valueFrom:
+            configMapKeyRef:
+              key: enable_topology
+              name: cloud-conf
         image: ${DRIVER_IMAGE}
         imagePullPolicy: IfNotPresent
         livenessProbe:

--- a/assets/overlays/openstack-cinder/generated/standalone/node.yaml
+++ b/assets/overlays/openstack-cinder/generated/standalone/node.yaml
@@ -38,12 +38,18 @@ spec:
         - --provide-node-service=true
         - --endpoint=$(CSI_ENDPOINT)
         - --cloud-config=$(CLOUD_CONFIG)
+        - --with-topology=$(ENABLE_TOPOLOGY)
         - --v=${LOG_LEVEL}
         env:
         - name: CSI_ENDPOINT
           value: unix://csi/csi.sock
         - name: CLOUD_CONFIG
           value: /etc/kubernetes/config/cloud.conf
+        - name: ENABLE_TOPOLOGY
+          valueFrom:
+            configMapKeyRef:
+              key: enable_topology
+              name: cloud-conf
         image: ${DRIVER_IMAGE}
         imagePullPolicy: IfNotPresent
         livenessProbe:

--- a/assets/overlays/openstack-cinder/patches/node_add_driver.yaml
+++ b/assets/overlays/openstack-cinder/patches/node_add_driver.yaml
@@ -25,12 +25,18 @@ spec:
             - "--provide-node-service=true"
             - "--endpoint=$(CSI_ENDPOINT)"
             - "--cloud-config=$(CLOUD_CONFIG)"
+            - "--with-topology=$(ENABLE_TOPOLOGY)"
             - "--v=${LOG_LEVEL}"
           env:
             - name: CSI_ENDPOINT
               value: unix://csi/csi.sock
             - name: CLOUD_CONFIG
               value: /etc/kubernetes/config/cloud.conf
+            - name: ENABLE_TOPOLOGY
+              valueFrom:
+                configMapKeyRef:
+                  key: enable_topology
+                  name: cloud-conf
           volumeMounts:
             - name: kubelet-dir
               mountPath: /var/lib/kubelet


### PR DESCRIPTION
This is a follow-up to https://github.com/openshift/csi-operator/pull/345. Failure to do so results in the node driver reporting topology information which the provisioner respects, preventing us attaching the created volume.
