### PR TITLE
OCPBUGS-105392: Add proxy hook for HyperShift CSI driver controller deployments

### DIFF
--- a/pkg/driver/common/operator/hooks.go
+++ b/pkg/driver/common/operator/hooks.go
@@ -43,7 +43,7 @@ func NewDefaultOperatorControllerConfig(flavour generator.ClusterFlavour, c *cli
 		cfg.AddDeploymentHookBuilders(c, withClusterWideProxy, withStandaloneReplicas)
 	} else {
 		// HyperShift
-		cfg.AddDeploymentHookBuilders(c, withHyperShiftReplicas, withHyperShiftNodeSelector, withHyperShiftLabels, withHyperShiftControlPlaneImages, withHyperShiftCustomTolerations, withHyperShiftRunAsUser)
+		cfg.AddDeploymentHookBuilders(c, withHyperShiftReplicas, withHyperShiftNodeSelector, withHyperShiftLabels, withHyperShiftControlPlaneImages, withHyperShiftCustomTolerations, withHyperShiftRunAsUser, withHyperShiftProxy)
 	}
 
 	return cfg
@@ -258,6 +258,22 @@ func withHyperShiftRunAsUser(c *clients.Clients) (dc.DeploymentHookFunc, []facto
 		}
 		deployment.Spec.Template.Spec.SecurityContext.RunAsUser = &runAsUserValue
 
