### PR TITLE
OCPBUGS-100071: csi-driver-smb: DeleteVolume call fails to mkdir under /tmp

### DIFF
--- a/assets/overlays/samba/generated/standalone/controller.yaml
+++ b/assets/overlays/samba/generated/standalone/controller.yaml
@@ -265,5 +265,6 @@ spec:
       - name: metrics-serving-cert
         secret:
           secretName: smb-csi-driver-controller-metrics-serving-cert
-      - emptyDir: {}
+      - emptyDir:
+          medium: Memory
         name: tmp-dir

--- a/assets/overlays/samba/generated/standalone/node.yaml
+++ b/assets/overlays/samba/generated/standalone/node.yaml
@@ -173,7 +173,8 @@ spec:
       - name: metrics-serving-cert
         secret:
           secretName: smb-csi-driver-node-metrics-serving-cert
-      - emptyDir: {}
+      - emptyDir:
+          medium: Memory
         name: tmp-dir
   updateStrategy:
     rollingUpdate:

--- a/assets/overlays/samba/patches/controller_add_driver.yaml
+++ b/assets/overlays/samba/patches/controller_add_driver.yaml
@@ -80,4 +80,5 @@ spec:
         - name: socket-dir
           emptyDir: {}
         - name: tmp-dir
-          emptyDir: {}
+          emptyDir:
+            medium: Memory

--- a/assets/overlays/samba/patches/node_add_driver.yaml
+++ b/assets/overlays/samba/patches/node_add_driver.yaml
@@ -54,4 +54,5 @@ spec:
           terminationMessagePolicy: FallbackToLogsOnError
       volumes:
         - name: tmp-dir
-          emptyDir: {}
+          emptyDir:
+            medium: Memory


### PR DESCRIPTION
https://redhat.atlassian.net/browse/OCPBUGS-100071

`readOnlyRootFilesystem` still applies when the driver attempts to create subdirectories under `/tmp` even though it's mounted as emptydir. Adding `medium: Memory` to the tmp-dir volume though allows new directories to be created under `/tmp` and allows the `DeleteVolume` call to succeed.

Manual testing: ran the operator with these changes locally and followed the "steps to reproduce" in the bug to verify the PV is deleted successfully.

/verified by @dobsonj
/cherry-pick release-4.22 release-4.21

/cc @openshift/storage
