### PR TITLE
OCPBUGS-54385: Avoid informer resync

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/openshift/client-go v0.0.0-20250710075018-396b36f983ee
 	github.com/openshift/hypershift v0.1.65
 	github.com/openshift/hypershift/api v0.0.0-20250807075541-3c03a646d838
-	github.com/openshift/library-go v0.0.0-20250818065802-cf8518058622
+	github.com/openshift/library-go v0.0.0-20250910143751-71c215a861c7
 	github.com/prometheus/client_golang v1.23.0
 	github.com/spf13/cobra v1.9.1
 	gopkg.in/ini.v1 v1.67.0

--- a/go.sum
+++ b/go.sum
@@ -208,8 +208,8 @@ github.com/openshift/hypershift v0.1.65 h1:dS9xLPcmoOEAfUCOyYWI/knePnXrOltO+DjZC
 github.com/openshift/hypershift v0.1.65/go.mod h1:rlmJfhwZ0/oN7njKHXFGm0vvo9Z4YkscvR0a5rn0Jco=
 github.com/openshift/hypershift/api v0.0.0-20250807075541-3c03a646d838 h1:2qKQN5Kimf4nm/PpIEP0TVGPnIRmIeJACAUSHd4K/RI=
 github.com/openshift/hypershift/api v0.0.0-20250807075541-3c03a646d838/go.mod h1:oCHHubcVHaPsiV8jSafkG/zQiJ1bwnxQfOM7mPpu3uM=
-github.com/openshift/library-go v0.0.0-20250818065802-cf8518058622 h1:IUs2XpDgkCQIIAPCVnHEjIUYiq0dvVskD/ekof7+XjQ=
-github.com/openshift/library-go v0.0.0-20250818065802-cf8518058622/go.mod h1:tptKNust9MdRI0p90DoBSPHIrBa9oh+Rok59tF0vT8c=
+github.com/openshift/library-go v0.0.0-20250910143751-71c215a861c7 h1:iouQp/LSN59yn/uRafnHrbyuCEDz1ofRUeo7yOxTSLM=
+github.com/openshift/library-go v0.0.0-20250910143751-71c215a861c7/go.mod h1:tptKNust9MdRI0p90DoBSPHIrBa9oh+Rok59tF0vT8c=
 github.com/orisano/pixelmatch v0.0.0-20220722002657-fb0b55479cde/go.mod h1:nZgzbfBr3hhjoZnS66nKrHmduYNpc34ny7RK4z5/HM0=
 github.com/patrickmn/go-cache v2.1.0+incompatible h1:HRMgzkcYKYpi3C8ajMPV8OFXaaRUnok+kx1WdO15EQc=
 github.com/patrickmn/go-cache v2.1.0+incompatible/go.mod h1:3Qf8kWWT7OJRJbdiICTKqZju1ZixQ/KpMGzzAfe6+WQ=

