### PR TITLE
STOR-2477: create-efs-volume: add single-zone support

### DIFF
--- a/assets/overlays/aws-efs/testing/sc-single-zone.yaml
+++ b/assets/overlays/aws-efs/testing/sc-single-zone.yaml
@@ -1,0 +1,17 @@
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: ${storageclassname}
+provisioner: efs.csi.aws.com
+mountOptions:
+  - tls
+parameters:
+  provisioningMode: efs-ap
+  fileSystemId: ${filesystemid}
+  directoryPerms: "700"
+  basePath: "/dynamic_provisioning"
+allowedTopologies:
+- matchLabelExpressions:
+  - key: topology.kubernetes.io/zone
+    values:
+    - ${zone}

--- a/cmd/create-efs-volume/main.go
+++ b/cmd/create-efs-volume/main.go
@@ -16,6 +16,7 @@ import (
 
 var (
 	useLocalAWSCredentials bool
+	singleZone             string
 )
 
 func main() {
@@ -49,11 +50,12 @@ func NewOperatorCommand() *cobra.Command {
 	ctrlCmd.Short = "Create EFS volume"
 	flags := ctrlCmd.Flags()
 	flags.BoolVar(&useLocalAWSCredentials, "local-aws-creds", false, "Use local AWS credentials instead of credentials loaded from the OCP cluster.")
+	flags.StringVar(&singleZone, "single-zone", "", "Create a single-zone volume in given zone.")
 	cmd.AddCommand(ctrlCmd)
 
 	return cmd
 }
 
 func runOperatorWithCredentialsConfig(ctx context.Context, controllerConfig *controllercmd.ControllerContext) error {
-	return efscreate.RunOperator(ctx, controllerConfig, useLocalAWSCredentials)
+	return efscreate.RunOperator(ctx, controllerConfig, useLocalAWSCredentials, singleZone)
 }


### PR DESCRIPTION
`create-efs-volume start --single-zone=us-east-1a` creates a single-zone AWS EFS volume in given zone.