### PR TITLE
STOR-2920: Bump OLM metadata to 5.0

### DIFF
--- a/config/aws-efs/manifests/aws-efs-csi-driver-operator.package.yaml
+++ b/config/aws-efs/manifests/aws-efs-csi-driver-operator.package.yaml
@@ -1,4 +1,4 @@
 packageName: aws-efs-csi-driver-operator
 channels:
   - name: stable
-    currentCSV: aws-efs-csi-driver-operator.v4.22.0
+    currentCSV: aws-efs-csi-driver-operator.v5.0.0

--- a/config/aws-efs/manifests/stable/aws-efs-csi-driver-operator.clusterserviceversion.yaml
+++ b/config/aws-efs/manifests/stable/aws-efs-csi-driver-operator.clusterserviceversion.yaml
@@ -1,7 +1,7 @@
 apiVersion: operators.coreos.com/v1alpha1
 kind: ClusterServiceVersion
 metadata:
-  name: aws-efs-csi-driver-operator.v4.22.0
+  name: aws-efs-csi-driver-operator.v5.0.0
   namespace: placeholder
   annotations:
     categories: Storage
@@ -13,8 +13,8 @@ metadata:
     repository: https://github.com/openshift/aws-efs-csi-driver-operator
     createdAt: "2021-07-14T00:00:00Z"
     description: Install and configure AWS EFS CSI driver.
-    olm.properties: '[{"type":"olm.maxOpenShiftVersion","value":"4.23"}]'
-    olm.skipRange: ">=4.9.0-0 <4.22.0"
+    olm.properties: '[{"type":"olm.maxOpenShiftVersion","value":"5.1"}]'
+    olm.skipRange: ">=4.9.0-0 <5.0.0"
     features.operators.openshift.io/disconnected: "true"
     features.operators.openshift.io/fips-compliant: "true"
     features.operators.openshift.io/proxy-aware: "true"
@@ -50,7 +50,7 @@ spec:
       url: https://github.com/openshift/aws-efs-csi-driver-operator
     - name: Source Repository
       url: https://github.com/openshift/aws-efs-csi-driver-operator
-  version: 4.22.0
+  version: 5.0.0
   maturity: stable
   maintainers:
     - email: aos-storage-staff@redhat.com
@@ -60,7 +60,7 @@ spec:
     name: Red Hat
   labels:
     alm-owner-metering: aws-efs-csi-driver-operator
-    alm-status-descriptors: aws-efs-csi-driver-operator.v4.22.0
+    alm-status-descriptors: aws-efs-csi-driver-operator.v5.0.0
   selector:
     matchLabels:
       alm-owner-metering: aws-efs-csi-driver-operator

--- a/config/samba/manifests/smb-csi-driver-operator.package.yaml
+++ b/config/samba/manifests/smb-csi-driver-operator.package.yaml
@@ -1,4 +1,4 @@
 packageName: smb-csi-driver-operator
 channels:
   - name: stable
-    currentCSV: smb-csi-driver-operator.v4.22.0
+    currentCSV: smb-csi-driver-operator.v5.0.0

--- a/config/samba/manifests/stable/smb-csi-driver-operator.clusterserviceversion.yaml
+++ b/config/samba/manifests/stable/smb-csi-driver-operator.clusterserviceversion.yaml
@@ -1,7 +1,7 @@
 apiVersion: operators.coreos.com/v1alpha1
 kind: ClusterServiceVersion
 metadata:
-  name: smb-csi-driver-operator.v4.22.0
+  name: smb-csi-driver-operator.v5.0.0
   namespace: placeholder
   annotations:
     categories: Storage
@@ -13,8 +13,8 @@ metadata:
     repository: https://github.com/openshift/csi-operator
     createdAt: "2021-07-14T00:00:00Z"
     description: Install and configure CIFS/SMB CSI driver.
-    olm.properties: '[{"type":"olm.maxOpenShiftVersion","value":"4.23"}]'
-    olm.skipRange: ">=4.15.0-0 <4.22.0"
+    olm.properties: '[{"type":"olm.maxOpenShiftVersion","value":"5.1"}]'
+    olm.skipRange: ">=4.15.0-0 <5.0.0"
     features.operators.openshift.io/disconnected: "true"
     features.operators.openshift.io/fips-compliant: "false"
     features.operators.openshift.io/proxy-aware: "true"
@@ -44,7 +44,7 @@ spec:
       url: https://github.com/openshift/csi-operator
     - name: Source Repository
       url: https://github.com/openshift/csi-operator
-  version: 4.22.0
+  version: 5.0.0
   maturity: stable
   maintainers:
     - email: aos-storage-staff@redhat.com
@@ -54,7 +54,7 @@ spec:
     name: Red Hat
   labels:
     alm-owner-metering: smb-csi-driver-operator
-    alm-status-descriptors: smb-csi-driver-operator.v4.22.0
+    alm-status-descriptors: smb-csi-driver-operator.v5.0.0
   selector:
     matchLabels:
       alm-owner-metering: smb-csi-driver-operator


### PR DESCRIPTION
https://redhat.atlassian.net/browse/STOR-2920

Changes generated with:

`make metadata OCP_VERSION=5.0.0`

/cc @openshift/storage
