### PR TITLE
OCPBUGS-101779: azure-disk: Disallow empty cloud config

### DIFF
--- a/assets/overlays/azure-disk/generated/hypershift/controller.yaml
+++ b/assets/overlays/azure-disk/generated/hypershift/controller.yaml
@@ -106,6 +106,7 @@ spec:
         - --v=${LOG_LEVEL}
         - --cloud-config-secret-name=
         - --cloud-config-secret-namespace=
+        - --allow-empty-cloud-config=false
         env:
         - name: AZURE_CREDENTIAL_FILE
           value: /etc/kubernetes/cloud.conf

--- a/assets/overlays/azure-disk/generated/hypershift/node.yaml
+++ b/assets/overlays/azure-disk/generated/hypershift/node.yaml
@@ -43,6 +43,7 @@ spec:
         - --cloud-config-secret-name=
         - --cloud-config-secret-namespace=
         - --remove-not-ready-taint=false
+        - --allow-empty-cloud-config=false
         env:
         - name: AZURE_CREDENTIAL_FILE
           value: /etc/kubernetes/cloud.conf

--- a/assets/overlays/azure-disk/generated/standalone/controller.yaml
+++ b/assets/overlays/azure-disk/generated/standalone/controller.yaml
@@ -71,6 +71,7 @@ spec:
         - --v=${LOG_LEVEL}
         - --cloud-config-secret-name=
         - --cloud-config-secret-namespace=
+        - --allow-empty-cloud-config=false
         env:
         - name: AZURE_CREDENTIAL_FILE
           value: /etc/kubernetes/cloud.conf

--- a/assets/overlays/azure-disk/generated/standalone/node.yaml
+++ b/assets/overlays/azure-disk/generated/standalone/node.yaml
@@ -43,6 +43,7 @@ spec:
         - --cloud-config-secret-name=
         - --cloud-config-secret-namespace=
         - --remove-not-ready-taint=false
+        - --allow-empty-cloud-config=false
         env:
         - name: AZURE_CREDENTIAL_FILE
           value: /etc/kubernetes/cloud.conf

--- a/assets/overlays/azure-disk/patches/controller_add_driver.yaml
+++ b/assets/overlays/azure-disk/patches/controller_add_driver.yaml
@@ -27,6 +27,8 @@ spec:
             # Use credentials provided by the azure-inject-credentials container
             - --cloud-config-secret-name=
             - --cloud-config-secret-namespace=
+            # Disallow empty cloud config
+            - --allow-empty-cloud-config=false
           env:
             - name: AZURE_CREDENTIAL_FILE
               value: "/etc/kubernetes/cloud.conf"

--- a/assets/overlays/azure-disk/patches/node_add_driver.yaml
+++ b/assets/overlays/azure-disk/patches/node_add_driver.yaml
@@ -26,6 +26,8 @@ spec:
             # Disable the remove-not-ready-taint, as it is not implemented in ocp
             # https://github.com/kubernetes-sigs/azuredisk-csi-driver/pull/2309
             - --remove-not-ready-taint=false
+            # Disallow empty cloud config
+            - --allow-empty-cloud-config=false
           env:
             - name: AZURE_CREDENTIAL_FILE
               value: "/etc/kubernetes/cloud.conf"


### PR DESCRIPTION
https://redhat.atlassian.net/browse/OCPBUGS-101779

We always pass cloud config to controller and node pods via `AZURE_CREDENTIAL_FILE`, hence empty cloud config must never happen.

This PR doesn't fully resolve OCPBUGS-101779, but if something goes wrong, it is better to return error explicitly than crashes with nil pointer dereference.