### PR TITLE
STOR-2996: Sync gcp pd csi driver operator to legacy subdir

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: rhel-9-release-golang-1.25-openshift-4.22
+  tag: rhel-9-release-golang-1.26-openshift-5.0

--- a/Dockerfile.gcp-pd
+++ b/Dockerfile.gcp-pd
@@ -1,9 +1,9 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.25-openshift-4.22 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.26-openshift-5.0 AS builder
 WORKDIR /go/src/github.com/openshift/gcp-pd-csi-driver-operator
 COPY legacy/gcp-pd-csi-driver-operator .
 RUN make
 
-FROM registry.ci.openshift.org/ocp/4.22:base-rhel9
+FROM registry.ci.openshift.org/ocp/5.0:base-rhel9
 COPY --from=builder /go/src/github.com/openshift/gcp-pd-csi-driver-operator/gcp-pd-csi-driver-operator /usr/bin/
 ENTRYPOINT ["/usr/bin/gcp-pd-csi-driver-operator"]
 LABEL io.k8s.display-name="OpenShift GCP PD CSI Driver Operator" \

--- a/Dockerfile.openshift
+++ b/Dockerfile.openshift
@@ -1,9 +1,9 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.25-openshift-4.22 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.26-openshift-5.0 AS builder
 WORKDIR /go/src/github.com/openshift/gcp-pd-csi-driver-operator
 COPY . .
 RUN make
 
-FROM registry.ci.openshift.org/ocp/4.22:base-rhel9
+FROM registry.ci.openshift.org/ocp/5.0:base-rhel9
 COPY --from=builder /go/src/github.com/openshift/gcp-pd-csi-driver-operator/gcp-pd-csi-driver-operator /usr/bin/
 ENTRYPOINT ["/usr/bin/gcp-pd-csi-driver-operator"]
 LABEL io.k8s.display-name="OpenShift GCP PD CSI Driver Operator" \

--- a/test/e2e/manifest.yaml
+++ b/test/e2e/manifest.yaml
@@ -31,7 +31,7 @@ DriverInfo:
     multipods: true
     multiplePVsSameID: true
   VolumeSnapshotStressTestOptions:
-    NumPods: 2
-    NumSnapshots: 5
+    NumPods: 5
+    NumSnapshots: 2
 Timeouts:
   DataSourceProvision: 10m


### PR DESCRIPTION
Since PR#562 (which populated legacy/gcp-pd-csi-driver-operator) two PRs merged in openshift/gcp-pd-csi-driver-operator:

 * https://github.com/openshift/gcp-pd-csi-driver-operator/pull/190
 * https://github.com/openshift/gcp-pd-csi-driver-operator/pull/192

This PR brings corresponding commits to csi-operator repo by command:
```
$ git subtree pull --prefix=legacy/gcp-pd-csi-driver-operator --squash https://github.com/openshift/gcp-pd-csi-driver-operator main
```

After that, the PR adds one manual change on the top sync-ing legacy/gcp-pd-csi-driver-operator/Dockerfile.openshift into root Dockerfile.gcp-pd.

https://redhat.atlassian.net/browse/STOR-2996