### PR TITLE
OCPBUGS-42363: Re-enable Azure Disk load test

### DIFF
--- a/test/e2e/azure-disk/ocp-manifest.yaml
+++ b/test/e2e/azure-disk/ocp-manifest.yaml
@@ -1,4 +1,4 @@
 Driver: disk.csi.azure.com
 LUNStressTest:
-  PodsTotal: 10 # See OCPBUGS-41265, Azure reboots a node under a heavy attach/detach load
+  PodsTotal: 260
   Timeout: "60m" # The test needs ~40 min in ideal conditions.


### PR DESCRIPTION
In Nov 2024 Microsoft wrote that they're deploying a fix for OCPBUGS-42363 in 2025. It's mid 2026, let's try to enable the test.