### PR TITLE
STOR-2477: Correct efs single-zone storageclass

### DIFF
--- a/assets/overlays/aws-efs/testing/sc-single-zone.yaml
+++ b/assets/overlays/aws-efs/testing/sc-single-zone.yaml
@@ -15,3 +15,4 @@ allowedTopologies:
   - key: topology.kubernetes.io/zone
     values:
     - ${zone}
+volumeBindingMode: WaitForFirstConsumer


### PR DESCRIPTION
- We introduce the `create-efs-volume` single zone support in https://github.com/openshift/csi-operator/pull/390, while when storageclass set with `allowedTopologies` must using `volumeBindingMode: WaitForFirstConsumer`(**[the default](https://github.com/kubernetes/kubernetes/blob/master/pkg/apis/storage/v1/defaults.go#L39)** is `Immediate`) otherwise the volume provision will not respect the allowedTopologies settings.