### PR TITLE
OCPBUGS-85457: Add init container for Manila node daemonset

### DIFF
--- a/assets/overlays/openstack-manila/generated/hypershift/node.yaml
+++ b/assets/overlays/openstack-manila/generated/hypershift/node.yaml
@@ -158,6 +158,28 @@ spec:
           name: registration-dir
       dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
+      initContainers:
+      - command:
+        - sh
+        - -c
+        - |
+          until [ -S /var/lib/kubelet/plugins/csi-nfsplugin/csi.sock ]; do
+            echo "Waiting for NFS CSI plugin socket..."
+            sleep 2
+          done
+        image: ${DRIVER_IMAGE}
+        name: wait-for-nfs-plugin
+        resources:
+          requests:
+            cpu: 10m
+            memory: 50Mi
+        securityContext:
+          privileged: false
+          readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /var/lib/kubelet/plugins/csi-nfsplugin
+          name: fwd-plugin-dir
       nodeSelector:
         kubernetes.io/os: linux
       priorityClassName: system-node-critical

--- a/assets/overlays/openstack-manila/generated/standalone/node.yaml
+++ b/assets/overlays/openstack-manila/generated/standalone/node.yaml
@@ -158,6 +158,28 @@ spec:
           name: registration-dir
       dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
+      initContainers:
+      - command:
+        - sh
+        - -c
+        - |
+          until [ -S /var/lib/kubelet/plugins/csi-nfsplugin/csi.sock ]; do
+            echo "Waiting for NFS CSI plugin socket..."
+            sleep 2
+          done
+        image: ${DRIVER_IMAGE}
+        name: wait-for-nfs-plugin
+        resources:
+          requests:
+            cpu: 10m
+            memory: 50Mi
+        securityContext:
+          privileged: false
+          readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /var/lib/kubelet/plugins/csi-nfsplugin
+          name: fwd-plugin-dir
       nodeSelector:
         kubernetes.io/os: linux
       priorityClassName: system-node-critical

--- a/assets/overlays/openstack-manila/patches/node_add_driver.yaml
+++ b/assets/overlays/openstack-manila/patches/node_add_driver.yaml
@@ -90,6 +90,28 @@ spec:
               cpu: 10m
               memory: 50Mi
           terminationMessagePolicy: FallbackToLogsOnError
+      initContainers:
+        - name: wait-for-nfs-plugin
+          image: ${DRIVER_IMAGE}
+          command:
+            - sh
+            - -c
+            - |
+              until [ -S /var/lib/kubelet/plugins/csi-nfsplugin/csi.sock ]; do
+                echo "Waiting for NFS CSI plugin socket..."
+                sleep 2
+              done
+          securityContext:
+            readOnlyRootFilesystem: true
+            privileged: false
+          resources:
+            requests:
+              cpu: 10m
+              memory: 50Mi
+          terminationMessagePolicy: FallbackToLogsOnError
+          volumeMounts:
+            - name: fwd-plugin-dir
+              mountPath: /var/lib/kubelet/plugins/csi-nfsplugin
       volumes:
         - name: cloud-credentials
           secret:


### PR DESCRIPTION
The Manila CSI driver node plugin fatally exits on startup when the NFS CSI plugin socket (`/var/lib/kubelet/plugins/csi-nfsplugin/csi.sock`) is not yet available. After node disruptions, both DaemonSets restart concurrently and the Manila driver crashes because upstream ProbeForever only retries on DeadlineExceeded, not on Unavailable (connection refused). This causes excessive container restarts (>3), failing the CI invariant test.

In addition to an upcoming fix to make the driver more tolerant, add a `wait-for-nfs-plugin` init container to the Manila node DaemonSet that polls for the NFS plugin socket before allowing the csi-driver container to start. This ensures proper startup ordering between the two DaemonSets without requiring changes to the upstream driver.