--- a/pkg/clients/builder.go
+++ b/pkg/clients/builder.go
@@ -77,7 +77,7 @@ func (b *Builder) WithHyperShiftGuest(kubeConfigFile string, cloudConfigNamespac
 func (b *Builder) BuildOrDie(ctx context.Context) *Clients {
 	controlPlaneRestConfig := rest.AddUserAgent(b.controllerConfig.KubeConfig, b.userAgent)
 	controlPlaneKubeClient := kubeclient.NewForConfigOrDie(controlPlaneRestConfig)
-	controlPlaneKubeInformers := v1helpers.NewKubeInformersForNamespaces(controlPlaneKubeClient, b.controlPlaneNamespaces...)
+	controlPlaneKubeInformers := v1helpers.NewKubeInformersForNamespacesWithResyncPeriod(controlPlaneKubeClient, time.Duration(0), b.controlPlaneNamespaces...)
 
 	controlPlaneDynamicClient := dynamic.NewForConfigOrDie(controlPlaneRestConfig)
 	controlPlaneDynamicInformers := dynamicinformer.NewFilteredDynamicSharedInformerFactory(controlPlaneDynamicClient, b.resync, b.controllerConfig.OperatorNamespace, nil)
@@ -121,7 +121,7 @@ func (b *Builder) BuildOrDie(ctx context.Context) *Clients {
 	// store guestKubeConfig in case we need it later for running
 	b.guestKubeConfig = guestKubeConfig
 	b.client.KubeClient = guestKubeClient
-	b.client.KubeInformers = v1helpers.NewKubeInformersForNamespaces(guestKubeClient, b.guestNamespaces...)
+	b.client.KubeInformers = v1helpers.NewKubeInformersForNamespacesWithResyncPeriod(guestKubeClient, time.Duration(0), b.guestNamespaces...)
 
 	gvk := opv1.SchemeGroupVersion.WithKind("ClusterCSIDriver")
 	gvr := opv1.SchemeGroupVersion.WithResource("clustercsidrivers")

--- a/vendor/github.com/openshift/library-go/pkg/operator/resource/resourceread/networking.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/resource/resourceread/networking.go
@@ -18,7 +18,7 @@ func init() {
 }
 
 func ReadNetworkPolicyV1OrDie(objBytes []byte) *networkingv1.NetworkPolicy {
-	requiredObj, err := runtime.Decode(coreCodecs.UniversalDecoder(networkingv1.SchemeGroupVersion), objBytes)
+	requiredObj, err := runtime.Decode(netCodecs.UniversalDecoder(networkingv1.SchemeGroupVersion), objBytes)
 	if err != nil {
 		panic(err)
 	}

--- a/vendor/github.com/openshift/library-go/pkg/operator/v1helpers/informers.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/v1helpers/informers.go
@@ -32,17 +32,21 @@ type KubeInformersForNamespaces interface {
 
 var _ KubeInformersForNamespaces = kubeInformersForNamespaces{}
 
-func NewKubeInformersForNamespaces(kubeClient kubernetes.Interface, namespaces ...string) KubeInformersForNamespaces {
+func NewKubeInformersForNamespacesWithResyncPeriod(kubeClient kubernetes.Interface, resyncInterval time.Duration, namespaces ...string) KubeInformersForNamespaces {
 	ret := kubeInformersForNamespaces{}
 	for _, namespace := range namespaces {
 		if len(namespace) == 0 {
-			ret[""] = informers.NewSharedInformerFactory(kubeClient, 10*time.Minute)
+			ret[""] = informers.NewSharedInformerFactory(kubeClient, resyncInterval)
 			continue
 		}
-		ret[namespace] = informers.NewSharedInformerFactoryWithOptions(kubeClient, 10*time.Minute, informers.WithNamespace(namespace))
+		ret[namespace] = informers.NewSharedInformerFactoryWithOptions(kubeClient, resyncInterval, informers.WithNamespace(namespace))
 	}
 
 	return ret
+}
+
+func NewKubeInformersForNamespaces(kubeClient kubernetes.Interface, namespaces ...string) KubeInformersForNamespaces {
+	return NewKubeInformersForNamespacesWithResyncPeriod(kubeClient, 10*time.Minute, namespaces...)
 }
 
 type kubeInformersForNamespaces map[string]informers.SharedInformerFactory

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -452,7 +452,7 @@ github.com/openshift/hypershift/api/karpenter/v1beta1
 github.com/openshift/hypershift/api/scheduling
 github.com/openshift/hypershift/api/scheduling/v1alpha1
 github.com/openshift/hypershift/api/util/ipnet
-# github.com/openshift/library-go v0.0.0-20250818065802-cf8518058622
+# github.com/openshift/library-go v0.0.0-20250910143751-71c215a861c7
 ## explicit; go 1.24.0
 github.com/openshift/library-go/pkg/apiserver/jsonpatch
 github.com/openshift/library-go/pkg/authorization/hardcodedauthorizer


### PR DESCRIPTION
https://issues.redhat.com/browse/OCPBUGS-54385

Most of controllers do per-controller resync, so informer resync is redundant. The only exception is LogLevel controller, but it must be safe to call reconciliation loop when an update happens without resync.