### PR TITLE
GCP-1074: feat(gcp-pd): enable HyperShift support for GCP PD CSI driver operator

### DIFF
--- a/assets/overlays/gcp-pd/generated/hypershift/cabundle_cm.yaml
+++ b/assets/overlays/gcp-pd/generated/hypershift/cabundle_cm.yaml
@@ -1,0 +1,13 @@
+# Generated file. Do not edit. Update using "make update".
+#
+# Loaded from base/cabundle_cm.yaml
+#
+#
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    config.openshift.io/inject-trusted-cabundle: "true"
+  name: gcp-pd-csi-driver-trusted-ca-bundle
+  namespace: ${NAMESPACE}

--- a/assets/overlays/gcp-pd/generated/hypershift/controller.yaml
+++ b/assets/overlays/gcp-pd/generated/hypershift/controller.yaml
@@ -4,20 +4,28 @@
 # Applied strategic merge patch overlays/gcp-pd/patches/controller_add_driver.yaml
 # provisioner.yaml: Loaded from common/sidecars/provisioner.yaml
 # provisioner.yaml: Added arguments [--default-fstype=ext4 --feature-gates=Topology=true --extra-create-metadata=true --timeout=250s --controller-publish-readonly]
+# provisioner.yaml: Applied JSON patch common/hypershift/sidecar_add_kubeconfig.yaml.patch
 # Applied strategic merge patch provisioner.yaml
 # attacher.yaml: Loaded from common/sidecars/attacher.yaml
 # attacher.yaml: Added arguments [--timeout=250s]
+# attacher.yaml: Applied JSON patch common/hypershift/sidecar_add_kubeconfig.yaml.patch
 # Applied strategic merge patch attacher.yaml
 # resizer.yaml: Loaded from common/sidecars/resizer.yaml
+# resizer.yaml: Applied JSON patch common/hypershift/sidecar_add_kubeconfig.yaml.patch
 # Applied strategic merge patch resizer.yaml
 # snapshotter.yaml: Loaded from common/sidecars/snapshotter.yaml
 # snapshotter.yaml: Added arguments [--timeout=300s]
+# snapshotter.yaml: Applied JSON patch common/hypershift/sidecar_add_kubeconfig.yaml.patch
 # Applied strategic merge patch snapshotter.yaml
 # pod_network_livenessprobe.yaml: Loaded from common/sidecars/pod_network_livenessprobe.yaml
 # pod_network_livenessprobe.yaml: Added arguments [--probe-timeout=3s]
 # Applied strategic merge patch pod_network_livenessprobe.yaml
-# Applied strategic merge patch common/standalone/controller_add_affinity.yaml
+# Applied strategic merge patch common/hypershift/controller_add_affinity_tolerations.yaml
+# Applied JSON patch common/hypershift/controller_add_kubeconfig_volume.yaml.patch
+# Applied strategic merge patch common/hypershift/controller_add_hypershift_managed_by_label.yaml
+# Applied strategic merge patch common/hypershift/controller_add_hypershift_desired_version_annotation.yaml
 # Applied strategic merge patch common/readOnlyRootFilesystem.yaml
+# Applied strategic merge patch overlays/gcp-pd/patches/controller_add_hypershift_controller_minter.yaml
 #
 #
 
@@ -27,6 +35,9 @@ metadata:
   annotations:
     config.openshift.io/inject-proxy: csi-driver
     config.openshift.io/inject-proxy-cabundle: csi-driver
+    release.openshift.io/desired-version: ${RELEASE_VERSION}
+  labels:
+    hypershift.openshift.io/managed-by: cluster-storage-operator
   name: gcp-pd-csi-driver-controller
   namespace: ${NAMESPACE}
 spec:
@@ -46,8 +57,33 @@ spec:
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app: gcp-pd-csi-driver-controller
+        hypershift.openshift.io/hosted-control-plane: ${NAMESPACE}
     spec:
       affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: hypershift.openshift.io/control-plane
+                operator: In
+                values:
+                - "true"
+            weight: 50
+          - preference:
+              matchExpressions:
+              - key: hypershift.openshift.io/cluster
+                operator: In
+                values:
+                - ${NAMESPACE}
+            weight: 100
+        podAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  hypershift.openshift.io/hosted-control-plane: ${NAMESPACE}
+              topologyKey: kubernetes.io/hostname
+            weight: 100
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
           - podAffinityTerm:
@@ -65,9 +101,11 @@ spec:
         - --allow-hdha-provisioning=true
         - --supports-dynamic-throughput-provisioning=hyperdisk-balanced,hyperdisk-throughput,hyperdisk-ml
         - --supports-dynamic-iops-provisioning=hyperdisk-balanced,hyperdisk-extreme
+        - --run-node-service=false
+        - --cloud-config=/etc/gcp-cloud-config/cloud.conf
         env:
         - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/cloud-sa/service_account.json
+          value: /etc/cloud-sa/application_default_credentials.json
         - name: CSI_ENDPOINT
           value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
         image: ${DRIVER_IMAGE}
@@ -88,6 +126,7 @@ spec:
         resources:
           requests:
             cpu: 10m
+            ephemeral-storage: 20Mi
             memory: 50Mi
         securityContext:
           readOnlyRootFilesystem: true
@@ -100,6 +139,9 @@ spec:
           readOnly: true
         - mountPath: /var/run/secrets/openshift/serviceaccount
           name: bound-sa-token
+          readOnly: true
+        - mountPath: /etc/gcp-cloud-config
+          name: gcp-cloud-config
           readOnly: true
       - args:
         - --csi-address=/var/lib/csi/sockets/pluginproxy/csi.sock
@@ -115,13 +157,17 @@ spec:
         - --extra-create-metadata=true
         - --timeout=250s
         - --controller-publish-readonly
-        env: []
+        - --kubeconfig=$(KUBECONFIG)
+        env:
+        - name: KUBECONFIG
+          value: /etc/hosted-kubernetes/kubeconfig
         image: ${PROVISIONER_IMAGE}
         imagePullPolicy: IfNotPresent
         name: csi-provisioner
         resources:
           requests:
             cpu: 10m
+            ephemeral-storage: 10Mi
             memory: 50Mi
         securityContext:
           readOnlyRootFilesystem: true
@@ -129,6 +175,9 @@ spec:
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
+        - mountPath: /etc/hosted-kubernetes
+          name: hosted-kubeconfig
+          readOnly: true
       - args:
         - --secure-listen-address=0.0.0.0:9202
         - --upstream=http://127.0.0.1:8202/
@@ -147,6 +196,7 @@ spec:
         resources:
           requests:
             cpu: 10m
+            ephemeral-storage: 10Mi
             memory: 20Mi
         securityContext:
           readOnlyRootFilesystem: true
@@ -164,13 +214,17 @@ spec:
         - --leader-election-namespace=${NODE_NAMESPACE}
         - --v=${LOG_LEVEL}
         - --timeout=250s
-        env: []
+        - --kubeconfig=$(KUBECONFIG)
+        env:
+        - name: KUBECONFIG
+          value: /etc/hosted-kubernetes/kubeconfig
         image: ${ATTACHER_IMAGE}
         imagePullPolicy: IfNotPresent
         name: csi-attacher
         resources:
           requests:
             cpu: 10m
