### PR TITLE
OCPBUGS-60464: Bump library-go to fix panic

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/openshift/client-go v0.0.0-20250710075018-396b36f983ee
 	github.com/openshift/hypershift v0.1.65
 	github.com/openshift/hypershift/api v0.0.0-20250807075541-3c03a646d838
-	github.com/openshift/library-go v0.0.0-20250729191057-91376e1b394e
+	github.com/openshift/library-go v0.0.0-20250818065802-cf8518058622
 	github.com/prometheus/client_golang v1.23.0
 	github.com/spf13/cobra v1.9.1
 	gopkg.in/ini.v1 v1.67.0

--- a/go.sum
+++ b/go.sum
@@ -208,8 +208,8 @@ github.com/openshift/hypershift v0.1.65 h1:dS9xLPcmoOEAfUCOyYWI/knePnXrOltO+DjZC
 github.com/openshift/hypershift v0.1.65/go.mod h1:rlmJfhwZ0/oN7njKHXFGm0vvo9Z4YkscvR0a5rn0Jco=
 github.com/openshift/hypershift/api v0.0.0-20250807075541-3c03a646d838 h1:2qKQN5Kimf4nm/PpIEP0TVGPnIRmIeJACAUSHd4K/RI=
 github.com/openshift/hypershift/api v0.0.0-20250807075541-3c03a646d838/go.mod h1:oCHHubcVHaPsiV8jSafkG/zQiJ1bwnxQfOM7mPpu3uM=
-github.com/openshift/library-go v0.0.0-20250729191057-91376e1b394e h1:xYT+P++PSc9G+Y47pIcU9fm8IDV/tg6tMi3i+0m23pU=
-github.com/openshift/library-go v0.0.0-20250729191057-91376e1b394e/go.mod h1:tptKNust9MdRI0p90DoBSPHIrBa9oh+Rok59tF0vT8c=
+github.com/openshift/library-go v0.0.0-20250818065802-cf8518058622 h1:IUs2XpDgkCQIIAPCVnHEjIUYiq0dvVskD/ekof7+XjQ=
+github.com/openshift/library-go v0.0.0-20250818065802-cf8518058622/go.mod h1:tptKNust9MdRI0p90DoBSPHIrBa9oh+Rok59tF0vT8c=
 github.com/orisano/pixelmatch v0.0.0-20220722002657-fb0b55479cde/go.mod h1:nZgzbfBr3hhjoZnS66nKrHmduYNpc34ny7RK4z5/HM0=
 github.com/patrickmn/go-cache v2.1.0+incompatible h1:HRMgzkcYKYpi3C8ajMPV8OFXaaRUnok+kx1WdO15EQc=
 github.com/patrickmn/go-cache v2.1.0+incompatible/go.mod h1:3Qf8kWWT7OJRJbdiICTKqZju1ZixQ/KpMGzzAfe6+WQ=

--- a/vendor/github.com/openshift/library-go/pkg/operator/resource/resourceapply/storage.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/resource/resourceapply/storage.go
@@ -142,6 +142,9 @@ func ApplyCSIDriver(ctx context.Context, client storageclientv1.CSIDriversGetter
 	if required.Annotations == nil {
 		required.Annotations = map[string]string{}
 	}
+	if required.Labels == nil {
+		required.Labels = map[string]string{}
+	}
 	if err := SetSpecHashAnnotation(&required.ObjectMeta, required.Spec); err != nil {
 		return nil, false, err
 	}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -452,7 +452,7 @@ github.com/openshift/hypershift/api/karpenter/v1beta1
 github.com/openshift/hypershift/api/scheduling
 github.com/openshift/hypershift/api/scheduling/v1alpha1
 github.com/openshift/hypershift/api/util/ipnet
-# github.com/openshift/library-go v0.0.0-20250729191057-91376e1b394e
+# github.com/openshift/library-go v0.0.0-20250818065802-cf8518058622
 ## explicit; go 1.24.0
 github.com/openshift/library-go/pkg/apiserver/jsonpatch
 github.com/openshift/library-go/pkg/authorization/hardcodedauthorizer


### PR DESCRIPTION
in assigning custom labels to csidriver object

https://issues.redhat.com/browse/OCPBUGS-60464