### PR TITLE
STOR-2996: Run unit-tests in /legacy subdir

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,13 @@ include $(addprefix ./vendor/github.com/openshift/build-machinery-go/make/, \
 	targets/openshift/yq.mk \
 )
 
+# Run unit tests in legacy modules as part of test-unit
+test-unit: test-unit-legacy
+
+test-unit-legacy:
+	$(MAKE) -C legacy/gcp-pd-csi-driver-operator test-unit
+.PHONY: test-unit-legacy
+
 # Bump OCP version in CSV and OLM metadata
 #
 # Example:


### PR DESCRIPTION
The initial PR moving `gcp-pd-csi-driver-operator` from https://github.com/openshift/gcp-pd-csi-driver-operator to `/legacy` subdir if csi-operator missed the issue: CI unit-test job simply executes `make test-unit`, and it does not cross module boundaries (because `legacy/gcp-pd-csi-driver-operator/` has its own `go.mod`)

https://redhat.atlassian.net/browse/STOR-2996