### PR TITLE
OCPBUGS-86023: Add memory limits to SMB CSI sidecar containers

### DIFF
--- a/assets/overlays/samba/generated/standalone/controller.yaml
+++ b/assets/overlays/samba/generated/standalone/controller.yaml
@@ -13,6 +13,7 @@
 # pod_network_livenessprobe.yaml: Added arguments [--probe-timeout=3s]
 # Applied strategic merge patch pod_network_livenessprobe.yaml
 # Applied strategic merge patch common/standalone/controller_add_affinity.yaml
+# Applied strategic merge patch overlays/samba/patches/controller_sidecar_resource_limits.yaml
 #
 #
 
@@ -105,6 +106,8 @@ spec:
         imagePullPolicy: IfNotPresent
         name: csi-provisioner
         resources:
+          limits:
+            memory: 400Mi
           requests:
             cpu: 10m
             memory: 50Mi
@@ -182,6 +185,8 @@ spec:
         imagePullPolicy: IfNotPresent
         name: csi-resizer
         resources:
+          limits:
+            memory: 400Mi
           requests:
             cpu: 10m
             memory: 50Mi
@@ -226,6 +231,8 @@ spec:
         imagePullPolicy: IfNotPresent
         name: csi-liveness-probe
         resources:
+          limits:
+            memory: 100Mi
           requests:
             cpu: 10m
             memory: 50Mi

--- a/assets/overlays/samba/generated/standalone/controller.yaml
+++ b/assets/overlays/samba/generated/standalone/controller.yaml
@@ -14,6 +14,7 @@
 # Applied strategic merge patch pod_network_livenessprobe.yaml
 # Applied strategic merge patch common/standalone/controller_add_affinity.yaml
 # Applied strategic merge patch overlays/samba/patches/controller_sidecar_resource_limits.yaml
+# Applied strategic merge patch overlays/samba/patches/controller_kube_rbac_proxy_resource_limits.yaml
 #
 #
 
@@ -135,6 +136,8 @@ spec:
           name: driver-m
           protocol: TCP
         resources:
+          limits:
+            memory: 100Mi
           requests:
             cpu: 10m
             memory: 20Mi
@@ -160,6 +163,8 @@ spec:
           name: provisioner-m
           protocol: TCP
         resources:
+          limits:
+            memory: 100Mi
           requests:
             cpu: 10m
             memory: 20Mi
@@ -212,6 +217,8 @@ spec:
           name: resizer-m
           protocol: TCP
         resources:
+          limits:
+            memory: 100Mi
           requests:
             cpu: 10m
             memory: 20Mi

--- a/assets/overlays/samba/patches/controller_kube_rbac_proxy_resource_limits.yaml
+++ b/assets/overlays/samba/patches/controller_kube_rbac_proxy_resource_limits.yaml
@@ -1,0 +1,18 @@
+kind: Deployment
+apiVersion: apps/v1
+spec:
+  template:
+    spec:
+      containers:
+        - name: kube-rbac-proxy-8221
+          resources:
+            limits:
+              memory: 100Mi
+        - name: provisioner-kube-rbac-proxy
+          resources:
+            limits:
+              memory: 100Mi
+        - name: resizer-kube-rbac-proxy
+          resources:
+            limits:
+              memory: 100Mi

--- a/assets/overlays/samba/patches/controller_sidecar_resource_limits.yaml
+++ b/assets/overlays/samba/patches/controller_sidecar_resource_limits.yaml
@@ -1,0 +1,18 @@
+kind: Deployment
+apiVersion: apps/v1
+spec:
+  template:
+    spec:
+      containers:
+        - name: csi-provisioner
+          resources:
+            limits:
+              memory: 400Mi
+        - name: csi-resizer
+          resources:
+            limits:
+              memory: 400Mi
+        - name: csi-liveness-probe
+          resources:
+            limits:
+              memory: 100Mi

--- a/pkg/driver/samba/samba.go
+++ b/pkg/driver/samba/samba.go
@@ -57,6 +57,7 @@ func GetSambaGeneratorConfig() *generator.CSIDriverGeneratorConfig {
 			),
 			AssetPatches: generator.NewAssetPatches(generator.StandaloneOnly,
 				"controller.yaml", "common/standalone/controller_add_affinity.yaml",
+				"controller.yaml", "overlays/samba/patches/controller_sidecar_resource_limits.yaml",
 			),
 		},
 

--- a/pkg/driver/samba/samba.go
+++ b/pkg/driver/samba/samba.go
@@ -58,6 +58,7 @@ func GetSambaGeneratorConfig() *generator.CSIDriverGeneratorConfig {
 			AssetPatches: generator.NewAssetPatches(generator.StandaloneOnly,
 				"controller.yaml", "common/standalone/controller_add_affinity.yaml",
 				"controller.yaml", "overlays/samba/patches/controller_sidecar_resource_limits.yaml",
+				"controller.yaml", "overlays/samba/patches/controller_kube_rbac_proxy_resource_limits.yaml",
 			),
 		},
 


### PR DESCRIPTION
## Summary

Add memory limits to all sidecar containers in the SMB CSI driver controller
deployment to align with upstream.

## Problem

A customer reports memory alerts on `smb-csi-driver-controller` after
upgrading to OCP 4.20. The alert compares `kube_pod_resource_request` (~241Mi)
against `kube_pod_resource_limit` (~210Mi) and fires because requests exceed
limits.

This is misleading. The 200Mi limit is a container limit on `csi-driver`, not
a pod limit. The other 6 containers have no limits — meaning they are
effectively unlimited. But `kube_pod_resource_limit` contributes 0 for
containers without limits instead of infinity, making the sum artificially low.

There is no runtime impact: `csi-driver` uses ~31Mi of its 200Mi limit, pods
have 0 restarts, no OOM kills.

## Root Cause

[Upstream](https://github.com/kubernetes-csi/csi-driver-smb/blob/master/deploy/csi-smb-controller.yaml) defines limits on all containers (total 1100Mi). The OCP operator only carries the `csi-driver` limit and leaves sidecars without limits. Three OCP-specific `kube-rbac-proxy` containers also lack limits.

## Fix

1. Add limits matching upstream: provisioner (400Mi), resizer (400Mi),
   liveness-probe (100Mi).
2. Add limits to OCP-specific kube-rbac-proxy containers (100Mi).

## References

- [Upstream controller.yaml](https://github.com/kubernetes-csi/csi-driver-smb/blob/master/deploy/csi-smb-controller.yaml)
- [OCP 4.20 controller.yaml](https://github.com/openshift/csi-operator/blob/release-4.20/assets/overlays/samba/generated/standalone/controller.yaml)