+            ephemeral-storage: 10Mi
             memory: 50Mi
         securityContext:
           readOnlyRootFilesystem: true
@@ -178,6 +232,9 @@ spec:
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
+        - mountPath: /etc/hosted-kubernetes
+          name: hosted-kubeconfig
+          readOnly: true
       - args:
         - --secure-listen-address=0.0.0.0:9203
         - --upstream=http://127.0.0.1:8203/
@@ -196,6 +253,7 @@ spec:
         resources:
           requests:
             cpu: 10m
+            ephemeral-storage: 10Mi
             memory: 20Mi
         securityContext:
           readOnlyRootFilesystem: true
@@ -212,13 +270,17 @@ spec:
         - --leader-election-retry-period=${LEADER_ELECTION_RETRY_PERIOD}
         - --leader-election-namespace=${NODE_NAMESPACE}
         - --v=${LOG_LEVEL}
-        env: []
+        - --kubeconfig=$(KUBECONFIG)
+        env:
+        - name: KUBECONFIG
+          value: /etc/hosted-kubernetes/kubeconfig
         image: ${RESIZER_IMAGE}
         imagePullPolicy: IfNotPresent
         name: csi-resizer
         resources:
           requests:
             cpu: 10m
+            ephemeral-storage: 10Mi
             memory: 50Mi
         securityContext:
           readOnlyRootFilesystem: true
@@ -226,6 +288,9 @@ spec:
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
+        - mountPath: /etc/hosted-kubernetes
+          name: hosted-kubeconfig
+          readOnly: true
       - args:
         - --secure-listen-address=0.0.0.0:9204
         - --upstream=http://127.0.0.1:8204/
@@ -244,6 +309,7 @@ spec:
         resources:
           requests:
             cpu: 10m
+            ephemeral-storage: 10Mi
             memory: 20Mi
         securityContext:
           readOnlyRootFilesystem: true
@@ -261,13 +327,17 @@ spec:
         - --leader-election-namespace=${NODE_NAMESPACE}
         - --v=${LOG_LEVEL}
         - --timeout=300s
-        env: []
+        - --kubeconfig=$(KUBECONFIG)
+        env:
+        - name: KUBECONFIG
+          value: /etc/hosted-kubernetes/kubeconfig
         image: ${SNAPSHOTTER_IMAGE}
         imagePullPolicy: IfNotPresent
         name: csi-snapshotter
         resources:
           requests:
             cpu: 10m
+            ephemeral-storage: 10Mi
             memory: 50Mi
         securityContext:
           readOnlyRootFilesystem: true
@@ -275,6 +345,9 @@ spec:
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
+        - mountPath: /etc/hosted-kubernetes
+          name: hosted-kubeconfig
+          readOnly: true
       - args:
         - --secure-listen-address=0.0.0.0:9205
         - --upstream=http://127.0.0.1:8205/
@@ -293,6 +366,7 @@ spec:
         resources:
           requests:
             cpu: 10m
+            ephemeral-storage: 10Mi
             memory: 20Mi
         securityContext:
           readOnlyRootFilesystem: true
@@ -312,6 +386,7 @@ spec:
         resources:
           requests:
             cpu: 10m
+            ephemeral-storage: 10Mi
             memory: 50Mi
         securityContext:
           readOnlyRootFilesystem: true
@@ -319,17 +394,44 @@ spec:
         volumeMounts:
         - mountPath: /csi
           name: socket-dir
-      hostNetwork: true
-      nodeSelector:
-        node-role.kubernetes.io/master: ""
-      priorityClassName: system-cluster-critical
+      - args:
+        - --service-account-namespace=openshift-cluster-csi-drivers
+        - --service-account-name=gcp-pd-csi-driver-controller-sa
+        - --token-audience=openshift
+        - --token-file=/var/run/secrets/openshift/serviceaccount/token
+        - --kubeconfig=/etc/hosted-kubernetes/kubeconfig
+        command:
+        - /usr/bin/control-plane-operator
+        - token-minter
+        image: ${HYPERSHIFT_IMAGE}
+        imagePullPolicy: IfNotPresent
+        name: token-minter
+        resources:
+          requests:
+            cpu: 10m
+            ephemeral-storage: 10Mi
+            memory: 10Mi
+        securityContext:
+          readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /var/run/secrets/openshift/serviceaccount
+          name: bound-sa-token
+        - mountPath: /etc/hosted-kubernetes
+          name: hosted-kubeconfig
+          readOnly: true
+      hostNetwork: false
+      priorityClassName: hypershift-control-plane
       serviceAccountName: gcp-pd-csi-driver-controller-sa
       tolerations:
-      - key: CriticalAddonsOnly
-        operator: Exists
       - effect: NoSchedule
-        key: node-role.kubernetes.io/master
-        operator: Exists
+        key: hypershift.openshift.io/control-plane
+        operator: Equal
+        value: "true"
+      - effect: NoSchedule
+        key: hypershift.openshift.io/cluster
+        operator: Equal
+        value: ${NAMESPACE}
       volumes:
       - emptyDir: {}
         name: socket-dir
@@ -339,9 +441,13 @@ spec:
       - name: cloud-sa-volume
         secret:
           secretName: gcp-pd-cloud-credentials
-      - name: bound-sa-token
-        projected:
-          sources:
-          - serviceAccountToken:
-              audience: openshift
-              path: token
+      - emptyDir:
+          medium: Memory
+        name: bound-sa-token
+      - name: hosted-kubeconfig
+        secret:
+          defaultMode: 420
+          secretName: service-network-admin-kubeconfig
+      - configMap:
+          name: gcp-pd-cloud-config
+        name: gcp-cloud-config

--- a/assets/overlays/gcp-pd/generated/hypershift/controller_hostnetwork_binding.yaml
+++ b/assets/overlays/gcp-pd/generated/hypershift/controller_hostnetwork_binding.yaml
@@ -1,0 +1,18 @@
+# Generated file. Do not edit. Update using "make update".
+#
+# Loaded from overlays/gcp-pd/base/controller_hostnetwork_binding.yaml
+#
+#
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: gcp-pd-controller-hostnetwork-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: gcp-pd-hostnetwork-role
+subjects:
+- kind: ServiceAccount
+  name: gcp-pd-csi-driver-controller-sa
+  namespace: ${NAMESPACE}

--- a/assets/overlays/gcp-pd/generated/hypershift/controller_pdb.yaml
+++ b/assets/overlays/gcp-pd/generated/hypershift/controller_pdb.yaml
@@ -1,0 +1,17 @@
+# Generated file. Do not edit. Update using "make update".
+#
+# Loaded from base/controller_pdb.yaml
+#
+#
+
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: gcp-pd-csi-driver-controller-pdb
+  namespace: ${NAMESPACE}
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: gcp-pd-csi-driver-controller
+  unhealthyPodEvictionPolicy: AlwaysAllow

--- a/assets/overlays/gcp-pd/generated/hypershift/controller_sa.yaml
+++ b/assets/overlays/gcp-pd/generated/hypershift/controller_sa.yaml
@@ -1,0 +1,14 @@
+# Generated file. Do not edit. Update using "make update".
+#
+# Loaded from base/controller_sa.yaml
+# Applied strategic merge patch common/hypershift/controller_sa_pull_secret.yaml
+#
+#
+
+apiVersion: v1
+imagePullSecrets:
+- name: pull-secret
+kind: ServiceAccount
+metadata:
+  name: gcp-pd-csi-driver-controller-sa
+  namespace: ${NAMESPACE}

