### PR TITLE
NO-JIRA: Normalize generation of driver metrics RBAC proxy sidecar (extended)

### DIFF
--- a/assets/common/sidecars/controller_driver_kube_rbac_proxy.yaml
+++ b/assets/common/sidecars/controller_driver_kube_rbac_proxy.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     spec:
       containers:
-        - name: kube-rbac-proxy-${LOCAL_METRICS_PORT}
+        - name: driver-kube-rbac-proxy
           securityContext:
             readOnlyRootFilesystem: true
           args:

--- a/assets/common/sidecars/node_driver_kube_rbac_proxy.yaml
+++ b/assets/common/sidecars/node_driver_kube_rbac_proxy.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     spec:
       containers:
-        - name: kube-rbac-proxy-${LOCAL_METRICS_PORT}
+        - name: driver-kube-rbac-proxy
           securityContext:
             readOnlyRootFilesystem: true
           args:

--- a/assets/overlays/aws-ebs/generated/hypershift/controller.yaml
+++ b/assets/overlays/aws-ebs/generated/hypershift/controller.yaml
@@ -158,7 +158,7 @@ spec:
         - --logtostderr=true
         image: ${KUBE_RBAC_PROXY_IMAGE}
         imagePullPolicy: IfNotPresent
-        name: kube-rbac-proxy-8201
+        name: driver-kube-rbac-proxy
         ports:
         - containerPort: 9201
           name: driver-m

--- a/assets/overlays/aws-ebs/generated/standalone/controller.yaml
+++ b/assets/overlays/aws-ebs/generated/standalone/controller.yaml
@@ -122,7 +122,7 @@ spec:
         - --logtostderr=true
         image: ${KUBE_RBAC_PROXY_IMAGE}
         imagePullPolicy: IfNotPresent
-        name: kube-rbac-proxy-8201
+        name: driver-kube-rbac-proxy
         ports:
         - containerPort: 9201
           name: driver-m

--- a/assets/overlays/azure-disk/generated/hypershift/controller.yaml
+++ b/assets/overlays/azure-disk/generated/hypershift/controller.yaml
@@ -152,7 +152,7 @@ spec:
         - --logtostderr=true
         image: ${KUBE_RBAC_PROXY_IMAGE}
         imagePullPolicy: IfNotPresent
-        name: kube-rbac-proxy-8201
+        name: driver-kube-rbac-proxy
         ports:
         - containerPort: 9201
           name: driver-m

--- a/assets/overlays/azure-disk/generated/hypershift/node.yaml
+++ b/assets/overlays/azure-disk/generated/hypershift/node.yaml
@@ -106,7 +106,7 @@ spec:
         - --logtostderr=true
         image: ${KUBE_RBAC_PROXY_IMAGE}
         imagePullPolicy: IfNotPresent
-        name: kube-rbac-proxy-8206
+        name: driver-kube-rbac-proxy
         ports:
         - containerPort: 9206
           name: driver-m

--- a/assets/overlays/azure-disk/generated/standalone/controller.yaml
+++ b/assets/overlays/azure-disk/generated/standalone/controller.yaml
@@ -117,7 +117,7 @@ spec:
         - --logtostderr=true
         image: ${KUBE_RBAC_PROXY_IMAGE}
         imagePullPolicy: IfNotPresent
-        name: kube-rbac-proxy-8201
+        name: driver-kube-rbac-proxy
         ports:
         - containerPort: 9201
           name: driver-m

--- a/assets/overlays/azure-disk/generated/standalone/node.yaml
+++ b/assets/overlays/azure-disk/generated/standalone/node.yaml
@@ -106,7 +106,7 @@ spec:
         - --logtostderr=true
         image: ${KUBE_RBAC_PROXY_IMAGE}
         imagePullPolicy: IfNotPresent
-        name: kube-rbac-proxy-8206
+        name: driver-kube-rbac-proxy
         ports:
         - containerPort: 9206
           name: driver-m

