### PR TITLE
OCPBUGS-111088: Replace deprecated pod.spec.service account

### DIFF
--- a/assets/base/controller.yaml
+++ b/assets/base/controller.yaml
@@ -27,7 +27,7 @@ spec:
       labels:
         app: ${ASSET_PREFIX}-controller
     spec:
-      serviceAccount: ${ASSET_PREFIX}-controller-sa
+      serviceAccountName: ${ASSET_PREFIX}-controller-sa
       volumes:
         - name: socket-dir
           emptyDir: {}

--- a/assets/base/node.yaml
+++ b/assets/base/node.yaml
@@ -28,7 +28,7 @@ spec:
       labels:
         app: ${ASSET_PREFIX}-node
     spec:
-      serviceAccount: ${ASSET_PREFIX}-node-sa
+      serviceAccountName: ${ASSET_PREFIX}-node-sa
       priorityClassName: system-node-critical
       tolerations:
         - operator: Exists

--- a/assets/overlays/aws-ebs/generated/hypershift/controller.yaml
+++ b/assets/overlays/aws-ebs/generated/hypershift/controller.yaml
@@ -495,7 +495,7 @@ spec:
         - mountPath: /var/run/aws/auth
           name: aws-auth
       priorityClassName: hypershift-control-plane
-      serviceAccount: aws-ebs-csi-driver-controller-sa
+      serviceAccountName: aws-ebs-csi-driver-controller-sa
       tolerations:
       - effect: NoSchedule
         key: hypershift.openshift.io/control-plane

--- a/assets/overlays/aws-ebs/generated/hypershift/node.yaml
+++ b/assets/overlays/aws-ebs/generated/hypershift/node.yaml
@@ -142,7 +142,7 @@ spec:
       nodeSelector:
         kubernetes.io/os: linux
       priorityClassName: system-node-critical
-      serviceAccount: aws-ebs-csi-driver-node-sa
+      serviceAccountName: aws-ebs-csi-driver-node-sa
       tolerations:
       - operator: Exists
       volumes:

--- a/assets/overlays/aws-ebs/generated/standalone/controller.yaml
+++ b/assets/overlays/aws-ebs/generated/standalone/controller.yaml
@@ -412,7 +412,7 @@ spec:
       nodeSelector:
         node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
-      serviceAccount: aws-ebs-csi-driver-controller-sa
+      serviceAccountName: aws-ebs-csi-driver-controller-sa
       tolerations:
       - key: CriticalAddonsOnly
         operator: Exists

--- a/assets/overlays/aws-ebs/generated/standalone/node.yaml
+++ b/assets/overlays/aws-ebs/generated/standalone/node.yaml
@@ -142,7 +142,7 @@ spec:
       nodeSelector:
         kubernetes.io/os: linux
       priorityClassName: system-node-critical
-      serviceAccount: aws-ebs-csi-driver-node-sa
+      serviceAccountName: aws-ebs-csi-driver-node-sa
       tolerations:
       - operator: Exists
       volumes:

--- a/assets/overlays/aws-efs/generated/standalone/controller.yaml
+++ b/assets/overlays/aws-efs/generated/standalone/controller.yaml
@@ -215,7 +215,7 @@ spec:
       nodeSelector:
         node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
-      serviceAccount: aws-efs-csi-driver-controller-sa
+      serviceAccountName: aws-efs-csi-driver-controller-sa
       tolerations:
       - key: CriticalAddonsOnly
         operator: Exists

--- a/assets/overlays/aws-efs/generated/standalone/node.yaml
+++ b/assets/overlays/aws-efs/generated/standalone/node.yaml
@@ -200,7 +200,7 @@ spec:
       nodeSelector:
         kubernetes.io/os: linux
       priorityClassName: system-node-critical
-      serviceAccount: aws-efs-csi-driver-node-sa
+      serviceAccountName: aws-efs-csi-driver-node-sa
       tolerations:
       - operator: Exists
       volumes:

--- a/assets/overlays/aws-efs/patches/controller_add_driver.yaml
+++ b/assets/overlays/aws-efs/patches/controller_add_driver.yaml
@@ -25,7 +25,7 @@ spec:
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
     spec:
       hostNetwork: true