--- a/assets/overlays/gcp-pd/generated/hypershift/csidriver.yaml
+++ b/assets/overlays/gcp-pd/generated/hypershift/csidriver.yaml
@@ -1,0 +1,19 @@
+# Generated file. Do not edit. Update using "make update".
+#
+# Loaded from overlays/gcp-pd/base/csidriver.yaml
+#
+#
+
+apiVersion: storage.k8s.io/v1
+kind: CSIDriver
+metadata:
+  name: pd.csi.storage.gke.io
+spec:
+  attachRequired: true
+  fsGroupPolicy: File
+  podInfoOnMount: false
+  requiresRepublish: false
+  seLinuxMount: true
+  storageCapacity: false
+  volumeLifecycleModes:
+  - Persistent

--- a/assets/overlays/gcp-pd/generated/hypershift/hostnetwork_role.yaml
+++ b/assets/overlays/gcp-pd/generated/hypershift/hostnetwork_role.yaml
@@ -1,0 +1,25 @@
+# Generated file. Do not edit. Update using "make update".
+#
+# Loaded from overlays/gcp-pd/base/hostnetwork_role.yaml
+#
+#
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: gcp-pd-hostnetwork-role
+rules:
+- apiGroups:
+  - security.openshift.io
+  resourceNames:
+  - hostnetwork-v2
+  resources:
+  - securitycontextconstraints
+  verbs:
+  - use
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get

--- a/assets/overlays/gcp-pd/generated/hypershift/kube_rbac_proxy_binding.yaml
+++ b/assets/overlays/gcp-pd/generated/hypershift/kube_rbac_proxy_binding.yaml
@@ -1,0 +1,19 @@
+# Generated file. Do not edit. Update using "make update".
+#
+# Loaded from base/rbac/kube_rbac_proxy_binding.yaml
+#
+#
+# Allow kube-rbac-proxies to create tokenreviews to check Prometheus identity when scraping metrics.
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: gcp-pd-kube-rbac-proxy-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: gcp-pd-kube-rbac-proxy-role
+subjects:
+- kind: ServiceAccount
+  name: gcp-pd-csi-driver-controller-sa
+  namespace: ${NAMESPACE}

--- a/assets/overlays/gcp-pd/generated/hypershift/kube_rbac_proxy_role.yaml
+++ b/assets/overlays/gcp-pd/generated/hypershift/kube_rbac_proxy_role.yaml
@@ -1,0 +1,18 @@
+# Generated file. Do not edit. Update using "make update".
+#
+# Loaded from base/rbac/kube_rbac_proxy_role.yaml
+#
+#
+# Allow kube-rbac-proxies to create tokenreviews to check Prometheus identity when scraping metrics.
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: gcp-pd-kube-rbac-proxy-role
+rules:
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create

--- a/assets/overlays/gcp-pd/generated/hypershift/lease_leader_election_binding.yaml
+++ b/assets/overlays/gcp-pd/generated/hypershift/lease_leader_election_binding.yaml
@@ -1,0 +1,20 @@
+# Generated file. Do not edit. Update using "make update".
+#
+# Loaded from base/rbac/lease_leader_election_binding.yaml
+#
+#
+# Grant controller access to leases
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: gcp-pd-csi-driver-lease-leader-election
+  namespace: ${NODE_NAMESPACE}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: gcp-pd-csi-driver-lease-leader-election
+subjects:
+- kind: ServiceAccount
+  name: gcp-pd-csi-driver-controller-sa
+  namespace: ${NODE_NAMESPACE}

--- a/assets/overlays/gcp-pd/generated/hypershift/lease_leader_election_role.yaml
+++ b/assets/overlays/gcp-pd/generated/hypershift/lease_leader_election_role.yaml
@@ -1,0 +1,24 @@
+# Generated file. Do not edit. Update using "make update".
+#
+# Loaded from base/rbac/lease_leader_election_role.yaml
+#
+#
+# Role for electing leader by the operator
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: gcp-pd-csi-driver-lease-leader-election
+  namespace: ${NODE_NAMESPACE}
+rules:
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - watch
+  - list
+  - delete
+  - update
+  - create

--- a/assets/overlays/gcp-pd/generated/hypershift/main_attacher_binding.yaml
+++ b/assets/overlays/gcp-pd/generated/hypershift/main_attacher_binding.yaml
@@ -1,0 +1,19 @@
+# Generated file. Do not edit. Update using "make update".
+#
+# Loaded from base/rbac/main_attacher_binding.yaml
+#   because it's needed by controller sidecar common/sidecars/attacher.yaml
+#
+#
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: gcp-pd-csi-main-attacher-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: openshift-csi-main-attacher-role
+subjects:
+- kind: ServiceAccount
+  name: gcp-pd-csi-driver-controller-sa
+  namespace: ${NODE_NAMESPACE}

--- a/assets/overlays/gcp-pd/generated/hypershift/main_provisioner_binding.yaml
+++ b/assets/overlays/gcp-pd/generated/hypershift/main_provisioner_binding.yaml
@@ -1,0 +1,19 @@
+# Generated file. Do not edit. Update using "make update".
+#
+# Loaded from base/rbac/main_provisioner_binding.yaml
+#   because it's needed by controller sidecar common/sidecars/provisioner.yaml
+#
+#
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: gcp-pd-csi-main-provisioner-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: openshift-csi-main-provisioner-role
+subjects:
+- kind: ServiceAccount
+  name: gcp-pd-csi-driver-controller-sa
+  namespace: ${NODE_NAMESPACE}

--- a/assets/overlays/gcp-pd/generated/hypershift/main_resizer_binding.yaml
+++ b/assets/overlays/gcp-pd/generated/hypershift/main_resizer_binding.yaml
@@ -1,0 +1,19 @@
+# Generated file. Do not edit. Update using "make update".
+#
+# Loaded from base/rbac/main_resizer_binding.yaml
+#   because it's needed by controller sidecar common/sidecars/resizer.yaml
+#
+#
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: gcp-pd-csi-main-resizer-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: openshift-csi-main-resizer-role
+subjects:
+- kind: ServiceAccount
+  name: gcp-pd-csi-driver-controller-sa
+  namespace: ${NODE_NAMESPACE}

--- a/assets/overlays/gcp-pd/generated/hypershift/main_snapshotter_binding.yaml
+++ b/assets/overlays/gcp-pd/generated/hypershift/main_snapshotter_binding.yaml
@@ -1,0 +1,19 @@
+# Generated file. Do not edit. Update using "make update".
+#
+# Loaded from base/rbac/main_snapshotter_binding.yaml
+#   because it's needed by controller sidecar common/sidecars/snapshotter.yaml
+#
+#
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: gcp-pd-csi-main-snapshotter-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: openshift-csi-main-snapshotter-role
+subjects:
+- kind: ServiceAccount
+  name: gcp-pd-csi-driver-controller-sa
+  namespace: ${NODE_NAMESPACE}

