### PR TITLE
OCPBUGS-80930: Add VolumeAttributesClass e2e test manifests for Azure disk

### DIFF
--- a/test/e2e/azure-disk/ultrassd-manifest.yaml
+++ b/test/e2e/azure-disk/ultrassd-manifest.yaml
@@ -1,0 +1,38 @@
+# Test manifest for https://github.com/kubernetes/kubernetes/tree/master/test/e2e/storage/external
+ShortName: azuredisk
+StorageClass:
+  FromExistingClassName: managed-csi-ultrassd
+SnapshotClass:
+  FromName: true
+VolumeAttributesClass:
+  FromFile: volumeattributesclass.yaml
+DriverInfo:
+  Name: disk.csi.azure.com
+  SupportedSizeRange:
+    Min: 4Gi
+    Max: 16Ti
+  SupportedFsType:
+    xfs: {}
+    ext4: {}
+  SupportedMountOption:
+    dirsync: {}
+  TopologyKeys: ["topology.disk.csi.azure.com/zone"]
+  Capabilities:
+    persistence: true
+    fsGroup: true
+    block: true
+    exec: true
+    volumeLimits: false
+    controllerExpansion: true
+    nodeExpansion: true
+    onlineExpansion: true
+    snapshotDataSource: true
+    pvcDataSource: true
+    topology: true
+    multipods: true
+    multiplePVsSameID: true
+    readWriteOncePod: true
+Timeouts:
+  PodStart: 15m
+  PodDelete: 15m
+  PVDelete: 20m

--- a/test/e2e/azure-disk/volumeattributesclass.yaml
+++ b/test/e2e/azure-disk/volumeattributesclass.yaml
@@ -1,0 +1,8 @@
+apiVersion: storage.k8s.io/v1
+kind: VolumeAttributesClass
+metadata:
+  name: ultrassd-azuredisk-vac
+driverName: disk.csi.azure.com
+parameters:
+  diskIOPSReadWrite: "1000"
+  diskMBpsReadWrite: "200"


### PR DESCRIPTION
## Summary
- Added `ultrassd-manifest.yaml` with VolumeAttributesClass support for running
  Kubernetes external storage e2e tests against the `managed-csi-ultrassd`
  StorageClass.
- Added `volumeattributesclass.yaml` defining an UltraSSD-backed
  VolumeAttributesClass with custom IOPS and throughput parameters