### PR TITLE
OCPBUGS-61164: AWS EBS Snapshotter timeout test flakiness

### DIFF
--- a/pkg/driver/aws-ebs/aws_ebs.go
+++ b/pkg/driver/aws-ebs/aws_ebs.go
@@ -94,6 +94,7 @@ func GetAWSEBSGeneratorConfig() *generator.CSIDriverGeneratorConfig {
 					"base/rbac/volumeattributesclass_reader_resizer_binding.yaml",
 				),
 				commongenerator.DefaultSnapshotter.WithExtraArguments(
+					"--timeout=60s",
 					"--extra-create-metadata",
 					"--kube-api-qps=20",
 					"--kube-api-burst=100",

--- a/pkg/driver/common/operator/test_manifests/aws_ebs_controller_hypershift.yaml
+++ b/pkg/driver/common/operator/test_manifests/aws_ebs_controller_hypershift.yaml
@@ -300,6 +300,7 @@ spec:
           name: hosted-kubeconfig
           readOnly: true
       - args:
+        - --timeout=60s
         - --secure-listen-address=0.0.0.0:9206
         - --upstream=http://127.0.0.1:8206/
         - --tls-cert-file=/etc/tls/private/tls.crt


### PR DESCRIPTION
Increase the timeout of the default CSI snapshotter to avoid sporadic timeouts on e2e-aws-ovn tests.

Fixes [OCPBUGS-61164](https://issues.redhat.com/browse/OCPBUGS-61164)