--- a/assets/overlays/gcp-pd/generated/hypershift/manifests.yaml
+++ b/assets/overlays/gcp-pd/generated/hypershift/manifests.yaml
@@ -1,0 +1,33 @@
+controllerStaticAssetNames:
+- cabundle_cm.yaml
+- controller.yaml
+- controller_pdb.yaml
+- controller_sa.yaml
+- service.yaml
+guestStaticAssetNames:
+- controller_hostnetwork_binding.yaml
+- csidriver.yaml
+- hostnetwork_role.yaml
+- kube_rbac_proxy_binding.yaml
+- kube_rbac_proxy_role.yaml
+- lease_leader_election_binding.yaml
+- lease_leader_election_role.yaml
+- main_attacher_binding.yaml
+- main_provisioner_binding.yaml
+- main_resizer_binding.yaml
+- main_snapshotter_binding.yaml
+- node.yaml
+- node_privileged_binding.yaml
+- node_sa.yaml
+- privileged_role.yaml
+- prometheus_binding.yaml
+- prometheus_role.yaml
+- storageclass.yaml
+- storageclass_hyperdisk_balanced.yaml
+- storageclass_reader_resizer_binding.yaml
+- storageclass_ssd.yaml
+- volumeattributesclass_reader_provisioner_binding.yaml
+- volumeattributesclass_reader_resizer_binding.yaml
+- volumesnapshot_reader_provisioner_binding.yaml
+- volumesnapshotclass.yaml
+- volumesnapshotclass_images.yaml

--- a/assets/overlays/gcp-pd/generated/hypershift/node.yaml
+++ b/assets/overlays/gcp-pd/generated/hypershift/node.yaml
@@ -1,0 +1,206 @@
+# Generated file. Do not edit. Update using "make update".
+#
+# Loaded from base/node.yaml
+# Applied strategic merge patch overlays/gcp-pd/patches/node_add_driver.yaml
+# node_driver_registrar.yaml: Loaded from common/sidecars/node_driver_registrar.yaml
+# Applied strategic merge patch node_driver_registrar.yaml
+# host_network_livenessprobe.yaml: Loaded from common/sidecars/host_network_livenessprobe.yaml
+# host_network_livenessprobe.yaml: Added arguments [--probe-timeout=3s]
+# Applied strategic merge patch host_network_livenessprobe.yaml
+# Applied strategic merge patch common/readOnlyRootFilesystem.yaml
+#
+#
+
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  annotations:
+    config.openshift.io/inject-proxy: csi-driver
+    config.openshift.io/inject-proxy-cabundle: csi-driver
+  name: gcp-pd-csi-driver-node
+  namespace: ${NODE_NAMESPACE}
+spec:
+  selector:
+    matchLabels:
+      app: gcp-pd-csi-driver-node
+  template:
+    metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/enable-ds-eviction: "false"
+        openshift.io/required-scc: privileged
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+      labels:
+        app: gcp-pd-csi-driver-node
+    spec:
+      containers:
+      - args:
+        - --endpoint=$(CSI_ENDPOINT)
+        - --logtostderr
+        - --v=${LOG_LEVEL}
+        - --enable-storage-pools=true
+        - --node-name=$(KUBE_NODE_NAME)
+        env:
+        - name: CSI_ENDPOINT
+          value: unix:/csi/csi.sock
+        - name: KUBE_NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        image: ${DRIVER_IMAGE}
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          failureThreshold: 5
+          httpGet:
+            host: 127.0.0.1
+            path: /healthz
+            port: healthz
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          timeoutSeconds: 3
+        name: csi-driver
+        ports:
+        - containerPort: 10300
+          name: healthz
+          protocol: TCP
+        resources:
+          requests:
+            cpu: 10m
+            memory: 50Mi
+        securityContext:
+          privileged: true
+          readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /var/lib/kubelet
+          mountPropagation: Bidirectional
+          name: kubelet-dir
+        - mountPath: /csi
+          name: socket-dir
+        - mountPath: /dev
+          name: device-dir
+        - mountPath: /etc/udev
+          name: udev-rules-etc
+        - mountPath: /lib/udev
+          name: udev-rules-lib
+        - mountPath: /run/udev
+          name: udev-socket
+        - mountPath: /sys
+          name: sys
+        - mountPath: /etc/selinux
+          name: etc-selinux
+      - args:
+        - --csi-address=/csi/csi.sock
+        - --kubelet-registration-path=/var/lib/kubelet/plugins/pd.csi.storage.gke.io/csi.sock
+        - --http-endpoint=127.0.0.1:10303
+        - --v=${LOG_LEVEL}
+        env: []
+        image: ${NODE_DRIVER_REGISTRAR_IMAGE}
+        imagePullPolicy: IfNotPresent
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - /bin/sh
+              - -c
+              - rm -rf /registration/pd.csi.storage.gke.io-reg.sock /csi/csi.sock
+        livenessProbe:
+          failureThreshold: 5
+          httpGet:
+            host: 127.0.0.1
+            path: /healthz
+            port: rhealthz
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          timeoutSeconds: 3
+        name: csi-node-driver-registrar
+        ports:
+        - containerPort: 10303
+          name: rhealthz
+          protocol: TCP
+        resources:
+          requests:
+            cpu: 10m
+            memory: 50Mi
+        securityContext:
+          privileged: true
+          readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /csi
+          name: socket-dir
+        - mountPath: /registration
+          name: registration-dir
+      - args:
+        - --csi-address=/csi/csi.sock
+        - --http-endpoint=127.0.0.1:10300
+        - --v=${LOG_LEVEL}
+        - --probe-timeout=3s
+        env: []
+        image: ${LIVENESS_PROBE_IMAGE}
+        imagePullPolicy: IfNotPresent
+        name: csi-liveness-probe
+        resources:
+          requests:
+            cpu: 10m
+            memory: 50Mi
+        securityContext:
+          readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /csi
+          name: socket-dir
+      hostNetwork: true
+      nodeSelector:
+        kubernetes.io/os: linux
+      priorityClassName: system-node-critical
+      serviceAccountName: gcp-pd-csi-driver-node-sa
+      tolerations:
+      - operator: Exists
+      volumes:
+      - hostPath:
+          path: /var/lib/kubelet
+          type: Directory
+        name: kubelet-dir
+      - hostPath:
+          path: /var/lib/kubelet/plugins/pd.csi.storage.gke.io/
+          type: DirectoryOrCreate
+        name: socket-dir
+      - hostPath:
+          path: /var/lib/kubelet/plugins_registry/
+          type: Directory
+        name: registration-dir
+      - hostPath:
+          path: /dev
+          type: Directory
+        name: device-dir
+      - hostPath:
+          path: /etc/selinux
+          type: DirectoryOrCreate
+        name: etc-selinux
+      - hostPath:
+          path: /sys/fs
+          type: Directory
+        name: sys-fs
+      - name: metrics-serving-cert
+        secret:
+          secretName: gcp-pd-csi-driver-node-metrics-serving-cert
+      - hostPath:
+          path: /etc/udev
+          type: Directory
+        name: udev-rules-etc
+      - hostPath:
+          path: /lib/udev
+          type: Directory
+        name: udev-rules-lib
+      - hostPath:
+          path: /run/udev
+          type: Directory
+        name: udev-socket
+      - hostPath:
+          path: /sys
+          type: Directory
+        name: sys
+  updateStrategy:
+    rollingUpdate:
+      maxUnavailable: 10%
+    type: RollingUpdate