-      serviceAccount: aws-efs-csi-driver-controller-sa
+      serviceAccountName: aws-efs-csi-driver-controller-sa
       priorityClassName: system-cluster-critical
       nodeSelector:
         node-role.kubernetes.io/master: ""

--- a/assets/overlays/aws-efs/patches/node_add_driver.yaml
+++ b/assets/overlays/aws-efs/patches/node_add_driver.yaml
@@ -23,7 +23,7 @@ spec:
         cluster-autoscaler.kubernetes.io/enable-ds-eviction: "false"
     spec:
       hostNetwork: true
-      serviceAccount: aws-efs-csi-driver-node-sa
+      serviceAccountName: aws-efs-csi-driver-node-sa
       priorityClassName: system-node-critical
       dnsPolicy: Default # Don't use in-cluster DNS, one-zone volumes would be resolved by DNS pods in a random zone. We need it resolved on the node where the volume will be mounted.
       tolerations:

--- a/assets/overlays/azure-disk/generated/hypershift/controller.yaml
+++ b/assets/overlays/azure-disk/generated/hypershift/controller.yaml
@@ -418,7 +418,7 @@ spec:
         - mountPath: /csi
           name: socket-dir
       priorityClassName: hypershift-control-plane
-      serviceAccount: azure-disk-csi-driver-controller-sa
+      serviceAccountName: azure-disk-csi-driver-controller-sa
       tolerations:
       - effect: NoSchedule
         key: hypershift.openshift.io/control-plane

--- a/assets/overlays/azure-disk/generated/hypershift/node.yaml
+++ b/assets/overlays/azure-disk/generated/hypershift/node.yaml
@@ -209,7 +209,7 @@ spec:
       nodeSelector:
         kubernetes.io/os: linux
       priorityClassName: system-node-critical
-      serviceAccount: azure-disk-csi-driver-node-sa
+      serviceAccountName: azure-disk-csi-driver-node-sa
       tolerations:
       - operator: Exists
       volumes:

--- a/assets/overlays/azure-disk/generated/standalone/controller.yaml
+++ b/assets/overlays/azure-disk/generated/standalone/controller.yaml
@@ -384,7 +384,7 @@ spec:
       nodeSelector:
         node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
-      serviceAccount: azure-disk-csi-driver-controller-sa
+      serviceAccountName: azure-disk-csi-driver-controller-sa
       tolerations:
       - key: CriticalAddonsOnly
         operator: Exists

--- a/assets/overlays/azure-disk/generated/standalone/node.yaml
+++ b/assets/overlays/azure-disk/generated/standalone/node.yaml
@@ -209,7 +209,7 @@ spec:
       nodeSelector:
         kubernetes.io/os: linux
       priorityClassName: system-node-critical
-      serviceAccount: azure-disk-csi-driver-node-sa
+      serviceAccountName: azure-disk-csi-driver-node-sa
       tolerations:
       - operator: Exists
       volumes:

--- a/assets/overlays/azure-file/generated/hypershift/controller.yaml
+++ b/assets/overlays/azure-file/generated/hypershift/controller.yaml
@@ -426,7 +426,7 @@ spec:
         - mountPath: /csi
           name: socket-dir
       priorityClassName: hypershift-control-plane
-      serviceAccount: azure-file-csi-driver-controller-sa
+      serviceAccountName: azure-file-csi-driver-controller-sa
       tolerations:
       - effect: NoSchedule
         key: hypershift.openshift.io/control-plane

--- a/assets/overlays/azure-file/generated/hypershift/node.yaml
+++ b/assets/overlays/azure-file/generated/hypershift/node.yaml
@@ -187,7 +187,7 @@ spec:
       nodeSelector:
         kubernetes.io/os: linux
       priorityClassName: system-node-critical
-      serviceAccount: azure-file-csi-driver-node-sa
+      serviceAccountName: azure-file-csi-driver-node-sa
       tolerations:
       - operator: Exists
       volumes:

--- a/assets/overlays/azure-file/generated/standalone/controller.yaml
+++ b/assets/overlays/azure-file/generated/standalone/controller.yaml
@@ -385,7 +385,7 @@ spec:
       nodeSelector:
         node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
-      serviceAccount: azure-file-csi-driver-controller-sa
+      serviceAccountName: azure-file-csi-driver-controller-sa
       tolerations:
       - key: CriticalAddonsOnly
         operator: Exists