--- a/assets/overlays/azure-file/generated/hypershift/controller.yaml
+++ b/assets/overlays/azure-file/generated/hypershift/controller.yaml
@@ -167,7 +167,7 @@ spec:
         - --logtostderr=true
         image: ${KUBE_RBAC_PROXY_IMAGE}
         imagePullPolicy: IfNotPresent
-        name: kube-rbac-proxy-8211
+        name: driver-kube-rbac-proxy
         ports:
         - containerPort: 9211
           name: driver-m

--- a/assets/overlays/azure-file/generated/standalone/controller.yaml
+++ b/assets/overlays/azure-file/generated/standalone/controller.yaml
@@ -125,7 +125,7 @@ spec:
         - --logtostderr=true
         image: ${KUBE_RBAC_PROXY_IMAGE}
         imagePullPolicy: IfNotPresent
-        name: kube-rbac-proxy-8211
+        name: driver-kube-rbac-proxy
         ports:
         - containerPort: 9211
           name: driver-m

--- a/assets/overlays/openstack-cinder/generated/hypershift/controller.yaml
+++ b/assets/overlays/openstack-cinder/generated/hypershift/controller.yaml
@@ -160,7 +160,7 @@ spec:
         - --logtostderr=true
         image: ${KUBE_RBAC_PROXY_IMAGE}
         imagePullPolicy: IfNotPresent
-        name: kube-rbac-proxy-8202
+        name: driver-kube-rbac-proxy
         ports:
         - containerPort: 9202
           name: driver-m

--- a/assets/overlays/openstack-cinder/generated/standalone/controller.yaml
+++ b/assets/overlays/openstack-cinder/generated/standalone/controller.yaml
@@ -124,7 +124,7 @@ spec:
         - --logtostderr=true
         image: ${KUBE_RBAC_PROXY_IMAGE}
         imagePullPolicy: IfNotPresent
-        name: kube-rbac-proxy-8202
+        name: driver-kube-rbac-proxy
         ports:
         - containerPort: 9202
           name: driver-m

--- a/assets/overlays/samba/generated/standalone/controller.yaml
+++ b/assets/overlays/samba/generated/standalone/controller.yaml
@@ -126,7 +126,7 @@ spec:
         - --logtostderr=true
         image: ${KUBE_RBAC_PROXY_IMAGE}
         imagePullPolicy: IfNotPresent
-        name: kube-rbac-proxy-8221
+        name: driver-kube-rbac-proxy
         ports:
         - containerPort: 9221
           name: driver-m

--- a/pkg/driver/common/operator/hooks_test.go
+++ b/pkg/driver/common/operator/hooks_test.go
@@ -219,7 +219,7 @@ func Test_WithHyperShiftControlPlaneImages(t *testing.T) {
 			expectedContainerImages: map[string]string{
 				"csi-driver":                  "control_plane_driver_image:1",
 				"csi-liveness-probe":          "control_plane_livenessprobe_image:1",
-				"kube-rbac-proxy-8201":        "control_plane_kube_rbac_proxy_image:1",
+				"driver-kube-rbac-proxy":      "control_plane_kube_rbac_proxy_image:1",
 				"provisioner-kube-rbac-proxy": "control_plane_kube_rbac_proxy_image:1",
 				"attacher-kube-rbac-proxy":    "control_plane_kube_rbac_proxy_image:1",
 				"resizer-kube-rbac-proxy":     "control_plane_kube_rbac_proxy_image:1",

--- a/pkg/driver/common/operator/test_manifests/aws_ebs_controller_hypershift.yaml
+++ b/pkg/driver/common/operator/test_manifests/aws_ebs_controller_hypershift.yaml
@@ -112,7 +112,7 @@ spec:
         - --logtostderr=true
         image: ${KUBE_RBAC_PROXY_IMAGE}
         imagePullPolicy: IfNotPresent
-        name: kube-rbac-proxy-8201
+        name: driver-kube-rbac-proxy
         ports:
         - containerPort: 9201
           name: driver-m


### PR DESCRIPTION
This builds on #380 by changing the name of the proxy sidecar used for driver metrics.