--- a/assets/overlays/gcp-pd/generated/hypershift/node_privileged_binding.yaml
+++ b/assets/overlays/gcp-pd/generated/hypershift/node_privileged_binding.yaml
@@ -1,0 +1,18 @@
+# Generated file. Do not edit. Update using "make update".
+#
+# Loaded from base/rbac/node_privileged_binding.yaml
+#
+#
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: gcp-pd-node-privileged-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: gcp-pd-privileged-role
+subjects:
+- kind: ServiceAccount
+  name: gcp-pd-csi-driver-node-sa
+  namespace: ${NODE_NAMESPACE}

--- a/assets/overlays/gcp-pd/generated/hypershift/node_sa.yaml
+++ b/assets/overlays/gcp-pd/generated/hypershift/node_sa.yaml
@@ -1,0 +1,11 @@
+# Generated file. Do not edit. Update using "make update".
+#
+# Loaded from base/node_sa.yaml
+#
+#
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: gcp-pd-csi-driver-node-sa
+  namespace: ${NODE_NAMESPACE}

--- a/assets/overlays/gcp-pd/generated/hypershift/privileged_role.yaml
+++ b/assets/overlays/gcp-pd/generated/hypershift/privileged_role.yaml
@@ -1,0 +1,20 @@
+# Generated file. Do not edit. Update using "make update".
+#
+# Loaded from base/rbac/privileged_role.yaml
+#
+#
+# TODO: create custom SCC with things that the AWS CSI driver needs
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: gcp-pd-privileged-role
+rules:
+- apiGroups:
+  - security.openshift.io
+  resourceNames:
+  - privileged
+  resources:
+  - securitycontextconstraints
+  verbs:
+  - use

--- a/assets/overlays/gcp-pd/generated/hypershift/prometheus_binding.yaml
+++ b/assets/overlays/gcp-pd/generated/hypershift/prometheus_binding.yaml
@@ -1,0 +1,20 @@
+# Generated file. Do not edit. Update using "make update".
+#
+# Loaded from base/rbac/prometheus_binding.yaml
+#
+#
+# Grant cluster-monitoring access to the operator metrics service
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: gcp-pd-csi-driver-prometheus
+  namespace: ${NODE_NAMESPACE}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: gcp-pd-csi-driver-prometheus
+subjects:
+- kind: ServiceAccount
+  name: prometheus-k8s
+  namespace: openshift-monitoring

--- a/assets/overlays/gcp-pd/generated/hypershift/prometheus_role.yaml
+++ b/assets/overlays/gcp-pd/generated/hypershift/prometheus_role.yaml
@@ -1,0 +1,23 @@
+# Generated file. Do not edit. Update using "make update".
+#
+# Loaded from base/rbac/prometheus_role.yaml
+#
+#
+# Role for accessing metrics exposed by the operator
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: gcp-pd-csi-driver-prometheus
+  namespace: ${NODE_NAMESPACE}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - services
+  - endpoints
+  - pods
+  verbs:
+  - get
+  - list
+  - watch

--- a/assets/overlays/gcp-pd/generated/hypershift/service.yaml
+++ b/assets/overlays/gcp-pd/generated/hypershift/service.yaml
@@ -1,0 +1,41 @@
+# Generated file. Do not edit. Update using "make update".
+#
+# Loaded from base/controller_metrics_service.yaml
+# Applied strategic merge patch common/metrics/service_add_port.yaml
+# Applied strategic merge patch common/metrics/service_add_port.yaml
+# Applied strategic merge patch common/metrics/service_add_port.yaml
+# Applied strategic merge patch common/metrics/service_add_port.yaml
+#
+#
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    service.beta.openshift.io/serving-cert-secret-name: gcp-pd-csi-driver-controller-metrics-serving-cert
+  labels:
+    app: gcp-pd-csi-driver-controller-metrics
+  name: gcp-pd-csi-driver-controller-metrics
+  namespace: ${NAMESPACE}
+spec:
+  ports:
+  - name: provisioner-m
+    port: 9202
+    protocol: TCP
+    targetPort: provisioner-m
+  - name: attacher-m
+    port: 9203
+    protocol: TCP
+    targetPort: attacher-m
+  - name: resizer-m
+    port: 9204
+    protocol: TCP
+    targetPort: resizer-m
+  - name: snapshotter-m
+    port: 9205
+    protocol: TCP
+    targetPort: snapshotter-m
+  selector:
+    app: gcp-pd-csi-driver-controller
+  sessionAffinity: None
+  type: ClusterIP

--- a/assets/overlays/gcp-pd/generated/hypershift/storageclass.yaml
+++ b/assets/overlays/gcp-pd/generated/hypershift/storageclass.yaml
@@ -1,0 +1,19 @@
+# Generated file. Do not edit. Update using "make update".
+#
+# Loaded from overlays/gcp-pd/base/storageclass.yaml
+#
+#
+
+allowVolumeExpansion: true
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "true"
+  name: standard-csi
+parameters:
+  replication-type: none
+  type: pd-standard
+provisioner: pd.csi.storage.gke.io
+reclaimPolicy: Delete
+volumeBindingMode: WaitForFirstConsumer

--- a/assets/overlays/gcp-pd/generated/hypershift/storageclass_hyperdisk_balanced.yaml
+++ b/assets/overlays/gcp-pd/generated/hypershift/storageclass_hyperdisk_balanced.yaml
@@ -1,0 +1,19 @@
+# Generated file. Do not edit. Update using "make update".
+#
+# Loaded from overlays/gcp-pd/base/storageclass_hyperdisk_balanced.yaml
+#
+#
+
+allowVolumeExpansion: true
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "true"
+  name: hyperdisk-balanced
+parameters:
+  replication-type: none
+  type: hyperdisk-balanced
+provisioner: pd.csi.storage.gke.io
+reclaimPolicy: Delete
+volumeBindingMode: WaitForFirstConsumer

--- a/assets/overlays/gcp-pd/generated/hypershift/storageclass_reader_resizer_binding.yaml
+++ b/assets/overlays/gcp-pd/generated/hypershift/storageclass_reader_resizer_binding.yaml
@@ -1,0 +1,19 @@
+# Generated file. Do not edit. Update using "make update".
+#
+# Loaded from base/rbac/storageclass_reader_resizer_binding.yaml
+#   because it's needed by controller sidecar common/sidecars/resizer.yaml
+#
+#
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: gcp-pd-csi-storageclass-reader-resizer-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: openshift-csi-resizer-storageclass-reader-role
+subjects:
+- kind: ServiceAccount
+  name: gcp-pd-csi-driver-controller-sa
+  namespace: ${NODE_NAMESPACE}

--- a/assets/overlays/gcp-pd/generated/hypershift/storageclass_ssd.yaml
+++ b/assets/overlays/gcp-pd/generated/hypershift/storageclass_ssd.yaml
@@ -1,0 +1,17 @@
+# Generated file. Do not edit. Update using "make update".
+#
+# Loaded from overlays/gcp-pd/base/storageclass_ssd.yaml
+#
+#
+
+allowVolumeExpansion: true
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: ssd-csi
+parameters:
+  replication-type: none
+  type: pd-ssd
+provisioner: pd.csi.storage.gke.io
+reclaimPolicy: Delete
+volumeBindingMode: WaitForFirstConsumer

