### PR TITLE
OCPBUGS-99199: Add networking.k8s.io group policy

### DIFF
--- a/config/aws-efs/manifests/stable/aws-efs-csi-driver-operator.clusterserviceversion.yaml
+++ b/config/aws-efs/manifests/stable/aws-efs-csi-driver-operator.clusterserviceversion.yaml
@@ -343,6 +343,14 @@ spec:
                 - get
                 - list
                 - watch
+            - apiGroups:
+                - networking.k8s.io
+              resources:
+                - networkpolicies
+              verbs:
+                - create
+                - delete
+                - update
           serviceAccountName: aws-efs-csi-driver-operator
       deployments:
         - name: aws-efs-csi-driver-operator


### PR DESCRIPTION
https://redhat.atlassian.net/browse/OCPBUGS-99199

Add `networking.k8s.io/networkpolicies` RBAC to the aws-efs CSV to pass the `olm.required_network_policy_rbac_for_operands` Conforma check, which becomes a release blocker on August 8th.