--- a/assets/overlays/azure-file/generated/standalone/node.yaml
+++ b/assets/overlays/azure-file/generated/standalone/node.yaml
@@ -187,7 +187,7 @@ spec:
       nodeSelector:
         kubernetes.io/os: linux
       priorityClassName: system-node-critical
-      serviceAccount: azure-file-csi-driver-node-sa
+      serviceAccountName: azure-file-csi-driver-node-sa
       tolerations:
       - operator: Exists
       volumes:

--- a/assets/overlays/gcp-pd/generated/standalone/controller.yaml
+++ b/assets/overlays/gcp-pd/generated/standalone/controller.yaml
@@ -322,7 +322,7 @@ spec:
       nodeSelector:
         node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
-      serviceAccount: gcp-pd-csi-driver-controller-sa
+      serviceAccountName: gcp-pd-csi-driver-controller-sa
       tolerations:
       - key: CriticalAddonsOnly
         operator: Exists

--- a/assets/overlays/gcp-pd/generated/standalone/node.yaml
+++ b/assets/overlays/gcp-pd/generated/standalone/node.yaml
@@ -155,7 +155,7 @@ spec:
       nodeSelector:
         kubernetes.io/os: linux
       priorityClassName: system-node-critical
-      serviceAccount: gcp-pd-csi-driver-node-sa
+      serviceAccountName: gcp-pd-csi-driver-node-sa
       tolerations:
       - operator: Exists
       volumes:

--- a/assets/overlays/openstack-cinder/generated/hypershift/controller.yaml
+++ b/assets/overlays/openstack-cinder/generated/hypershift/controller.yaml
@@ -416,7 +416,7 @@ spec:
       nodeSelector:
         node-role.kubernetes.io/master: ""
       priorityClassName: hypershift-control-plane
-      serviceAccount: openstack-cinder-csi-driver-controller-sa
+      serviceAccountName: openstack-cinder-csi-driver-controller-sa
       tolerations:
       - effect: NoSchedule
         key: hypershift.openshift.io/control-plane

--- a/assets/overlays/openstack-cinder/generated/hypershift/node.yaml
+++ b/assets/overlays/openstack-cinder/generated/hypershift/node.yaml
@@ -165,7 +165,7 @@ spec:
       nodeSelector:
         kubernetes.io/os: linux
       priorityClassName: system-node-critical
-      serviceAccount: openstack-cinder-csi-driver-node-sa
+      serviceAccountName: openstack-cinder-csi-driver-node-sa
       tolerations:
       - operator: Exists
       volumes:

--- a/assets/overlays/openstack-cinder/generated/standalone/controller.yaml
+++ b/assets/overlays/openstack-cinder/generated/standalone/controller.yaml
@@ -356,7 +356,7 @@ spec:
       nodeSelector:
         node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
-      serviceAccount: openstack-cinder-csi-driver-controller-sa
+      serviceAccountName: openstack-cinder-csi-driver-controller-sa
       tolerations:
       - key: CriticalAddonsOnly
         operator: Exists

--- a/assets/overlays/openstack-cinder/generated/standalone/node.yaml
+++ b/assets/overlays/openstack-cinder/generated/standalone/node.yaml
@@ -165,7 +165,7 @@ spec:
       nodeSelector:
         kubernetes.io/os: linux
       priorityClassName: system-node-critical
-      serviceAccount: openstack-cinder-csi-driver-node-sa
+      serviceAccountName: openstack-cinder-csi-driver-node-sa
       tolerations:
       - operator: Exists
       volumes:

--- a/assets/overlays/openstack-manila/base/node_nfs.yaml
+++ b/assets/overlays/openstack-manila/base/node_nfs.yaml
@@ -23,7 +23,7 @@ spec:
     spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
-      serviceAccount: manila-csi-driver-node-sa
+      serviceAccountName: manila-csi-driver-node-sa
       priorityClassName: system-node-critical
       tolerations:
         - operator: Exists

--- a/assets/overlays/openstack-manila/generated/hypershift/controller.yaml
+++ b/assets/overlays/openstack-manila/generated/hypershift/controller.yaml
@@ -361,7 +361,7 @@ spec:
       nodeSelector:
         node-role.kubernetes.io/master: ""
       priorityClassName: hypershift-control-plane
