### PR TITLE
OCPBUGS-60655: Disable LUN stress test for azure-file

### DIFF
--- a/test/e2e/azure-file/ocp-manifest.yaml
+++ b/test/e2e/azure-file/ocp-manifest.yaml
@@ -1,4 +1,4 @@
 Driver: file.csi.azure.com
 LUNStressTest:
-  PodsTotal: 260
+  PodsTotal: 10 # See OCPBUGS-60655, Azure throttles provisioning requests
   Timeout: "30m" # The test needs ~5 min in ideal conditions.


### PR DESCRIPTION
https://issues.redhat.com/browse/OCPBUGS-60655

Temporarily reduce load on azure-file to avoid hitting the throttle + timeout in periodic jobs.

see also: https://github.com/openshift/csi-operator/pull/282

/cc @openshift/storage @jsafrane
