### PR TITLE
MULTIARCH-5554: update smb-csi-driver-operator support to add ppc64le

### DIFF
--- a/config/samba/manifests/stable/smb-csi-driver-operator.clusterserviceversion.yaml
+++ b/config/samba/manifests/stable/smb-csi-driver-operator.clusterserviceversion.yaml
@@ -27,6 +27,7 @@ metadata:
     operator-metering: "true"
     "operatorframework.io/arch.amd64": supported
     "operatorframework.io/arch.arm64": supported
+    "operatorframework.io/arch.ppc64le": supported
 spec:
   displayName: CIFS/SMB CSI Driver Operator
   description: |


### PR DESCRIPTION
Adds `operatorframework.io/arch.ppc64le` supported flag.