### PR TITLE
OCPBUGS-85106: Add required-scc annotation to EFS and SMB operator deployments

### DIFF
--- a/config/aws-efs/manifests/stable/aws-efs-csi-driver-operator.clusterserviceversion.yaml
+++ b/config/aws-efs/manifests/stable/aws-efs-csi-driver-operator.clusterserviceversion.yaml
@@ -355,6 +355,7 @@ spec:
               metadata:
                 annotations:
                   target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+                  openshift.io/required-scc: restricted-v2
                 labels:
                   app: aws-efs-csi-driver-operator
                   openshift.storage.network-policy.all-egress: allow

--- a/config/samba/manifests/stable/smb-csi-driver-operator.clusterserviceversion.yaml
+++ b/config/samba/manifests/stable/smb-csi-driver-operator.clusterserviceversion.yaml
@@ -306,6 +306,7 @@ spec:
               metadata:
                 annotations:
                   target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+                  openshift.io/required-scc: restricted-v2
                 labels:
                   app: smb-csi-driver-operator
                   openshift.storage.network-policy.dns: allow


### PR DESCRIPTION
Failing sippy tests: https://sippy.dptools.openshift.org/sippy-ng/tests/5.0/analysis?test=%5BMonitor%3Arequired-scc-annotation-checker%5D%5Bsig-auth%5D%20all%20workloads%20in%20ns%2Fopenshift-cluster-csi-drivers%20must%20set%20the%20%27openshift.io%2Frequired-scc%27%20annotation

We're planning on fixing all remaining workloads in `ns/openshift-cluster-csi-drivers` so that we can drop the [exception](https://github.com/openshift/origin/blob/main/pkg/monitortests/authentication/requiredsccmonitortests/monitortest.go#L42) from the required-scc-annotation-checker monitor test.