### PR TITLE
OCPBUGS-84052: Mount writable /tmp in SMB CSI driver

### DIFF
--- a/assets/overlays/samba/generated/standalone/node.yaml
+++ b/assets/overlays/samba/generated/standalone/node.yaml
@@ -74,6 +74,8 @@ spec:
         - mountPath: /var/lib/kubelet/
           mountPropagation: Bidirectional
           name: kubelet-dir
+        - mountPath: /tmp
+          name: tmp-dir
       - args:
         - --csi-address=/csi/csi.sock
         - --kubelet-registration-path=/var/lib/kubelet/plugins/smb.csi.k8s.io/csi.sock
@@ -171,6 +173,8 @@ spec:
       - name: metrics-serving-cert
         secret:
           secretName: smb-csi-driver-node-metrics-serving-cert
+      - emptyDir: {}
+        name: tmp-dir
   updateStrategy:
     rollingUpdate:
       maxUnavailable: 10%

--- a/assets/overlays/samba/patches/node_add_driver.yaml
+++ b/assets/overlays/samba/patches/node_add_driver.yaml
@@ -43,6 +43,8 @@ spec:
             - mountPath: /var/lib/kubelet/
               mountPropagation: Bidirectional
               name: kubelet-dir
+            - mountPath: /tmp
+              name: tmp-dir
           resources:
             limits:
               memory: 200Mi
@@ -50,3 +52,6 @@ spec:
               cpu: 10m
               memory: 20Mi
           terminationMessagePolicy: FallbackToLogsOnError
+      volumes:
+        - name: tmp-dir
+          emptyDir: {}


### PR DESCRIPTION
There are configurations which need writable `/tmp` in the SMB CSI driver container. Those got broken with changing the root file system to read-only.