### PR TITLE
OCPBUGS-97920: allow specific actions for AWS EFS CredentialsRequest

### DIFF
--- a/assets/overlays/aws-efs/base/credentials.yaml
+++ b/assets/overlays/aws-efs/base/credentials.yaml
@@ -13,7 +13,13 @@ spec:
     statementEntries:
     - effect: Allow
       action:
-      - elasticfilesystem:*
+      # https://github.com/openshift/aws-efs-csi-driver/blob/master/docs/iam-policy-example.json
+      - elasticfilesystem:DescribeAccessPoints
+      - elasticfilesystem:DescribeFileSystems
+      - elasticfilesystem:DescribeMountTargets
+      - elasticfilesystem:CreateAccessPoint
+      - elasticfilesystem:DeleteAccessPoint
+      - elasticfilesystem:TagResource
       - ec2:DescribeAvailabilityZones # for one-zone volumes
       resource: "*"
   # STS fields will be set by the operator

--- a/assets/overlays/aws-efs/generated/standalone/credentials.yaml
+++ b/assets/overlays/aws-efs/generated/standalone/credentials.yaml
@@ -15,7 +15,12 @@ spec:
     kind: AWSProviderSpec
     statementEntries:
     - action:
-      - elasticfilesystem:*
+      - elasticfilesystem:DescribeAccessPoints
+      - elasticfilesystem:DescribeFileSystems
+      - elasticfilesystem:DescribeMountTargets
+      - elasticfilesystem:CreateAccessPoint
+      - elasticfilesystem:DeleteAccessPoint
+      - elasticfilesystem:TagResource
       - ec2:DescribeAvailabilityZones
       effect: Allow
       resource: '*'


### PR DESCRIPTION
https://redhat.atlassian.net/browse/OCPBUGS-97920

This PR replaces the wildcard `elasticfilesystem:*` in the CredentialsRequest for AWS EFS with specific actions from https://github.com/openshift/aws-efs-csi-driver/blob/master/docs/iam-policy-example.json

/cc @openshift/storage
