### PR TITLE
OCPBUGS-120667: fix(gcp-pd): don't apply guest-cluster resources against the management cluster on HyperShift

### DIFF
--- a/cmd/gcp-pd-csi-driver-operator/main.go
+++ b/cmd/gcp-pd-csi-driver-operator/main.go
@@ -50,6 +50,6 @@ func NewOperatorCommand() *cobra.Command {
 }
 
 func runCSIDriverOperator(ctx context.Context, controllerConfig *controllercmd.ControllerContext) error {
-	opConfig := gcp_pd.GetGCPPDOperatorConfig()
+	opConfig := gcp_pd.GetGCPPDOperatorConfig(*guestKubeconfig != "")
 	return operator.RunOperator(ctx, controllerConfig, *guestKubeconfig, opConfig)
 }

--- a/pkg/driver/gcp-pd/gcp_pd.go
+++ b/pkg/driver/gcp-pd/gcp_pd.go
@@ -134,7 +134,42 @@ func GetGCPPDGeneratorConfig() *generator.CSIDriverGeneratorConfig {
 }
 
 // GetGCPPDOperatorConfig returns runtime configuration of the CSI driver operator.
-func GetGCPPDOperatorConfig() *config.OperatorConfig {
+func GetGCPPDOperatorConfig(isHypershift bool) *config.OperatorConfig {
+	// PrerequisiteAssets are applied early, before controllers start, via the
+	// control-plane client only (see pkg/operator/starter.go / OCPBUGS-99490):
+	// the Deployment controller can otherwise create the controller pod before
+	// StaticResourcesController applies its ClusterRole/ClusterRoleBinding,
+	// causing SCC admission to deny the pod (see hostnetwork_role.yaml /
+	// controller_hostnetwork_binding.yaml below).
+	//
+	// On standalone, the control-plane client is the only cluster, and the
+	// controller pod runs with hostNetwork: true, so all of these genuinely
+	// need to be applied there before the Deployment controller starts.
+	//
+	// On HyperShift, the control-plane client is the *management* cluster,
+	// which has no cluster-scoped RBAC-create rights there (see
+	// cluster-storage-operator's scoped mgmt Role). The controller pod runs
+	// with hostNetwork: false on HyperShift, so hostnetwork_role.yaml /
+	// controller_hostnetwork_binding.yaml are not needed at all. node_sa.yaml,
+	// privileged_role.yaml and node_privileged_binding.yaml are node/guest-
+	// cluster resources for the node DaemonSet (which does run with
+	// hostNetwork: true, but on the guest cluster) - they are already applied
+	// via the correct (guest) client through GuestConfig.Assets /
+	// commongenerator.DefaultNodeAssets below. So on HyperShift only
+	// controller_sa.yaml belongs in this list.
+	prerequisiteAssets := []string{
+		"controller_sa.yaml",
+	}
+	if !isHypershift {
+		prerequisiteAssets = append(prerequisiteAssets,
+			"node_sa.yaml",
+			"hostnetwork_role.yaml",
+			"controller_hostnetwork_binding.yaml",
+			"privileged_role.yaml",
+			"node_privileged_binding.yaml",
+		)
+	}
+
 	return &config.OperatorConfig{
 		CSIDriverName:                   opv1.GCPPDCSIDriver,
 		UserAgent:                       "gcp-pd-csi-driver-operator",
@@ -142,14 +177,7 @@ func GetGCPPDOperatorConfig() *config.OperatorConfig {
 		AssetDir:                        generatedAssetBase,
 		OperatorControllerConfigBuilder: GetGCPPDOperatorControllerConfig,
 		Removable:                       false,
-		PrerequisiteAssets: []string{
-			"controller_sa.yaml",
-			"node_sa.yaml",
-			"hostnetwork_role.yaml",
-			"controller_hostnetwork_binding.yaml",
-			"privileged_role.yaml",
-			"node_privileged_binding.yaml",
-		},
+		PrerequisiteAssets:              prerequisiteAssets,
 	}
 }
 

--- a/pkg/operator/prerequisites_test.go
+++ b/pkg/operator/prerequisites_test.go
@@ -22,7 +22,7 @@ import (
 )
 
 func TestApplyPrerequisites(t *testing.T) {
-	opConfig := gcp_pd.GetGCPPDOperatorConfig()
+	opConfig := gcp_pd.GetGCPPDOperatorConfig(false)
 	assetDir := filepath.Join(opConfig.AssetDir, string(generator.FlavourStandalone))
 	a, err := generated_assets.NewFromAssets(assets.ReadFile, assetDir)
 	if err != nil {


### PR DESCRIPTION
Bug: OCPBUGS-120667

## Summary

Problem: On HyperShift, the operator applies `PrerequisiteAssets` using the management-cluster client. Several of those assets are guest-cluster resources that shouldn't be applied to the management cluster at all.

Fix: `GetGCPPDOperatorConfig` now takes an `isHypershift` flag. On HyperShift, `PrerequisiteAssets` only includes `controller_sa.yaml`. Among the rest:

- `hostnetwork_role.yaml` / `controller_hostnetwork_binding.yaml` — not needed at all on HyperShift, since the controller pod runs with `hostNetwork: false` there.
- `node_sa.yaml` / `privileged_role.yaml` / `node_privileged_binding.yaml` — still needed, these guest-cluster resources are already applied correctly via `GuestConfig.Assets`, so listing them here too was just duplicating.

Standalone is unaffected (`isHypershift=false` keeps the full list).

## Test plan

- [x] `go build ./...`
- [x] Live-verified on a HyperShift GCP HostedCluster: with this fix, `gcp-pd-csi-driver-operator` no longer crash-loops on `Forbidden` errors applying cluster-scoped RBAC against the management cluster.

Made with [Cursor](https://cursor.com)