### PR TITLE
STOR-2330: Add labels to subscribe openstack cinder and manila CSI driver controllers to NPs

### DIFF
--- a/assets/overlays/openstack-cinder/generated/hypershift/controller.yaml
+++ b/assets/overlays/openstack-cinder/generated/hypershift/controller.yaml
@@ -51,6 +51,10 @@ spec:
       labels:
         app: openstack-cinder-csi-driver-controller
         hypershift.openshift.io/hosted-control-plane: ${NAMESPACE}
+        openshift.storage.network-policy.all-egress: allow
+        openshift.storage.network-policy.api-server: allow
+        openshift.storage.network-policy.dns: allow
+        openshift.storage.network-policy.metrics-range: allow
     spec:
       affinity:
         nodeAffinity:

--- a/assets/overlays/openstack-cinder/generated/standalone/controller.yaml
+++ b/assets/overlays/openstack-cinder/generated/standalone/controller.yaml
@@ -45,6 +45,10 @@ spec:
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app: openstack-cinder-csi-driver-controller
+        openshift.storage.network-policy.all-egress: allow
+        openshift.storage.network-policy.api-server: allow
+        openshift.storage.network-policy.dns: allow
+        openshift.storage.network-policy.metrics-range: allow
     spec:
       affinity:
         podAntiAffinity:

--- a/assets/overlays/openstack-cinder/patches/controller_add_driver.yaml
+++ b/assets/overlays/openstack-cinder/patches/controller_add_driver.yaml
@@ -10,6 +10,11 @@ spec:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: "cacert,config-cinderplugin,secret-cinderplugin,socket-dir"
         openshift.io/required-scc: restricted-v2
+      labels:
+        openshift.storage.network-policy.all-egress: allow
+        openshift.storage.network-policy.api-server: allow
+        openshift.storage.network-policy.dns: allow
+        openshift.storage.network-policy.metrics-range: allow
     spec:
       priorityClassName: system-cluster-critical
       nodeSelector:

--- a/assets/overlays/openstack-manila/generated/hypershift/controller.yaml
+++ b/assets/overlays/openstack-manila/generated/hypershift/controller.yaml
@@ -51,6 +51,10 @@ spec:
         app: openstack-manila-csi
         component: controllerplugin
         hypershift.openshift.io/hosted-control-plane: ${NAMESPACE}
+        openshift.storage.network-policy.all-egress: allow
+        openshift.storage.network-policy.api-server: allow
+        openshift.storage.network-policy.dns: allow
+        openshift.storage.network-policy.metrics-range: allow
     spec:
       affinity:
         nodeAffinity:

--- a/assets/overlays/openstack-manila/generated/standalone/controller.yaml
+++ b/assets/overlays/openstack-manila/generated/standalone/controller.yaml
@@ -45,6 +45,10 @@ spec:
       labels:
         app: openstack-manila-csi
         component: controllerplugin
+        openshift.storage.network-policy.all-egress: allow
+        openshift.storage.network-policy.api-server: allow
+        openshift.storage.network-policy.dns: allow
+        openshift.storage.network-policy.metrics-range: allow
     spec:
       affinity:
         podAntiAffinity:

--- a/assets/overlays/openstack-manila/patches/controller_add_driver.yaml
+++ b/assets/overlays/openstack-manila/patches/controller_add_driver.yaml
@@ -20,6 +20,10 @@ spec:
       labels:
         app: openstack-manila-csi
         component: controllerplugin
+        openshift.storage.network-policy.all-egress: allow
+        openshift.storage.network-policy.api-server: allow
+        openshift.storage.network-policy.dns: allow
+        openshift.storage.network-policy.metrics-range: allow
       annotations:
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
         openshift.io/required-scc: restricted-v2


### PR DESCRIPTION
https://issues.redhat.com//browse/STOR-2330

This PR subscribes openstack cinder and manila CSI driver controller pods to NPs from https://github.com/openshift/cluster-storage-operator/pull/579.