### PR TITLE
STOR-2998: Copy the test manifests from the `legacy` dir to a top-level `test` dir

### DIFF
--- a/test/e2e/gcp-pd/hyperdisk-manifest.yaml
+++ b/test/e2e/gcp-pd/hyperdisk-manifest.yaml
@@ -1,0 +1,39 @@
+StorageClass:
+  FromExistingClassName: hyperdisk-balanced
+SnapshotClass:
+  FromName: true
+VolumeAttributesClass:
+  FromFile: volumeattributesclass.yaml
+DriverInfo:
+  Name: pd.csi.storage.gke.io
+  SupportedFsType:
+    xfs: {}
+    ext4: {}
+  SupportedMountOption:
+    debug:
+    nouid32:
+  SupportedSizeRange:
+    # Smaller volumes cannot pass resize tests due to IOPS. 
+    # For example, 4Gi volume gets 2000 IOPS max and it cannot be resized to 5Gi that needs 2500 as minimum.
+    # 6Gi gets 3000 IOPS, which is the minimum for any bigger volume.
+    Min: 6Gi 
+    Max: 64Ti
+  TopologyKeys:
+    - topology.gke.io/zone
+  Capabilities:
+    persistence: true
+    fsGroup: true
+    block: true
+    exec: true
+    # The driver does support volume limits, however, we disable
+    # the capability to avoid creating 100+ volumes in a single test.
+    volumeLimits: false
+    controllerExpansion: true
+    nodeExpansion: true
+    snapshotDataSource: true
+    pvcDataSource: true
+    topology: true
+    multipods: true
+    multiplePVsSameID: true
+Timeouts:
+  DataSourceProvision: 10m

--- a/test/e2e/gcp-pd/image-snapshot-manifest.yaml
+++ b/test/e2e/gcp-pd/image-snapshot-manifest.yaml
@@ -1,0 +1,37 @@
+StorageClass:
+  FromExistingClassName: ssd-csi
+SnapshotClass:
+  FromExistingClassName: csi-gce-pd-vsc-images
+DriverInfo:
+  Name: pd.csi.storage.gke.io
+  SupportedFsType:
+    xfs: {}
+    ext4: {}
+  SupportedMountOption:
+    debug:
+    nouid32:
+  SupportedSizeRange:
+    Min: 1Gi
+    Max: 64Ti
+  TopologyKeys:
+    - topology.gke.io/zone
+  Capabilities:
+    persistence: true
+    fsGroup: true
+    block: true
+    exec: true
+    # The driver does support volume limits, however, we disable
+    # the capability to avoid creating 100+ volumes in a single test.
+    volumeLimits: false
+    controllerExpansion: true
+    nodeExpansion: true
+    snapshotDataSource: true
+    pvcDataSource: true
+    topology: true
+    multipods: true
+    multiplePVsSameID: true
+  VolumeSnapshotStressTestOptions:
+    NumPods: 2
+    NumSnapshots: 5
+Timeouts:
+  DataSourceProvision: 10m

--- a/test/e2e/gcp-pd/manifest.yaml
+++ b/test/e2e/gcp-pd/manifest.yaml
@@ -1,0 +1,37 @@
+StorageClass:
+  FromExistingClassName: ssd-csi
+SnapshotClass:
+  FromName: true
+DriverInfo:
+  Name: pd.csi.storage.gke.io
+  SupportedFsType:
+    xfs: {}
+    ext4: {}
+  SupportedMountOption:
+    debug:
+    nouid32:
+  SupportedSizeRange:
+    Min: 1Gi
+    Max: 64Ti
+  TopologyKeys:
+    - topology.gke.io/zone
+  Capabilities:
+    persistence: true
+    fsGroup: true
+    block: true
+    exec: true
+    # The driver does support volume limits, however, we disable
+    # the capability to avoid creating 100+ volumes in a single test.
+    volumeLimits: false
+    controllerExpansion: true
+    nodeExpansion: true
+    snapshotDataSource: true
+    pvcDataSource: true
+    topology: true
+    multipods: true
+    multiplePVsSameID: true
+  VolumeSnapshotStressTestOptions:
+    NumPods: 5
+    NumSnapshots: 2
+Timeouts:
+  DataSourceProvision: 10m

--- a/test/e2e/gcp-pd/ocp-manifest.yaml
+++ b/test/e2e/gcp-pd/ocp-manifest.yaml
@@ -1,0 +1,4 @@
+Driver: pd.csi.storage.gke.io
+LUNStressTest:
+  PodsTotal: 260
+  Timeout: "30m" # The test needs ~10 min in ideal conditions.

--- a/test/e2e/gcp-pd/volumeattributesclass.yaml
+++ b/test/e2e/gcp-pd/volumeattributesclass.yaml
@@ -1,0 +1,8 @@
+apiVersion: storage.k8s.io/v1
+kind: VolumeAttributesClass
+metadata:
+  name: csi-gcepd-hdb-vac
+driverName: pd.csi.storage.gke.io
+parameters:
+  iops: "3000"
+  throughput: "140Mi"


### PR DESCRIPTION
so we can eventually remove the legacy dir (after updating CI jobs).

```
$ cp legacy/gcp-pd-csi-driver-operator/test/e2e/*.yaml test/e2e/gcp-pd/
```