### PR TITLE
OCPBUGS-99200: Add networking.k8s.io group policy

### DIFF
--- a/config/samba/manifests/stable/smb-csi-driver-operator.clusterserviceversion.yaml
+++ b/config/samba/manifests/stable/smb-csi-driver-operator.clusterserviceversion.yaml
@@ -294,6 +294,14 @@ spec:
                 - get
                 - list
                 - watch
+            - apiGroups:
+                - networking.k8s.io
+              resources:
+                - networkpolicies
+              verbs:
+                - create
+                - delete
+                - update
           serviceAccountName: smb-csi-driver-operator
       deployments:
         - name: smb-csi-driver-operator


### PR DESCRIPTION
https://redhat.atlassian.net/browse/OCPBUGS-99200

Add `networking.k8s.io/networkpolicies` RBAC to the SMB CSI driver operator CSV to pass the `olm.required_network_policy_rbac_for_operands` Conforma check, which becomes a release blocker on August 8th.