--- a/assets/overlays/gcp-pd/generated/hypershift/volumeattributesclass_reader_provisioner_binding.yaml
+++ b/assets/overlays/gcp-pd/generated/hypershift/volumeattributesclass_reader_provisioner_binding.yaml
@@ -1,0 +1,19 @@
+# Generated file. Do not edit. Update using "make update".
+#
+# Loaded from base/rbac/volumeattributesclass_reader_provisioner_binding.yaml
+#   because it's needed by controller sidecar common/sidecars/provisioner.yaml
+#
+#
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: gcp-pd-csi-volumeattributesclass-reader-provisioner-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: openshift-csi-provisioner-volumeattributesclass-reader-role
+subjects:
+- kind: ServiceAccount
+  name: gcp-pd-csi-driver-controller-sa
+  namespace: ${NODE_NAMESPACE}

--- a/assets/overlays/gcp-pd/generated/hypershift/volumeattributesclass_reader_resizer_binding.yaml
+++ b/assets/overlays/gcp-pd/generated/hypershift/volumeattributesclass_reader_resizer_binding.yaml
@@ -1,0 +1,19 @@
+# Generated file. Do not edit. Update using "make update".
+#
+# Loaded from base/rbac/volumeattributesclass_reader_resizer_binding.yaml
+#   because it's needed by controller sidecar common/sidecars/resizer.yaml
+#
+#
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: gcp-pd-csi-volumeattributesclass-reader-resizer-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: openshift-csi-resizer-volumeattributesclass-reader-role
+subjects:
+- kind: ServiceAccount
+  name: gcp-pd-csi-driver-controller-sa
+  namespace: ${NODE_NAMESPACE}

--- a/assets/overlays/gcp-pd/generated/hypershift/volumesnapshot_reader_provisioner_binding.yaml
+++ b/assets/overlays/gcp-pd/generated/hypershift/volumesnapshot_reader_provisioner_binding.yaml
@@ -1,0 +1,19 @@
+# Generated file. Do not edit. Update using "make update".
+#
+# Loaded from base/rbac/volumesnapshot_reader_provisioner_binding.yaml
+#   because it's needed by controller sidecar common/sidecars/provisioner.yaml
+#
+#
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: gcp-pd-csi-volumesnapshot-reader-provisioner-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: openshift-csi-provisioner-volumesnapshot-reader-role
+subjects:
+- kind: ServiceAccount
+  name: gcp-pd-csi-driver-controller-sa
+  namespace: ${NODE_NAMESPACE}

--- a/assets/overlays/gcp-pd/generated/hypershift/volumesnapshotclass.yaml
+++ b/assets/overlays/gcp-pd/generated/hypershift/volumesnapshotclass.yaml
@@ -1,0 +1,14 @@
+# Generated file. Do not edit. Update using "make update".
+#
+# Loaded from overlays/gcp-pd/base/volumesnapshotclass.yaml
+#
+#
+
+apiVersion: snapshot.storage.k8s.io/v1
+deletionPolicy: Delete
+driver: pd.csi.storage.gke.io
+kind: VolumeSnapshotClass
+metadata:
+  annotations:
+    snapshot.storage.kubernetes.io/is-default-class: "true"
+  name: csi-gce-pd-vsc

--- a/assets/overlays/gcp-pd/generated/hypershift/volumesnapshotclass_images.yaml
+++ b/assets/overlays/gcp-pd/generated/hypershift/volumesnapshotclass_images.yaml
@@ -1,0 +1,14 @@
+# Generated file. Do not edit. Update using "make update".
+#
+# Loaded from overlays/gcp-pd/base/volumesnapshotclass_images.yaml
+#
+#
+
+apiVersion: snapshot.storage.k8s.io/v1
+deletionPolicy: Delete
+driver: pd.csi.storage.gke.io
+kind: VolumeSnapshotClass
+metadata:
+  name: csi-gce-pd-vsc-images
+parameters:
+  snapshot-type: images