+		return nil
+	}
+	return hook, nil
+}
+
+// withHyperShiftProxy injects management cluster proxy env vars into all containers.
+func withHyperShiftProxy(c *clients.Clients) (dc.DeploymentHookFunc, []factory.Informer) {
+	hook := func(_ *opv1.OperatorSpec, deployment *appsv1.Deployment) error {
+		for _, envName := range []string{"HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY"} {
+			if val := os.Getenv(envName); val != "" {
+				for i := range deployment.Spec.Template.Spec.Containers {
+					c := &deployment.Spec.Template.Spec.Containers[i]
+					c.Env = append(c.Env, corev1.EnvVar{Name: envName, Value: val})
+				}
+			}
+		}
 		return nil
 	}
 	return hook, nil

--- a/pkg/driver/common/operator/hooks_test.go
+++ b/pkg/driver/common/operator/hooks_test.go
@@ -328,6 +328,9 @@ func Test_WithHyperShiftProxy(t *testing.T) {
 			hook, _ := withHyperShiftProxy(c)
 			deployment := getTestDeployment()
 
+			t.Setenv("HTTP_PROXY", "")
+			t.Setenv("HTTPS_PROXY", "")
+			t.Setenv("NO_PROXY", "")
 			for key, value := range tt.env {
 				t.Setenv(key, value)
 			}

--- a/pkg/driver/common/operator/hooks_test.go
+++ b/pkg/driver/common/operator/hooks_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/openshift/csi-operator/pkg/driver/common/operator/test_manifests"
 	"github.com/openshift/library-go/pkg/operator/resource/resourceread"
 	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	fakedynamic "k8s.io/client-go/dynamic/fake"
@@ -258,6 +259,99 @@ func Test_WithHyperShiftControlPlaneImages(t *testing.T) {
 				}
 				if !found {
 					t.Errorf("container %s not found", containerName)
+				}
+			}
+		})
+	}
+}
+
+func findEnvVar(name string, envVars []corev1.EnvVar) *corev1.EnvVar {
+	for i := range envVars {
+		if envVars[i].Name == name {
+			return &envVars[i]
+		}
+	}
+	return nil
+}
+
+func Test_WithHyperShiftProxy(t *testing.T) {
+	tests := []struct {
+		name string
+		env  map[string]string
+		// container name -> env var name -> expected value
+		expectedEnvVars map[string]string
+		absentEnvVars   []string
+	}{
+		{
+			name: "all proxy env vars are set",
+			env: map[string]string{
+				"HTTP_PROXY":  "http://proxy.example.com:8080",
+				"HTTPS_PROXY": "https://proxy.example.com:8443",
+				"NO_PROXY":    "localhost,127.0.0.1",
+			},
+			expectedEnvVars: map[string]string{
+				"HTTP_PROXY":  "http://proxy.example.com:8080",
+				"HTTPS_PROXY": "https://proxy.example.com:8443",
+				"NO_PROXY":    "localhost,127.0.0.1",
+			},
+		},
+		{
+			name: "only HTTP_PROXY is set",
+			env: map[string]string{
+				"HTTP_PROXY": "http://proxy.example.com:8080",
+			},
+			expectedEnvVars: map[string]string{
+				"HTTP_PROXY": "http://proxy.example.com:8080",
+			},
+			absentEnvVars: []string{"HTTPS_PROXY", "NO_PROXY"},
+		},
+		{
+			name: "only HTTPS_PROXY is set",
+			env: map[string]string{
+				"HTTPS_PROXY": "https://proxy.example.com:8443",
+			},
+			expectedEnvVars: map[string]string{
+				"HTTPS_PROXY": "https://proxy.example.com:8443",
+			},
+			absentEnvVars: []string{"HTTP_PROXY", "NO_PROXY"},
+		},
+		{
+			name:          "no proxy env vars are set",
+			env:           nil,
+			absentEnvVars: []string{"HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cr := clients.GetFakeOperatorCR()
+			c := clients.NewFakeClients("clusters-test", cr)
+			hook, _ := withHyperShiftProxy(c)
+			deployment := getTestDeployment()
+
+			for key, value := range tt.env {
+				t.Setenv(key, value)
+			}
+			clients.SyncFakeInformers(t, c)
+
+			err := hook(&cr.Spec.OperatorSpec, deployment)
+			if err != nil {
+				t.Fatalf("unexpected hook error: %v", err)
+			}
+
+			for _, container := range deployment.Spec.Template.Spec.Containers {
+				for envName, expectedValue := range tt.expectedEnvVars {
+					envVar := findEnvVar(envName, container.Env)
+					if envVar == nil {
+						t.Errorf("container %s: expected env var %s to be present", container.Name, envName)
+					} else if envVar.Value != expectedValue {
+						t.Errorf("container %s: expected %s=%s, got %s", container.Name, envName, expectedValue, envVar.Value)
+					}
+				}
+
+				for _, envName := range tt.absentEnvVars {
+					if findEnvVar(envName, container.Env) != nil {
+						t.Errorf("container %s: expected env var %s to be absent", container.Name, envName)
+					}
 				}
 			}
 		})


### PR DESCRIPTION

  ## Summary

  - Add `withHyperShiftProxy` hook to inject management cluster proxy env vars (`HTTP_PROXY`, `HTTPS_PROXY`, `NO_PROXY`) into CSI driver controller containers in HyperShift mode.
  - Register the hook in `NewDefaultOperatorControllerConfig` for the HyperShift branch
  - Add unit tests covering full proxy, partial proxy, and no-proxy scenarios

  ## Problem
In `NewDefaultOperatorControllerConfig()`, the standalone branch registers `withClusterWideProxy` which reads proxy from the guest cluster's `observedConfig`. The HyperShift branch has no proxy hook at all, leaving CSI driver controller containers (csi-driver, csi-provisioner, csi-attacher, etc.) unable to reach cloud APIs when the management cluster requires a proxy.

  ## Fix
  
The new `withHyperShiftProxy` hook reads proxy env vars from `os.Getenv()` (management cluster proxy) and injects them into  all containers. This follows the same pattern as `withHyperShiftControlPlaneImages` and `withHyperShiftRunAsUser` in the same file. It is a no-op when no proxy is configured. Standalone mode is unaffected.

  This is step 3 of a 3-repo fix:
  1. **HyperShift CPO** (OCPBUGS-105282) — Inject proxy env vars into CSO deployment
  2. **cluster-storage-operator** (OCPBUGS-105391) — Pass proxy env vars to operand deployments
  3. **csi-operator** (this PR) — Add `withHyperShiftProxy` hook to inject proxy into CSI driver controller containers

  ## Test plan

  - [ ] Unit tests pass: `go test -race ./pkg/driver/common/operator/... -v`
  - [ ] `make test` passes
  - [ ] `make verify` passes
  - [ ] Full end-to-end validation requires all 3 repos fixed and tested on a proxy-required management cluster

  ## JIRA

  - [OCPBUGS-105392](https://redhat.atlassian.net/browse/OCPBUGS-105392)
  - Related: [OCPBUGS-105282](https://redhat.atlassian.net/browse/OCPBUGS-105282),
  [OCPBUGS-105391](https://redhat.atlassian.net/browse/OCPBUGS-105391)