-      serviceAccount: manila-csi-driver-controller-sa
+      serviceAccountName: manila-csi-driver-controller-sa
       tolerations:
       - effect: NoSchedule
         key: hypershift.openshift.io/control-plane

--- a/assets/overlays/openstack-manila/generated/hypershift/node.yaml
+++ b/assets/overlays/openstack-manila/generated/hypershift/node.yaml
@@ -183,7 +183,7 @@ spec:
       nodeSelector:
         kubernetes.io/os: linux
       priorityClassName: system-node-critical
-      serviceAccount: manila-csi-driver-node-sa
+      serviceAccountName: manila-csi-driver-node-sa
       tolerations:
       - operator: Exists
       volumes:

--- a/assets/overlays/openstack-manila/generated/hypershift/node_nfs.yaml
+++ b/assets/overlays/openstack-manila/generated/hypershift/node_nfs.yaml
@@ -57,7 +57,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
       priorityClassName: system-node-critical
-      serviceAccount: manila-csi-driver-node-sa
+      serviceAccountName: manila-csi-driver-node-sa
       tolerations:
       - operator: Exists
       volumes:

--- a/assets/overlays/openstack-manila/generated/standalone/controller.yaml
+++ b/assets/overlays/openstack-manila/generated/standalone/controller.yaml
@@ -307,7 +307,7 @@ spec:
       nodeSelector:
         node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
-      serviceAccount: manila-csi-driver-controller-sa
+      serviceAccountName: manila-csi-driver-controller-sa
       tolerations:
       - key: CriticalAddonsOnly
         operator: Exists

--- a/assets/overlays/openstack-manila/generated/standalone/node.yaml
+++ b/assets/overlays/openstack-manila/generated/standalone/node.yaml
@@ -183,7 +183,7 @@ spec:
       nodeSelector:
         kubernetes.io/os: linux
       priorityClassName: system-node-critical
-      serviceAccount: manila-csi-driver-node-sa
+      serviceAccountName: manila-csi-driver-node-sa
       tolerations:
       - operator: Exists
       volumes:

--- a/assets/overlays/openstack-manila/generated/standalone/node_nfs.yaml
+++ b/assets/overlays/openstack-manila/generated/standalone/node_nfs.yaml
@@ -57,7 +57,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
       priorityClassName: system-node-critical
-      serviceAccount: manila-csi-driver-node-sa
+      serviceAccountName: manila-csi-driver-node-sa
       tolerations:
       - operator: Exists
       volumes:

--- a/assets/overlays/samba/generated/standalone/controller.yaml
+++ b/assets/overlays/samba/generated/standalone/controller.yaml
@@ -252,7 +252,7 @@ spec:
       nodeSelector:
         node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
-      serviceAccount: smb-csi-driver-controller-sa
+      serviceAccountName: smb-csi-driver-controller-sa
       tolerations:
       - key: CriticalAddonsOnly
         operator: Exists

--- a/assets/overlays/samba/generated/standalone/node.yaml
+++ b/assets/overlays/samba/generated/standalone/node.yaml
@@ -142,7 +142,7 @@ spec:
       nodeSelector:
         kubernetes.io/os: linux
       priorityClassName: system-node-critical
-      serviceAccount: smb-csi-driver-node-sa
+      serviceAccountName: smb-csi-driver-node-sa
       tolerations:
       - operator: Exists
       volumes:

--- a/pkg/driver/common/operator/test_manifests/aws_ebs_controller_hypershift.yaml
+++ b/pkg/driver/common/operator/test_manifests/aws_ebs_controller_hypershift.yaml
@@ -359,7 +359,7 @@ spec:
           name: hosted-kubeconfig
           readOnly: true
       priorityClassName: hypershift-control-plane
-      serviceAccount: aws-ebs-csi-driver-controller-sa
+      serviceAccountName: aws-ebs-csi-driver-controller-sa
       tolerations:
       - effect: NoSchedule
         key: hypershift.openshift.io/control-plane


### PR DESCRIPTION
https://redhat.atlassian.net/browse/OCPBUGS-111088

https://kubernetes.io/docs/reference/kubernetes-api/core/pod-v1/?trk=1b925f30-c9bd-43be-b84c-cc7b18119eb7:

> ServiceAccount is a deprecated alias for ServiceAccountName