--- a/assets/overlays/gcp-pd/patches/controller_add_hypershift_controller_minter.yaml
+++ b/assets/overlays/gcp-pd/patches/controller_add_hypershift_controller_minter.yaml
@@ -1,0 +1,143 @@
+spec:
+  template:
+    spec:
+      # hostNetwork is set unconditionally in controller_add_driver.yaml, but the controller only
+      # ever needs it to reach a node-local link-local metadata service (e.g. GCE's instance
+      # metadata server), which HyperShift's controller never does: it authenticates purely via
+      # WIF through the token-minter sidecar above, over normal outbound networking. Disabling it
+      # here (HyperShift-only, standalone is left untouched) mirrors the Azure File driver, whose
+      # controller-side hostNetwork was removed for the same reason (see
+      # 9e370b7f "Change ports and remove hostNetwork from controller pods"), and is required for
+      # the controller to schedule at all on GKE Autopilot management clusters, which reject
+      # hostNetwork pods outright.
+      hostNetwork: false
+      # None of these containers write meaningful amounts of data to their writable layer (the
+      # only on-disk volume is the tiny CSI unix-domain socket in socket-dir); they only need
+      # room for a termination log. Without an explicit request, GKE Autopilot injects a 1Gi
+      # ephemeral-storage request per container, and with 11 containers in this pod that pushes
+      # the total past Autopilot's 10Gi per-workload cap (autogke-pod-limit-constraints),
+      # blocking the Deployment from ever being created on GKE Autopilot management clusters.
+      # Setting small explicit requests here (HyperShift-only; standalone is untouched, since it
+      # doesn't run on GKE Autopilot) avoids the default injection entirely.
+      containers:
+        # HyperShift populates the gcp-pd-cloud-credentials secret with a WIF external_account
+        # config keyed "application_default_credentials.json" (see hypershift-operator's
+        # GCPPDCloudCredentialsSecret/ReconcileCredentials), not "service_account.json" as used
+        # by the standalone CCO-managed secret. Override the env var here so the driver reads
+        # the file that actually exists in HyperShift.
+        - name: csi-driver
+          # The driver's --run-node-service defaults to true, so without this flag the
+          # controller binary also stands up a node service (mount manager, device utils, and a
+          # metadataservice.NewMetadataService() call that queries the "instance/machine-type"
+          # GCE metadata attribute). On a real GCE VM with hostNetwork, that query bypasses GKE's
+          # metadata-server DaemonSet and succeeds; here the pod isn't on hostNetwork (see above)
+          # and GKE's metadata server only exposes a fixed attribute subset that excludes
+          # machine-type, so the driver fails fast with "failed to get machine-type: metadata:
+          # GCE metadata \"instance/machine-type\" not defined". The controller pod never needs a
+          # node service (it's not the thing that mounts volumes), so disable it outright. This is
+          # arguably also correct for standalone, but is scoped to HyperShift here to avoid
+          # touching already-shipped standalone behavior. args replaces the full list (strategic
+          # merge does not merge unkeyed string slices), so repeat the base args here.
+          #
+          # --cloud-config is required for the same reason: with no config file, the driver's
+          # getProjectAndZone() falls back to the GCE metadata server for both project and zone
+          # (pkg/gce-cloud-provider/compute/gce.go). On HyperShift the controller pod runs on a
+          # management-cluster node, so that metadata call resolves to the management cluster's
+          # own GCP project rather than the tenant's, and every subsequent Compute API call is
+          # scoped to the wrong project even though WIF is correctly impersonating a
+          # tenant-project service account. gcp-pd-cloud-config is expected to be created
+          # out-of-band from HostedControlPlane.Spec.Platform.GCP.Project (analogous to Azure's
+          # adaptAzureCSIDiskSecret) - not by csi-operator, which has no HostedControlPlane API
+          # visibility.
+          args:
+          - --endpoint=$(CSI_ENDPOINT)
+          - --logtostderr
+          - --v=${LOG_LEVEL}
+          - --enable-storage-pools=true
+          - --allow-hdha-provisioning=true
+          - --supports-dynamic-throughput-provisioning=hyperdisk-balanced,hyperdisk-throughput,hyperdisk-ml
+          - --supports-dynamic-iops-provisioning=hyperdisk-balanced,hyperdisk-extreme
+          - --run-node-service=false
+          - --cloud-config=/etc/gcp-cloud-config/cloud.conf
+          env:
+          - name: GOOGLE_APPLICATION_CREDENTIALS
+            value: /etc/cloud-sa/application_default_credentials.json
+          resources:
+            requests:
+              ephemeral-storage: 20Mi
+          volumeMounts:
+          - mountPath: /etc/gcp-cloud-config
+            name: gcp-cloud-config
+            readOnly: true
+
+        - name: csi-provisioner
+          resources:
+            requests:
+              ephemeral-storage: 10Mi
+        - name: provisioner-kube-rbac-proxy
+          resources:
+            requests:
+              ephemeral-storage: 10Mi
+        - name: csi-attacher
+          resources:
+            requests:
+              ephemeral-storage: 10Mi
+        - name: attacher-kube-rbac-proxy
+          resources:
+            requests:
+              ephemeral-storage: 10Mi
+        - name: csi-resizer
+          resources:
+            requests:
+              ephemeral-storage: 10Mi
+        - name: resizer-kube-rbac-proxy
+          resources:
+            requests:
+              ephemeral-storage: 10Mi
+        - name: csi-snapshotter
+          resources:
+            requests:
+              ephemeral-storage: 10Mi
+        - name: snapshotter-kube-rbac-proxy
+          resources:
+            requests:
+              ephemeral-storage: 10Mi
+        - name: csi-liveness-probe
+          resources:
+            requests:
+              ephemeral-storage: 10Mi
+
+        - name: token-minter
+          securityContext:
+            readOnlyRootFilesystem: true
+          args:
+          - --service-account-namespace=openshift-cluster-csi-drivers
+          - --service-account-name=gcp-pd-csi-driver-controller-sa
+          - --token-audience=openshift
+          - --token-file=/var/run/secrets/openshift/serviceaccount/token
+          - --kubeconfig=/etc/hosted-kubernetes/kubeconfig
+          command:
+          - /usr/bin/control-plane-operator
+          - token-minter
+          image: ${HYPERSHIFT_IMAGE}
+          imagePullPolicy: IfNotPresent
+          resources:
+            requests:
+              cpu: 10m
+              memory: 10Mi
+              ephemeral-storage: 10Mi
+          terminationMessagePolicy: FallbackToLogsOnError
+          volumeMounts:
+          - mountPath: /var/run/secrets/openshift/serviceaccount
+            name: bound-sa-token
+          - mountPath: /etc/hosted-kubernetes
+            name: hosted-kubeconfig
+            readOnly: true
+      volumes:
+      - name: bound-sa-token
+        emptyDir:
+          medium: Memory
+        projected: null # Explicity overwrite existing projected: with null in strategic merge patch
+      - name: gcp-cloud-config
+        configMap:
+          name: gcp-pd-cloud-config

--- a/cmd/gcp-pd-csi-driver-operator/main.go
+++ b/cmd/gcp-pd-csi-driver-operator/main.go
@@ -20,6 +20,8 @@ func main() {
 	os.Exit(code)
 }
 
+var guestKubeconfig *string
+
 func NewOperatorCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "gcp-pd-csi-driver-operator",
@@ -37,6 +39,8 @@ func NewOperatorCommand() *cobra.Command {
 		clock.RealClock{},
 	).NewCommand()
 
+	guestKubeconfig = ctrlCmd.Flags().String("guest-kubeconfig", "", "Path to the guest kubeconfig file. This flag enables hypershift integration.")
+
 	ctrlCmd.Use = "start"
 	ctrlCmd.Short = "Start the GCP PD CSI Driver Operator"
 
@@ -47,5 +51,5 @@ func NewOperatorCommand() *cobra.Command {
 
 func runCSIDriverOperator(ctx context.Context, controllerConfig *controllercmd.ControllerContext) error {
 	opConfig := gcp_pd.GetGCPPDOperatorConfig()
-	return operator.RunOperator(ctx, controllerConfig, "", opConfig)
+	return operator.RunOperator(ctx, controllerConfig, *guestKubeconfig, opConfig)
 }

--- a/pkg/driver/gcp-pd/gcp_pd.go
+++ b/pkg/driver/gcp-pd/gcp_pd.go
@@ -65,7 +65,6 @@ func GetGCPPDGeneratorConfig() *generator.CSIDriverGeneratorConfig {
 		AssetPrefix:      "gcp-pd-csi-driver",
 		AssetShortPrefix: "gcp-pd",
 		DriverName:       "pd.csi.storage.gke.io",
-		StandaloneOnly:   true,
 		OutputDir:        generatedAssetBase,
 
 		ControllerConfig: &generator.ControlPlaneConfig{
@@ -100,8 +99,8 @@ func GetGCPPDGeneratorConfig() *generator.CSIDriverGeneratorConfig {
 				"base/rbac/kube_rbac_proxy_role.yaml",
 				"base/rbac/kube_rbac_proxy_binding.yaml",
 			),
-			AssetPatches: generator.NewAssetPatches(generator.StandaloneOnly,
-				"controller.yaml", "common/standalone/controller_add_affinity.yaml",
+			AssetPatches: commongenerator.DefaultAssetPatches.WithPatches(generator.HyperShiftOnly,
+				"controller.yaml", "overlays/gcp-pd/patches/controller_add_hypershift_controller_minter.yaml",
 			),
 		},
 
@@ -157,27 +156,26 @@ func GetGCPPDOperatorConfig() *config.OperatorConfig {
 // GetGCPPDOperatorControllerConfig returns second half of runtime configuration of the CSI driver operator,
 // after a client connection + cluster flavour are established.
 func GetGCPPDOperatorControllerConfig(ctx context.Context, flavour generator.ClusterFlavour, c *clients.Clients) (*config.OperatorControllerConfig, error) {
-	if flavour != generator.FlavourStandalone {
-		klog.Error(nil, "Flavour HyperShift is not supported")
-		return nil, fmt.Errorf("Flavour HyperShift is not supported")
-	}
-
 	cfg := operator.NewDefaultOperatorControllerConfig(flavour, c, "GCPPD")
 
-	oldPrivilegedBindingController := staticresourcecontroller.NewStaticResourceController(
-		cfg.GetControllerName("OldControllerPrivilegedBindingRemoval"),
-		assets.ReadFile,
-		nil,
-		resourceapply.NewKubeClientHolder(c.KubeClient).WithDynamicClient(c.DynamicClient),
-		c.OperatorClient,
-		c.EventRecorder,
-	).WithConditionalResources(
-		assets.ReadFile,
-		[]string{customAssetBase + "/old_controller_privileged_binding.yaml"},
-		func() bool { return false },
-		func() bool { return true },
-	)
-	cfg.ExtraControlPlaneControllers = append(cfg.ExtraControlPlaneControllers, oldPrivilegedBindingController)
+	if flavour == generator.FlavourStandalone {
+		// One-time cleanup of a ClusterRoleBinding used by an old version of the operator.
+		// Not applicable to HyperShift, which never shipped the old binding.
+		oldPrivilegedBindingController := staticresourcecontroller.NewStaticResourceController(
+			cfg.GetControllerName("OldControllerPrivilegedBindingRemoval"),
+			assets.ReadFile,
+			nil,
+			resourceapply.NewKubeClientHolder(c.KubeClient).WithDynamicClient(c.DynamicClient),
+			c.OperatorClient,
+			c.EventRecorder,
+		).WithConditionalResources(
+			assets.ReadFile,
+			[]string{customAssetBase + "/old_controller_privileged_binding.yaml"},
+			func() bool { return false },
+			func() bool { return true },
+		)
+		cfg.ExtraControlPlaneControllers = append(cfg.ExtraControlPlaneControllers, oldPrivilegedBindingController)
+	}
 
 	storageClassFiles, err := getStorageClassFiles(ctx, c.ConfigClientSet)
 	if err != nil {
@@ -202,6 +200,13 @@ func GetGCPPDOperatorControllerConfig(ctx context.Context, flavour generator.Clu
 	cfg.AddStorageClassHookBuilders(c, getKMSKeyHook)
 	cfg.DeploymentWatchedSecretNames = append(cfg.DeploymentWatchedSecretNames, cloudCredSecretName, metricsCertSecretName)
 	cfg.AddDaemonSetHookBuilders(c, withCABundleDaemonSetHook, withClusterWideProxyDaemonSetHook)
+
+	// GCP HCP uses Workload Identity Federation exclusively: on HyperShift, the controller
+	// authenticates using a token minted for a guest-cluster service account (trusted by the WIF
+	// pool) rather than the control-plane pod's own (management-cluster-signed) token. The
+	// token-minter sidecar and its supporting volumes are added statically via
+	// controller_add_hypershift_controller_minter.yaml (see GetGCPPDGeneratorConfig), mirroring the
+	// AWS EBS driver - no runtime hook is needed here.
 
 	return cfg, nil
 }

--- a/pkg/driver/gcp-pd/hypershift_test.go
+++ b/pkg/driver/gcp-pd/hypershift_test.go
@@ -1,0 +1,68 @@
+package gcp_pd
+
+import (
+	"context"
+	"testing"
+
+	configv1 "github.com/openshift/api/config/v1"
+	fakeconfig "github.com/openshift/client-go/config/clientset/versioned/fake"
+	"github.com/openshift/csi-operator/pkg/clients"
+	"github.com/openshift/csi-operator/pkg/generator"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// newTestClients returns fake Clients with an Infrastructure object already
+// registered, so getStorageClassFiles() resolves immediately instead of
+// polling.
+func newTestClients(t *testing.T) *clients.Clients {
+	t.Helper()
+	cr := clients.GetFakeOperatorCR()
+	c := clients.NewFakeClients("clusters-test", cr)
+	infra := &configv1.Infrastructure{
+		ObjectMeta: metav1.ObjectMeta{Name: globalInfrastructureName},
+		Status: configv1.InfrastructureStatus{
+			PlatformStatus: &configv1.PlatformStatus{
+				GCP: &configv1.GCPPlatformStatus{Region: "us-central1"},
+			},
+		},
+	}
+	if err := c.ConfigClientSet.(*fakeconfig.Clientset).Tracker().Add(infra); err != nil {
+		t.Fatalf("failed to seed fake Infrastructure: %v", err)
+	}
+	return c
+}
+
+func TestGetGCPPDOperatorControllerConfig(t *testing.T) {
+	t.Run("When flavour is HyperShift it should no longer return an error", func(t *testing.T) {
+		c := newTestClients(t)
+		cfg, err := GetGCPPDOperatorControllerConfig(context.Background(), generator.FlavourHyperShift, c)
+		if err != nil {
+			t.Fatalf("expected no error for HyperShift flavour, got: %v", err)
+		}
+		if cfg == nil {
+			t.Fatalf("expected non-nil config for HyperShift flavour")
+		}
+	})
+
+	t.Run("When flavour is Standalone it should still register the old privileged binding cleanup controller", func(t *testing.T) {
+		c := newTestClients(t)
+		cfg, err := GetGCPPDOperatorControllerConfig(context.Background(), generator.FlavourStandalone, c)
+		if err != nil {
+			t.Fatalf("unexpected error for Standalone flavour: %v", err)
+		}
+		if len(cfg.ExtraControlPlaneControllers) != 1 {
+			t.Errorf("expected 1 extra control plane controller (old binding cleanup) for Standalone, got %d", len(cfg.ExtraControlPlaneControllers))
+		}
+	})
+
+	t.Run("When flavour is HyperShift it should not register the standalone-only old privileged binding cleanup controller", func(t *testing.T) {
+		c := newTestClients(t)
+		cfg, err := GetGCPPDOperatorControllerConfig(context.Background(), generator.FlavourHyperShift, c)
+		if err != nil {
+			t.Fatalf("unexpected error for HyperShift flavour: %v", err)
+		}
+		if len(cfg.ExtraControlPlaneControllers) != 0 {
+			t.Errorf("expected 0 extra control plane controllers for HyperShift, got %d", len(cfg.ExtraControlPlaneControllers))
+		}
+	})
+}


### PR DESCRIPTION
Removes the StandaloneOnly restriction and the explicit HyperShift error in the runtime config builder, so the GCP PD CSI driver operator can now generate assets for and run on HyperShift-managed clusters, mirroring the AWS EBS driver's integration pattern:

- Generator config: drop StandaloneOnly, wire ControllerConfig.AssetPatches through commongenerator.DefaultAssetPatches (previously it only applied the standalone affinity patch and skipped every HyperShift-only patch), and add a HyperShift-only patch that swaps the projected bound-sa-token volume for an emptyDir populated by a token-minter sidecar. GCP HCP uses Workload Identity Federation exclusively, so, unlike Azure Disk, no runtime branching between identity mechanisms is needed - the token minter is baked into the generated asset statically, same as AWS EBS.
- Runtime config: remove the explicit "Flavour HyperShift is not supported" error. Gate the one-time OldControllerPrivilegedBindingRemoval cleanup controller to FlavourStandalone only, since HyperShift never shipped the legacy binding it cleans up.
- cmd/gcp-pd-csi-driver-operator: add the --guest-kubeconfig flag (mirrors aws-ebs-csi-driver-operator) and thread it through to RunOperator.
- Regenerate assets via `make update`, producing the new overlays/gcp-pd/generated/hypershift/ tree.
- Add unit tests covering the HyperShift runtime config no longer erroring and the standalone-only controller gating.

Jira: [GCP-1074](https://redhat.atlassian.net/browse/GCP-1074), [GCP-1075](https://redhat.atlassian.net/browse/GCP-1075)